### PR TITLE
Fix testing errors on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,3 @@ script:
     else
       $BUILD_COMMAND && ctest;
     fi
-
-# TODO: remove when osx is fully supported
-matrix:
-  include:
-  allow_failures:
-    - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
       ";
     else
       brew update;
-      brew install pkg-config jsoncpp leveldb;
+      brew install pkg-config jsoncpp leveldb libjson-rpc-cpp;
     fi
 
 script:

--- a/tests/Data/Test_Account.cpp
+++ b/tests/Data/Test_Account.cpp
@@ -23,7 +23,8 @@
 #include "libUtils/DataConversion.h"
 
 #define BOOST_TEST_MODULE accounttest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE (accounttest)
 

--- a/tests/Data/Test_AccountStore.cpp
+++ b/tests/Data/Test_AccountStore.cpp
@@ -18,8 +18,8 @@
 #include <string>
 
 #define BOOST_TEST_MODULE accountstoretest
-
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 #include "libCrypto/Schnorr.h"
 #include "libData/AccountData/Account.h"

--- a/tests/Data/Test_Transaction.cpp
+++ b/tests/Data/Test_Transaction.cpp
@@ -27,7 +27,8 @@
 
 
 #define BOOST_TEST_MODULE transactiontest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::multiprecision;
 

--- a/tests/Lookup/Test_LookupNodeForDSBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForDSBlock.cpp
@@ -31,7 +31,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE lookupnodedsblocktest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/tests/Lookup/Test_LookupNodeForTxBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForTxBlock.cpp
@@ -31,7 +31,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE lookupnodetxblocktest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/tests/Persistence/ReadBlock.cpp
+++ b/tests/Persistence/ReadBlock.cpp
@@ -24,7 +24,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE persistencetest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE (persistencetest)
 

--- a/tests/Persistence/Test_DSPersistence.cpp
+++ b/tests/Persistence/Test_DSPersistence.cpp
@@ -25,7 +25,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE persistencetest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE (persistencetest)
 

--- a/tests/Persistence/Test_TxBody.cpp
+++ b/tests/Persistence/Test_TxBody.cpp
@@ -25,7 +25,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE persistencetest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 using namespace std;
 

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -25,7 +25,8 @@
 #include "libUtils/TimeUtils.h"
 
 #define BOOST_TEST_MODULE persistencetest
-#include <boost/test/included/unit_test.hpp>
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
 
 using namespace std;
 

--- a/tests/depends/libDatabase/Test_LevelDB.cpp
+++ b/tests/depends/libDatabase/Test_LevelDB.cpp
@@ -10,9 +10,10 @@
 #include <vector>
 
 #define BOOST_TEST_MODULE trietest
+#define BOOST_TEST_DYN_LINK
 #include <boost/filesystem/path.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "depends/common/CommonIO.h"
 #include "depends/common/FixedHash.h"


### PR DESCRIPTION
The ctest is having errors on osx platform.

```
The following tests FAILED:
	  3 - Test_Account (Failed)
	  4 - Test_AccountStore (Failed)
	  6 - Test_Transaction (Failed)
	  7 - Test_LevelDB (Failed)
	  8 - Test_LookupNodeForDSBlock (Failed)
	  9 - Test_LookupNodeForTxBlock (Failed)
	 11 - Test_DSPersistence (Failed)
	 12 - Test_TxPersistence (Failed)
	 13 - Test_TxBody (Failed)
	 14 - ReadBlock (Failed)
```

found errors both on local Mac machines and travis build