### PR TITLE
Use inet_pton instead of inet_aton for portability

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -71,7 +71,7 @@ void Lookup::SetLookupNodes()
         if (v.first == "peer")
         {
             struct in_addr ip_addr;
-            inet_aton(v.second.get<string>("ip").c_str(), &ip_addr);
+            inet_pton(AF_INET, v.second.get<string>("ip").c_str(), &ip_addr);
             Peer lookup_node((uint128_t)ip_addr.s_addr, v.second.get<uint32_t>("port"));
             m_lookupNodes.push_back(lookup_node);
         }

--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -163,7 +163,7 @@ PeerManager::PeerManager(const std::pair<PrivKey, PubKey> & key, const Peer & pe
             {
                 PubKey key(DataConversion::HexStrToUint8Vec(v.second.get<string>("pubk")), 0);
                 struct in_addr ip_addr;
-                inet_aton(v.second.get<string>("ip").c_str(), &ip_addr);
+                inet_pton(AF_INET, v.second.get<string>("ip").c_str(), &ip_addr);
                 Peer peer((uint128_t)ip_addr.s_addr, v.second.get<unsigned int>("port"));
                 if (peer != m_selfPeer)
                 {

--- a/tests/Lookup/Test_LookupNodeForDSBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForDSBlock.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE (testDSBlockStoring)
 
     uint32_t listen_port = 5000; 
     struct in_addr ip_addr;
-    inet_aton("127.0.0.1", &ip_addr);
+    inet_pton(AF_INET, "127.0.0.1", &ip_addr);
     Peer lookup_node((uint128_t)ip_addr.s_addr, listen_port);
 
     vector<unsigned char> dsblockmsg = { MessageType::NODE, NodeInstructionType::DSBLOCK };
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE (testDSBlockStoring)
     curr_offset += UINT256_SIZE;
 
 	struct sockaddr_in localhost;
-	inet_aton("127.0.0.1", &localhost.sin_addr);
+	inet_pton(AF_INET, "127.0.0.1", &localhost.sin_addr);
 
 	dsblockmsg.resize(curr_offset + 16);
 	Serializable::SetNumber<uint128_t>(dsblockmsg, curr_offset, 
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE (testDSBlockRetrieval)
 
     uint32_t listen_port = 5000; 
     struct in_addr ip_addr;
-    inet_aton("127.0.0.1", &ip_addr);
+    inet_pton(AF_INET, "127.0.0.1", &ip_addr);
     Peer lookup_node((uint128_t)ip_addr.s_addr, listen_port);
 
     vector<unsigned char> getDSBlockMessage = { MessageType::LOOKUP, 

--- a/tests/Lookup/Test_LookupNodeForTxBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForTxBlock.cpp
@@ -74,7 +74,7 @@ void SendDSBlockFirstToMatchDSBlockNum(Peer & lookup_node)
     curr_offset += UINT256_SIZE;
 
     struct sockaddr_in localhost;
-    inet_aton("127.0.0.1", &localhost.sin_addr);
+    inet_pton(AF_INET, "127.0.0.1", &localhost.sin_addr);
 
     dsblockmsg.resize(curr_offset + 16);
     Serializable::SetNumber<uint128_t>(dsblockmsg, curr_offset, 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE (testTxBlockStoring)
 
     uint32_t listen_port = 5000; 
     struct in_addr ip_addr;
-    inet_aton("127.0.0.1", &ip_addr);
+    inet_pton(AF_INET, "127.0.0.1", &ip_addr);
     Peer lookup_node((uint128_t)ip_addr.s_addr, listen_port);
 
     SendDSBlockFirstToMatchDSBlockNum(lookup_node);
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE (testTxBlockRetrieval)
 
     uint32_t listen_port = 5000; 
     struct in_addr ip_addr;
-    inet_aton("127.0.0.1", &ip_addr);
+    inet_pton(AF_INET, "127.0.0.1", &ip_addr);
     Peer lookup_node((uint128_t)ip_addr.s_addr, listen_port);
 
     vector<unsigned char> getTxBlockMessage = { MessageType::LOOKUP, 

--- a/tests/Utils/Test_BoostBigNum.cpp
+++ b/tests/Utils/Test_BoostBigNum.cpp
@@ -71,7 +71,7 @@ int main()
 
 
     struct in_addr ip_addr;
-    inet_aton("54.169.197.255", &ip_addr);
+    inet_pton(AF_INET, "54.169.197.255", &ip_addr);
 
     uint128_t ipaddr_big = ip_addr.s_addr;
     uint32_t ipaddr_normal = ip_addr.s_addr;

--- a/tests/Zilliqa/main.cpp
+++ b/tests/Zilliqa/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, const char * argv[])
         PubKey pubkey(tmppubkey, 0);
 
         struct in_addr ip_addr;
-        inet_aton(argv[3], &ip_addr);
+        inet_pton(AF_INET, argv[3], &ip_addr);
         Peer my_port((uint128_t)ip_addr.s_addr, static_cast<unsigned int>(atoi(argv[4])));
 
         Zilliqa zilliqa(make_pair(privkey, pubkey), my_port, atoi(argv[5]) == 1);

--- a/tests/Zilliqa/send_txn.cpp
+++ b/tests/Zilliqa/send_txn.cpp
@@ -43,7 +43,7 @@ int main(int argc, const char * argv[])
 
     uint32_t listen_port = static_cast<unsigned int>(atoi(argv[1])); 
     struct in_addr ip_addr;
-    inet_aton("127.0.0.1", &ip_addr);
+    inet_pton(AF_INET, "127.0.0.1", &ip_addr);
     Peer my_port((uint128_t)ip_addr.s_addr, listen_port);
 
     // Send the generic message to the local node

--- a/tests/Zilliqa/sendcmd.cpp
+++ b/tests/Zilliqa/sendcmd.cpp
@@ -45,7 +45,7 @@ void process_addpeers(int numargs, const char * progname, const char * cmdname, 
     else
     {
         struct in_addr ip_addr;
-        inet_aton("127.0.0.1", &ip_addr);
+        inet_pton(AF_INET, "127.0.0.1", &ip_addr);
         Peer my_port(uint128_t(ip_addr.s_addr), listen_port);
 
         for (int i = 0; i < numargs; )
@@ -67,7 +67,7 @@ void process_addpeers(int numargs, const char * progname, const char * cmdname, 
             copy(tmp.begin(), tmp.end(), addnode_message.begin() + MessageOffset::BODY);
 
             // IP address
-            inet_aton(args[i++], &ip_addr);
+            inet_pton(AF_INET, args[i++], &ip_addr);
             uint128_t tmp2 = ip_addr.s_addr;
             Serializable::SetNumber<uint128_t>(addnode_message, MessageOffset::BODY + PUB_KEY_SIZE, tmp2, UINT128_SIZE);
 
@@ -91,7 +91,7 @@ void process_broadcast(int numargs, const char * progname, const char * cmdname,
     else
     {
         struct in_addr ip_addr;
-        inet_aton("127.0.0.1", &ip_addr);
+        inet_pton(AF_INET, "127.0.0.1", &ip_addr);
         Peer my_port((uint128_t)ip_addr.s_addr, listen_port);
 
         unsigned int numbytes = static_cast<unsigned int>(atoi(args[0]));
@@ -116,7 +116,7 @@ void process_cmd(int numargs, const char * progname, const char * cmdname, uint3
     else
     {
         struct in_addr ip_addr;
-        inet_aton("127.0.0.1", &ip_addr);
+        inet_pton(AF_INET, "127.0.0.1", &ip_addr);
         Peer my_port((uint128_t)ip_addr.s_addr, listen_port);
 
         // Send the generic message to the local node


### PR DESCRIPTION
This change appears to be neutral for the Ubuntu builds, but `inet_aton` is not defined on Windows platforms. I saw two straightforward resolutions:

1. Use `inet_pton` instead, which is defined on all platforms
2. Define `inet_aton` within a shared header for Windows platforms

I felt that the first approach is likely to be the simplest in the long run.

:link: Related to #19