### PR TITLE
Use boost::stacktrace for portability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ matrix:
         apt:
           packages:
             - g++-5
-            - libboost-all-dev
             - libleveldb-dev
             - libjsoncpp-dev
             - libsnappy-dev
@@ -25,7 +24,6 @@ matrix:
         apt:
           packages:
             - g++-5
-            - libboost-all-dev
             - libleveldb-dev
             - libjsoncpp-dev
             - libsnappy-dev
@@ -36,3 +34,12 @@ matrix:
             - llvm-toolchain-trusty-5.0
       script:
         - ./build_lookup.sh
+
+install:
+  - wget -O boost_1_65_1.tar.gz https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.gz
+  - tar xzf boost_1_65_1.tar.gz
+  - cd boost_1_65_1/
+  - ./bootstrap.sh --with-libraries=filesystem,system
+  - ./b2 link=shared threading=multi variant=release -d0
+  - sudo ./b2 install -d0
+  - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project (nuQoin)
 message(STATUS "We are on a ${CMAKE_SYSTEM_NAME} system")
 
 find_package(Boost COMPONENTS filesystem system unit_test_framework)
+if (NOT Boost_LIBRARIES)
+    SET(Boost_LIBRARIES ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+endif()
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSONCPP jsoncpp)
 link_libraries(${JSONCPP_LIBRARIES})

--- a/tests/Zilliqa/CMakeLists.txt
+++ b/tests/Zilliqa/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable (zilliqa main.cpp)
 target_include_directories (zilliqa PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService Node)
+target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService Node dl)
 
 add_executable (sendcmd sendcmd.cpp)
 target_include_directories (sendcmd PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/tests/Zilliqa/main.cpp
+++ b/tests/Zilliqa/main.cpp
@@ -14,12 +14,13 @@
 * and which include a reference to GPLv3 in their program files.
 **/
 
-#include <execinfo.h> // for backtrace
 #include <signal.h>
 
 #include <iostream>
 #include <arpa/inet.h>
 #include <algorithm>
+#include <boost/stacktrace.hpp>
+
 #include "libUtils/Logger.h"
 
 #include "libNetwork/PeerStore.h"
@@ -34,22 +35,7 @@ using namespace boost::multiprecision;
 /* Obtain a backtrace and print it to stdout. */
 void print_trace (void)
 {
-    void *array[10];
-    size_t size;
-    char **strings;
-    size_t i;
-
-    size = backtrace (array, 10);
-    strings = backtrace_symbols (array, size);
-
-    LOG_MESSAGE ("Obtained " << size << " stack frames.\n");
-
-    for (i = 0; i < size; i++)
-    {
-        LOG_MESSAGE(strings[i])
-    }
-     //printf ("%s\n", strings[i]);
-    free (strings);
+    LOG_MESSAGE(boost::stacktrace::stacktrace());
 }
 
 void got_terminated()


### PR DESCRIPTION
This change simplifies the code and addresses a future compatibility concern when Windows platforms are supported.

⚠️ This pull request changes the minimum version of Boost to 1.65.1. The Travis build is updated to account for this.
  
:link: Related to #19