### PR TITLE
Use std::chrono instead of clock_gettime for portability

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -45,7 +45,7 @@ class Mediator;
 class DirectoryService : public Executable, public Broadcastable
 {
 #ifdef STAT_TEST
-    timespec m_timespec;
+    std::chrono::system_clock::time_point m_timespec;
 #endif // STAT_TEST
 
     enum Action

--- a/src/libUtils/TimeUtils.cpp
+++ b/src/libUtils/TimeUtils.cpp
@@ -16,28 +16,22 @@
 
 #include "TimeUtils.h"
 
+using namespace std::chrono;
 using namespace boost::multiprecision;
 
-struct timespec r_timer_start()
+system_clock::time_point r_timer_start()
 {
-    struct timespec start_time;
-    clock_gettime(CLOCK_REALTIME, &start_time);
-    return start_time;
+    return system_clock::now();
 }
 
-double r_timer_end(struct timespec start_time)
+double r_timer_end(system_clock::time_point start_time)
 {
-    struct timespec end_time;
-    clock_gettime(CLOCK_REALTIME, &end_time);
-    double diffInMicroSecs = (end_time.tv_sec - start_time.tv_sec) * 1000000 + (end_time.tv_nsec - start_time.tv_nsec) / 1000;
-    return diffInMicroSecs;
+    duration<double, std::micro> difference = system_clock::now() - start_time;
+    return difference.count();
 }
 
 uint256_t get_time_as_int()
 {
-	struct timespec now_time;
-	clock_gettime(CLOCK_REALTIME, &now_time);
-	uint256_t microsecs = now_time.tv_sec * 1000000;
-	microsecs += now_time.tv_nsec / 1000;
-	return microsecs;
+    microseconds microsecs = duration_cast<microseconds>(system_clock::now().time_since_epoch());
+    return static_cast<uint256_t>(microsecs.count());
 }

--- a/src/libUtils/TimeUtils.h
+++ b/src/libUtils/TimeUtils.h
@@ -18,12 +18,11 @@
 #ifndef __TIMEUTILS_H__
 #define __TIMEUTILS_H__
 
-#include <time.h>
-
+#include <chrono>
 #include <boost/multiprecision/cpp_int.hpp>
 
-struct timespec r_timer_start();
-double r_timer_end(struct timespec start_time);
+std::chrono::system_clock::time_point r_timer_start();
+double r_timer_end(std::chrono::system_clock::time_point start_time);
 
 boost::multiprecision::uint256_t get_time_as_int();
 

--- a/tests/Crypto/Test_Schnorr.cpp
+++ b/tests/Crypto/Test_Schnorr.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE (test_performance)
         Signature signature;
 
         // Generate the signature
-        struct timespec t = r_timer_start();
+        auto t = r_timer_start();
         BOOST_CHECK_MESSAGE(schnorr.Sign(message_rand, keypair.first, keypair.second, signature) == true, "Signing failed");
         LOG_MESSAGE("Message size  = " << printable_sizes[i]);
         LOG_MESSAGE("Sign (usec)   = " << r_timer_end(t));


### PR DESCRIPTION
  This change simplifies the code using new C++ standard library features, and addresses a future issue where `clock_gettime` is not defined on Windows platforms.
  
:link: Related to #19