### PR TITLE
Enforce ubuntu 16.04 travis build for linux platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,45 @@
 language: generic
-sudo: false
-cache: apt
 
+# multiplied by platform
 os:
-  - linux
   - osx
+  - linux
 
+# multiplied by BUILD_COMMAND
 env:
-  global: LANGUAGE=C++ CXX=g++-5 CC=gcc-5
   matrix:
-    - BUILD_COMMAND="./build.sh"
-    - BUILD_COMMAND="./build_lookup.sh"
-
-addons:
-  apt:
-    packages:
-      - g++-5
-      - libboost-all-dev
-      - libleveldb-dev
-      - libjsoncpp-dev
-      - libsnappy-dev
-    sources: &sources
-      - r-packages-trusty
-      - llvm-toolchain-trusty
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
+    - BUILD_COMMAND=./build.sh
+    - BUILD_COMMAND=./build_lookup.sh
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pkg-config jsoncpp leveldb; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker pull ubuntu:16.04;
+      docker run -d -v $(pwd):/zilliqa -w /zilliqa --name ci ubuntu:16.04 tail -f /dev/null;
+    fi
+
+install:
+  # note: use option '-t' for 'docker exec' to enable colored output
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker exec -t ci /bin/sh -c "
+        apt-get -qq update;
+        apt-get install -y cmake build-essential pkg-config libssl-dev;
+        apt-get install -y libboost-all-dev libleveldb-dev libsnappy-dev;
+        apt-get install -y libjsoncpp-dev;
+      ";
+    else
+      brew update;
+      brew install pkg-config jsoncpp leveldb;
+    fi
 
 script:
-  - (eval "$BUILD_COMMAND")
-  - ctest
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      docker exec -t ci /bin/sh -c "$BUILD_COMMAND && ctest";
+    else
+      $BUILD_COMMAND && ctest;
+    fi
 
-# TODO: fix the travis build failure on osx
+# TODO: remove when osx is fully supported
 matrix:
+  include:
   allow_failures:
     - os: osx

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To run Zilliqa, we recommend the following minimum system requirements:
 * Recent dual core processor
 * 2 GB RAM
 
+> Note: Presently we are in active development on Ubuntu 16.04. The support for
+> building on other Ubuntu versions or other OSes is pending.
+
 ## Dependencies
 To compile and run the Zilliqa codebase, you will need the following dependencies to be installed on your machine:
 * `Boost` 
@@ -44,7 +47,7 @@ To compile and run the Zilliqa codebase, you will need the following dependencie
 * `CMake`
 * `build-essential`
 
-For a _Debian_-based system, you can use the following command to install the dependencies:  
+For Ubuntu 16.04, you can use the following command to install the dependencies:  
 ```bash
 sudo apt-get install libboost-all-dev libssl-dev libleveldb-dev libjsoncpp-dev libsnappy-dev cmake build-essential
 ```


### PR DESCRIPTION
Travis CI doesn't support Ubuntu 16.04 natively, so the docker image `ubuntu:16.04` is used. This releases us from maintaining another set of dependencies for old OS versions.

`README.md` is also updated to indicate the change. We now only need to maintain the development instructions on Ubuntu 16.04 for Linux platform. The support for other OSes and platforms will be improved after we have a major progress in the codebase.