### PR TITLE
 fix : osx build issues for openssl and boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,32 @@ link_libraries(${SNAPPY_LIBRARIES})
 
 ###################
 
+message(STATUS "checking for module 'openssl'")
+
+find_path(OPENSSL_INCLUDE_DIR
+    NAMES openssl/opensslv.h
+    PATHS /usr/local/opt/openssl/include /opt/local/include /usr/local/include /usr/include
+    DOC "Path in which openssl headers are located."
+)
+
+find_path(OPENSSL_LIBRARY_DIR
+    NAMES libssl.a libssl.dylib
+    PATHS /usr/local/opt/openssl/lib /usr/lib /usr/local/lib
+    DOC "Path in which openssl library is located."
+)
+
+if(OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARY_DIR)
+  set(OPENSSL_FOUND TRUE)
+endif()
+
+if(OPENSSL_FOUND)
+    message(STATUS "Found openssl (include: ${OPENSSL_INCLUDE_DIR}, library: ${OPENSSL_LIBRARY_DIR})")
+else()
+    message(STATUS "  package 'openssl' not found")
+endif()
+
+###################
+
 message(STATUS "checking for module 'jsoncpp'")
 
 # Look for the header file.
@@ -98,7 +124,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         -DSTAT_TEST \
         -DIS_LOOKUP_NODE \
         -ggdb \
-        -I/usr/local/Cellar/openssl/1.0.2/include \
+        -I${OPENSSL_INCLUDE_DIR} \
         -I/usr/local/Cellar/boost/include \
         -I/usr/local/include" )
     SET( CMAKE_EXE_LINKER_FLAGS
@@ -112,15 +138,12 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
         -Wall \
         -DSTAT_TEST \
         -DIS_LOOKUP_NODE \
-        -L/usr/local/Cellar/openssl/1.0.2/lib" )
+        -L${OPENSSL_LIBRARY_DIR}" )
 endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # To-do
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    # To-do
-endif()
 
 ADD_DEFINITIONS(-DSTAT_TEST)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,40 @@ if(IS_LOOKUP_NODE)
 endif(IS_LOOKUP_NODE)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -std=c++14 -Wall -ggdb" )
-    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread -ljsoncpp -lboost_system -lboost_filesystem -std=c++14 -Wall" )
+    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -std=c++14 -Wall -DSTAT_TEST -ggdb -DIS_LOOKUP_NODE" )
+    SET( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread -ljsoncpp -lboost_system -lboost_filesystem -std=c++14 -Wall -DSTAT_TEST -DIS_LOOKUP_NODE" )
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -stdlib=libc++ -std=c++14 -Wall -ggdb -I/usr/local/Cellar/openssl/1.0.2/include/openssl/ -I/usr/local/Cellar/boost/1.64.0_1/include -I/usr/local/include" )
-    SET( CMAKE_EXE_LINKER_FLAGS "-L/usr/local/opt/boost@1.64/lib ${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread ${jsoncpp_LIBRARIES}  -lboost_system -lboost_filesystem -std=c++14 -Wall -L/usr/local/Cellar/openssl/1.0.2/lib" )
+    SET( CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} \
+        ${GCC_COVERAGE_COMPILE_FLAGS} \
+        -pthread \
+        -stdlib=libc++ \
+        -std=c++14 \
+        -Wall \
+        -DSTAT_TEST \
+        -DIS_LOOKUP_NODE \
+        -ggdb \
+        -I/usr/local/Cellar/openssl/1.0.2/include \
+        -I/usr/local/Cellar/boost/include \
+        -I/usr/local/include" )
+    SET( CMAKE_EXE_LINKER_FLAGS
+        "-L/usr/local/opt/boost/lib \
+        ${CMAKE_EXE_LINKER_FLAGS} \
+        ${GCC_COVERAGE_LINK_FLAGS} \
+        -pthread ${jsoncpp_LIBRARIES} \
+        -lboost_system \
+        -lboost_filesystem \
+        -std=c++14 \
+        -Wall \
+        -DSTAT_TEST \
+        -DIS_LOOKUP_NODE \
+        -L/usr/local/Cellar/openssl/1.0.2/lib" )
 endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    # To-do
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     # To-do
 endif()

--- a/build.sh
+++ b/build.sh
@@ -20,5 +20,5 @@ rm -rf ./txblocks.db
 rm -rf ./test.db
 rm -rf ./txbodies.db
 
-cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2/include/openssl/ .
+cmake -DCMAKE_BUILD_TYPE=Debug .
 make -j4

--- a/src/libCrypto/CMakeLists.txt
+++ b/src/libCrypto/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(${OPENSSL_ROOT_DIR})
 add_library (Crypto Sha3.cpp Schnorr.cpp MultiSig.cpp)
 target_include_directories (Crypto PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries (Crypto Utils crypto)


### PR DESCRIPTION
- removed hardcoded version in boost path
- removed trailing `/openssl` in linker flags
  - this allows us to remove the workaround in `src/libCrypto`
  - needed because: e.g. `#include <openssl/ec.h>` in
    `src/libCrypto/*.h` would wind up looking in path
    `.../openssl/openssl/ec.h` instead of `.../openssl/ec.h`
- auto-detect openssl include and lib paths