### PR TITLE
Minor changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Zilliqa (codename Durian)
+# Zilliqa (codename _Durian_)
 ## Overview
-Zilliqa is a new blockchain platform capable of processing thousands of transactions per second with sharding built into it. With sharding, Zilliqa has the potential to match throughput benchmarks set by traditional payment methods (such as VISA and MasterCard). Even more importantly, Zilliqa’s transaction throughput increases (roughly) linearly with its network size.
+Zilliqa is a new blockchain platform capable of processing thousands of transactions per second with sharding built into it. With sharding, Zilliqa has the potential to match throughput benchmarks set by traditional payment methods (such as _VISA_ and _MasterCard_). More importantly, Zilliqa’s transaction throughput increases (roughly) linearly with its network size.
 
 ## Available Features
 The current release has the following features implemented:
@@ -8,11 +8,11 @@ The current release has the following features implemented:
 * Network sharding
 * Directory Service
 * Consensus for DS block, Sharding structure, Shard Microblock and Final block 
-* EC-Schnorr signature 
+* [EC-Schnorr signature](https://en.wikipedia.org/wiki/Schnorr_signature)
 * Data layer and accounts store 
 * Looking up nodes to allow new nodes to join 
 * Persistent storage for transactions
-* Merkle Patricia tree
+* [Merkle Patricia tree](https://github.com/ethereum/wiki/wiki/Patricia-Tree)
 * Transaction verification
 
 In the coming months, we plan to have the following features:
@@ -29,20 +29,22 @@ In the coming months, we plan to have the following features:
 
 ## Minimum system requirements
 To run Zilliqa, we recommend the following minimum system requirements:
-* x64 Linux operating system such as Ubuntu
+* x64 _Linux_ operating system such as _Ubuntu_
 * Recent dual core processor
 * 2 GB RAM
 
 ## Dependencies
 To compile and run the Zilliqa codebase, you will need the following dependencies to be installed on your machine:
-* Boost 
-* OpenSSL
-* Jsoncpp
-* Leveldb
-* Cmake
+* `Boost` 
+* `OpenSSL`
+* `Jsoncpp`
+* `Leveldb`
+* `Cmake`
 
-For a debian-based system, you can use the following command to install the dependencies:  
-`sudo apt-get install libboost-all-dev libssl-dev libleveldb-dev libjsoncpp-dev cmake`
+For a _Debian_-based system, you can use the following command to install the dependencies:  
+```bash
+sudo apt-get install libboost-all-dev libssl-dev libleveldb-dev libjsoncpp-dev cmake
+```
 
 # Running Zilliqa locally (using 10 shard nodes and DS node locally)  
 1. Build Zilliqa from the source.  
@@ -51,17 +53,17 @@ For a debian-based system, you can use the following command to install the depe
 2. Run the local testnet script  
 `./test/Node/test_node_simple.sh`  
 
-3. Logs of each node can be found at code/local_run
+3. Logs of each node can be found at `code/local_run`
 
-4. To terminate zilliqa,   
+4. To terminate Zilliqa,   
 `pkill zilliqa` 
 
 ## Running a Zilliqa Node on the public testnet 
 Coming soon...
 
 ## For further enquiries
-If you have issues running a node, do join our Zilliqa channel and ask us questions there! Our Slack invite link is https://invite.zilliqa.com/. You can also submit your issue at our github repository https://github.com/Zilliqa/zilliqa/issues 
+If you have issues running a node, please feel free to join our [Slack](https://invite.zilliqa.com/) or [Telegram](https://t.me/zilliqachat) and ask questions. You can also submit your issue at our [Github repository](https://github.com/Zilliqa/zilliqa/issues)
 
 ## Licence 
-You can view our licence at https://github.com/Zilliqa/zilliqa/blob/master/LICENSE
+You can view our [licence here](https://github.com/Zilliqa/zilliqa/blob/master/LICENSE).
 


### PR DESCRIPTION
It is always difficult to decide format on names/terms, but I felt that we might want to emphasise names such as _Durian_, _Linux_ etc...

**Not sure if we want to do the same with the name _Zilliqa_?**

 Since the command
`sudo apt-get install libboost-all-dev libssl-dev libleveldb-dev libjsoncpp-dev cmake`
was a bit longer I thought it would be clearer putting it in ``` 

**I added link to the Telegram group as well, but maybe that is unwanted?**

Please feel free to suggest improvements to this PR?