### PR TITLE
Fixed image references in State Diagrams.md

### DIFF
--- a/docs/State Diagrams.md
+++ b/docs/State Diagrams.md
@@ -1,13 +1,12 @@
 # State Diagrams
 
 ## DirectoryService
-
-![DirectoryService State Diagram](https://github.com/anquan-codebase/nuQoin/raw/master/docs/images/DirectoryService.jpg "DirectoryService State Diagram")
+![DirectoryService State Diagram](images/DirectoryService.jpg "DirectoryService State Diagram")
 
 ## Node
 
-![Node State Diagram](https://github.com/anquan-codebase/nuQoin/raw/master/docs/images/Node.jpg "Node State Diagram")
+![Node State Diagram](images/Node.jpg "Node State Diagram")
 
 ## Consensus
 
-<img src="https://github.com/anquan-codebase/nuQoin/raw/master/docs/images/Consensus.jpg" width="75%" alt="Consensus State Diagram"></img>
+![Consensus State Diagram](images/Consensus.jpg "Consensus State Diagram")


### PR DESCRIPTION
The image references pointed to another repository. I also changed them to be relative, instead of absolute.