### PR TITLE
Inconsistent view of m_hasAllPoWconns recovery

### DIFF
--- a/local_run/README.md
+++ b/local_run/README.md
@@ -1,1 +1,0 @@
-This folder housed the log files of the local runs for Zilliqa

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -42,7 +42,9 @@ enum DSInstructionType : unsigned char
     POW2SUBMISSION = 0x03,
     SHARDINGCONSENSUS = 0x04,
     MICROBLOCKSUBMISSION = 0x05,
-    FINALBLOCKCONSENSUS = 0x06
+    FINALBLOCKCONSENSUS = 0x06,
+    AllPoWConnRequest = 0x07,
+    AllPoWConnResponse = 0x08
 };
 
 enum NodeInstructionType : unsigned char

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -149,10 +149,17 @@ bool DirectoryService::DSBlockValidator(const vector<unsigned char> & dsblock)
 
     if (m_allPoWConns.find(m_pendingDSBlock->GetHeader().GetMinerPubKey()) == m_allPoWConns.end())
     {
-        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "To-do: Winning node of PoW1 not inside m_allPoWConns - should do another round of consensus!");
-        throw exception();
-    }
+        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Winning node of PoW1 not inside m_allPoWConns! Getting from ds leader");
+        
+        m_hasAllPoWconns = false; 
+        std::unique_lock<std::mutex> lk(m_CVAllPowConn);
 
+        RequestAllPoWConn(); 
+        while (!m_hasAllPoWconns)
+        {
+            cv_allPowConns.wait(lk);
+        }
+    }
     return true;
 }
 

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -152,7 +152,7 @@ bool DirectoryService::DSBlockValidator(const vector<unsigned char> & dsblock)
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Winning node of PoW1 not inside m_allPoWConns! Getting from ds leader");
         
         m_hasAllPoWconns = false; 
-        std::unique_lock<std::mutex> lk(m_CVAllPowConn);
+        std::unique_lock<std::mutex> lk(m_MutexCVAllPowConn);
 
         RequestAllPoWConn(); 
         while (!m_hasAllPoWconns)

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -557,6 +557,8 @@ void DirectoryService::RequestAllPoWConn()
     // TODO: Request from a total of 20 ds members 
 }
 
+#endif // IS_LOOKUP_NODE
+
 
 // Current this is only used by ds. But ideally, 20 ds nodes should
 bool DirectoryService::ProcessAllPoWConnRequest(const vector<unsigned char> & message, unsigned int offset, const Peer & from)
@@ -632,7 +634,6 @@ bool DirectoryService::ProcessAllPoWConnResponse(const vector<unsigned char> & m
     return true; 
 }
 
-#endif // IS_LOOKUP_NODE
 
 bool DirectoryService::Execute(const vector<unsigned char> & message, unsigned int offset, const Peer & from)
 {

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -628,9 +628,12 @@ bool DirectoryService::ProcessAllPoWConnResponse(const vector<unsigned char> & m
             m_allPoWConns.insert(make_pair(key, peer));
         }
     }
+    
+    {
+        std::unique_lock<std::mutex> lk(m_MutexCVAllPowConn);
+        m_hasAllPoWconns = true; 
+    }
     cv_allPowConns.notify_all(); 
- 
-    m_hasAllPoWconns = true; 
     return true; 
 }
 

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -145,6 +145,9 @@ class DirectoryService : public Executable, public Broadcastable
                                      unsigned int offset, const Peer & from);
     bool ProcessFinalBlockConsensus(const std::vector<unsigned char> & message, unsigned int offset, 
                                     const Peer & from);
+    bool ProcessAllPoWConnRequest(const vector<unsigned char> & message, unsigned int offset, const Peer & from); 
+    bool ProcessAllPoWConnResponse(const vector<unsigned char> & message, unsigned int offset, const Peer & from);
+
 #ifndef IS_LOOKUP_NODE
     bool CheckState(Action action);
     bool VerifyPOW2(const vector<unsigned char> &message, unsigned int offset, const Peer &from);
@@ -249,8 +252,6 @@ class DirectoryService : public Executable, public Broadcastable
 
     // Used to reconsile view of m_AllPowConn is different. 
     void RequestAllPoWConn();
-    bool ProcessAllPoWConnRequest(const vector<unsigned char> & message, unsigned int offset, const Peer & from); 
-    bool ProcessAllPoWConnResponse(const vector<unsigned char> & message, unsigned int offset, const Peer & from);
 
 
 #endif // IS_LOOKUP_NODE    

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -90,7 +90,7 @@ class DirectoryService : public Executable, public Broadcastable
     
     bool m_hasAllPoWconns = true; 
     std::condition_variable cv_allPowConns;
-    std::mutex m_CVAllPowConn; 
+    std::mutex m_MutexCVAllPowConn; 
 
     // Sharding committee members
     std::vector<std::map<PubKey, Peer>> m_shards;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -27,6 +27,7 @@
 #include <shared_mutex>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <libCrypto/Sha2.h>
+#include <condition_variable>
 
 #include "common/Executable.h"
 #include "common/Broadcastable.h"
@@ -86,6 +87,10 @@ class DirectoryService : public Executable, public Broadcastable
 
     std::shared_timed_mutex m_mutexProducerConsumer;
     std::mutex m_mutexConsensus;
+    
+    bool m_hasAllPoWconns = true; 
+    std::condition_variable cv_allPowConns;
+    std::mutex m_CVAllPowConn; 
 
     // Sharding committee members
     std::vector<std::map<PubKey, Peer>> m_shards;
@@ -241,6 +246,12 @@ class DirectoryService : public Executable, public Broadcastable
     bool FinalBlockValidator(const std::vector<unsigned char> & finalblock);
 
     void StoreFinalBlockToDisk();
+
+    // Used to reconsile view of m_AllPowConn is different. 
+    void RequestAllPoWConn();
+    bool ProcessAllPoWConnRequest(const vector<unsigned char> & message, unsigned int offset, const Peer & from); 
+    bool ProcessAllPoWConnResponse(const vector<unsigned char> & message, unsigned int offset, const Peer & from);
+
 
 #endif // IS_LOOKUP_NODE    
 

--- a/src/libDirectoryService/PoW1Processing.cpp
+++ b/src/libDirectoryService/PoW1Processing.cpp
@@ -74,16 +74,8 @@ bool DirectoryService::VerifyPoW1Submission(const vector<unsigned char> & messag
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Winner Peer ip addr           = " << from.GetPrintableIPAddress() << ":" << portNo);
 
     // Define the PoW1 parameters
-    // if (m_mediator.m_dsBlockChain.GetBlockCount() == 1) //genesis block
-    // {
-    //     rand1 = DataConversion::HexStrToStdArray(RAND1_GENESIS);
-    //     rand2 = DataConversion::HexStrToStdArray(RAND2_GENESIS);
-    // }
-    // else
-    // {
-        rand1 = m_mediator.m_dsBlockRand;
-        rand2 = m_mediator.m_txBlockRand;
-    // }
+    rand1 = m_mediator.m_dsBlockRand;
+    rand2 = m_mediator.m_txBlockRand;
 
     difficulty = POW1_DIFFICULTY; // TODO: Need to get the latest blocknum, diff, rand1, rand2
     // Verify nonce

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -239,7 +239,7 @@ bool DirectoryService::ShardingValidator(const vector<unsigned char> & sharding_
                 LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Shard node not inside m_allPoWConns. " << memberPeer->second.GetPrintableIPAddress() << " Port: " << memberPeer->second.m_listenPortHost);
                 
                 m_hasAllPoWconns = false; 
-                std::unique_lock<std::mutex> lk(m_CVAllPowConn);
+                std::unique_lock<std::mutex> lk(m_MutexCVAllPowConn);
 
                 RequestAllPoWConn(); 
                 while (!m_hasAllPoWconns)

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -206,6 +206,7 @@ bool DirectoryService::ShardingValidator(const vector<unsigned char> & sharding_
     //   [33-byte public key]
     //   ...
     // ...
+    lock_guard<mutex> g(m_mutexAllPoWConns);
 
     unsigned int curr_offset = 0;
 
@@ -215,7 +216,6 @@ bool DirectoryService::ShardingValidator(const vector<unsigned char> & sharding_
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Number of committees = " << numOfComms);
 
-    lock_guard<mutex> g(m_mutexAllPoWConns);
     for (unsigned int i = 0; i < numOfComms; i++)
     {
         m_shards.push_back(map<PubKey, Peer>());
@@ -232,15 +232,31 @@ bool DirectoryService::ShardingValidator(const vector<unsigned char> & sharding_
             PubKey memberPubkey(sharding_structure, curr_offset);
             curr_offset += PUB_KEY_SIZE; 
 
+
             auto memberPeer = m_allPoWConns.find(memberPubkey);
             if (memberPeer == m_allPoWConns.end())
             {
-                LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "To-do: Shard node not inside m_allPoWConns - should ask for nonce and IP info from leader!");
-                throw exception();
+                LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Shard node not inside m_allPoWConns. " << memberPeer->second.GetPrintableIPAddress() << " Port: " << memberPeer->second.m_listenPortHost);
+                
+                m_hasAllPoWconns = false; 
+                std::unique_lock<std::mutex> lk(m_CVAllPowConn);
+
+                RequestAllPoWConn(); 
+                while (!m_hasAllPoWconns)
+                {
+                    cv_allPowConns.wait(lk);
+                }
+                memberPeer = m_allPoWConns.find(memberPubkey);
+                
+                if (memberPeer == m_allPoWConns.end())
+                {
+                    LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Sharding validator error");
+                    throw exception(); 
+                }
+
             }
 
             // To-do: Should we check for a public key that's been assigned to more than 1 shard?
-
             m_shards.back().insert(make_pair(memberPubkey, memberPeer->second));
             m_publicKeyToShardIdMap.insert(make_pair(memberPubkey, i));
 

--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -101,7 +101,7 @@ bool Node::ReadVariablesFromShardingMessage(const vector<unsigned char> & messag
         if (m_mediator.m_selfPeer == m_myShardMembersNetworkInfo.back())
         {
             m_consensusMyID = i; // Set my ID
-           //m_myShardMembersNetworkInfo.back().m_ipAddress = 0;
+            //m_myShardMembersNetworkInfo.back().m_ipAddress = 0;
             m_myShardMembersNetworkInfo.back().m_listenPortHost = 0;
         }
 

--- a/tests/Zilliqa/CMakeLists.txt
+++ b/tests/Zilliqa/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable (zilliqa main.cpp)
 target_include_directories (zilliqa PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService Node)
-target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService)
 
 add_executable (sendcmd sendcmd.cpp)
 target_include_directories (sendcmd PUBLIC ${CMAKE_SOURCE_DIR}/src)


### PR DESCRIPTION
Not all DS members may receive POW submission from every single node. When a node didn't receive POW submission from nodes, it may not be able validate dsblock or sharding structure. This update will let the DS members requests the information from DS leader (rather than halting itself by raising an exception). 

A future improvement will be needed. The DS member should request the information from 20 DS rather than 1 DS. 

