### PR TITLE
fixes a compiler error on fedora/ some version of gcc

### DIFF
--- a/src/libUtils/Scheduler.h
+++ b/src/libUtils/Scheduler.h
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <functional>
 #include <map>
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
- adds #include functional to Scheduler.h
- fixes #46 
- also solves original problem of #21 