### PR TITLE
Ensure arrays are initialized with constants

### DIFF
--- a/tests/Persistence/Test_DSPersistence.cpp
+++ b/tests/Persistence/Test_DSPersistence.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE (testThreadSafety)
 
     LOG_MARKER();
 
-    int num_threads = 20;
+    const int num_threads = 20;
 
     bootstrap(num_threads);
 

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE (testThreadSafety)
 
     LOG_MARKER();
 
-    int num_threads = 20;
+    const int num_threads = 20;
 
     bootstrap(num_threads);
 


### PR DESCRIPTION
This fixes an unintentional declaration of a local variable as non-constant, which works for some compilers but fails for the Microsoft C++ compiler.
  
:link: Related to #19