### PR TITLE
Add build configuration for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: generic
+sudo: false
+cache: apt
+
+matrix:
+  include:
+    - env: LANGUAGE=C++ CXX=g++-5 CC=gcc-5
+      addons:
+        apt:
+          packages:
+            - g++-5
+            - libboost-all-dev
+            - libleveldb-dev
+            - libjsoncpp-dev
+          sources: &sources
+            - r-packages-trusty
+            - llvm-toolchain-trusty
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+      script:
+        - ./build.sh
+    - env: LANGUAGE=C++ CXX=g++-5 CC=gcc-5
+      addons:
+        apt:
+          packages:
+            - g++-5
+            - libboost-all-dev
+            - libleveldb-dev
+            - libjsoncpp-dev
+          sources: &sources
+            - r-packages-trusty
+            - llvm-toolchain-trusty
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+      script:
+        - ./build_lookup.sh


### PR DESCRIPTION
This PR implements the repository side of #48. A maintainer of this repository will still need to enable Travis CI before builds occur.