### PR TITLE
Support Mac OS

### DIFF
--- a/src/depends/common/CMakeLists.txt
+++ b/src/depends/common/CMakeLists.txt
@@ -1,3 +1,4 @@
+link_directories(${JSONCPP_LIBDIR})
 add_library (Common SHARED Common.cpp CommonData.cpp CommonIO.cpp FileSystem.cpp FixedHash.cpp RLP.cpp SHA3.cpp)
 include_directories(${Boost_INCLUDE_DIRS})
 target_include_directories (Common PUBLIC ${PROJECT_SOURCE_DIR}/src)

--- a/src/depends/json_spirit/CMakeLists.txt
+++ b/src/depends/json_spirit/CMakeLists.txt
@@ -6,5 +6,6 @@ json_spirit_writer.cpp)
 FIND_PACKAGE(Boost 1.34 REQUIRED)
 INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
 
+link_directories(${JSONCPP_LIBDIR})
 ADD_LIBRARY(json_spirit SHARED ${JSON_SPIRIT_SRCS})
 

--- a/src/depends/libTrie/CMakeLists.txt
+++ b/src/depends/libTrie/CMakeLists.txt
@@ -1,3 +1,4 @@
+link_directories(${JSONCPP_LIBDIR})
 add_library (Trie SHARED Trie.cpp TrieCommon.cpp TrieHash.cpp)
 target_include_directories (Trie PUBLIC ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries (Trie LINK_PUBLIC Common Database ${LevelDB_LIBRARIES} ${SNAPPY_LIBRARIES} Utils)

--- a/src/depends/libethash/CMakeLists.txt
+++ b/src/depends/libethash/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR}/src/)
 list(APPEND FILES sha3.c sha3.h)
 
+link_directories(${JSONCPP_LIBDIR})
 add_library(ethash SHARED ${FILES})
 
 if (CRYPTOPP_FOUND)

--- a/src/depends/minilzo/CMakeLists.txt
+++ b/src/depends/minilzo/CMakeLists.txt
@@ -1,2 +1,3 @@
+link_directories(${JSONCPP_LIBDIR})
 add_library (minilzo SHARED minilzo.c)
 target_include_directories (minilzo PUBLIC ${PROJECT_SOURCE_DIR}/src)

--- a/tests/Data/CMakeLists.txt
+++ b/tests/Data/CMakeLists.txt
@@ -6,7 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable(Test_Account Test_Account.cpp)
 target_include_directories(Test_Account PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_Account LINK_PUBLIC AccountData Utils Crypto)

--- a/tests/Data/CMakeLists.txt
+++ b/tests/Data/CMakeLists.txt
@@ -6,6 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable(Test_Account Test_Account.cpp)
 target_include_directories(Test_Account PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_Account LINK_PUBLIC AccountData Utils Crypto)

--- a/tests/Lookup/CMakeLists.txt
+++ b/tests/Lookup/CMakeLists.txt
@@ -6,7 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable(Test_LookupNodeForDSBlock Test_LookupNodeForDSBlock.cpp)
 target_include_directories(Test_LookupNodeForDSBlock PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_LookupNodeForDSBlock LINK_PUBLIC Crypto AccountData Network)

--- a/tests/Lookup/CMakeLists.txt
+++ b/tests/Lookup/CMakeLists.txt
@@ -6,6 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable(Test_LookupNodeForDSBlock Test_LookupNodeForDSBlock.cpp)
 target_include_directories(Test_LookupNodeForDSBlock PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_LookupNodeForDSBlock LINK_PUBLIC Crypto AccountData Network)

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -17,6 +17,7 @@ endif(CMAKE_CONFIGURATION_TYPES)
 #target_include_directories (Test_PeerManager PUBLIC ${CMAKE_SOURCE_DIR}/src)
 #target_link_libraries (Test_PeerManager LINK_PUBLIC Utils Network Zilliqa)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable (Test_PeerStore Test_PeerStore.cpp)
 target_include_directories (Test_PeerStore PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_PeerStore LINK_PUBLIC Network Utils)

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(CMAKE_CONFIGURATION_TYPES)
 #target_include_directories (Test_PeerManager PUBLIC ${CMAKE_SOURCE_DIR}/src)
 #target_link_libraries (Test_PeerManager LINK_PUBLIC Utils Network Zilliqa)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable (Test_PeerStore Test_PeerStore.cpp)
 target_include_directories (Test_PeerStore PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_PeerStore LINK_PUBLIC Network Utils)

--- a/tests/Persistence/CMakeLists.txt
+++ b/tests/Persistence/CMakeLists.txt
@@ -6,7 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable(Test_DSPersistence Test_DSPersistence.cpp)
 target_include_directories(Test_DSPersistence PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_DSPersistence LINK_PUBLIC Crypto AccountData BlockChainData Utils Persistence)

--- a/tests/Persistence/CMakeLists.txt
+++ b/tests/Persistence/CMakeLists.txt
@@ -6,6 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable(Test_DSPersistence Test_DSPersistence.cpp)
 target_include_directories(Test_DSPersistence PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_DSPersistence LINK_PUBLIC Crypto AccountData BlockChainData Utils Persistence)

--- a/tests/Utils/CMakeLists.txt
+++ b/tests/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable (Test_TimeLockedFunction Test_TimeLockedFunction.cpp)
 target_include_directories (Test_TimeLockedFunction PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_TimeLockedFunction LINK_PUBLIC Utils)

--- a/tests/Utils/CMakeLists.txt
+++ b/tests/Utils/CMakeLists.txt
@@ -6,7 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable (Test_TimeLockedFunction Test_TimeLockedFunction.cpp)
 target_include_directories (Test_TimeLockedFunction PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_TimeLockedFunction LINK_PUBLIC Utils)

--- a/tests/Zilliqa/CMakeLists.txt
+++ b/tests/Zilliqa/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable (zilliqa main.cpp)
 target_include_directories (zilliqa PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService Node)

--- a/tests/Zilliqa/CMakeLists.txt
+++ b/tests/Zilliqa/CMakeLists.txt
@@ -1,3 +1,4 @@
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable (zilliqa main.cpp)
 target_include_directories (zilliqa PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (zilliqa LINK_PUBLIC Consensus Network Utils Zilliqa DirectoryService Node)

--- a/tests/depends/libDatabase/CMakeLists.txt
+++ b/tests/depends/libDatabase/CMakeLists.txt
@@ -6,7 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
-link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
+link_directories(${JSONCPP_LIBDIR} /usr/local/lib)
 add_executable(Test_LevelDB Test_LevelDB.cpp)
 target_include_directories(Test_LevelDB PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
 target_link_libraries(Test_LevelDB LINK_PUBLIC ${Boost_LIBRARIES} Database Utils)

--- a/tests/depends/libDatabase/CMakeLists.txt
+++ b/tests/depends/libDatabase/CMakeLists.txt
@@ -6,6 +6,7 @@ else(CMAKE_CONFIGURATION_TYPES)
     configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 endif(CMAKE_CONFIGURATION_TYPES)
 
+link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
 add_executable(Test_LevelDB Test_LevelDB.cpp)
 target_include_directories(Test_LevelDB PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
 target_link_libraries(Test_LevelDB LINK_PUBLIC ${Boost_LIBRARIES} Database Utils)


### PR DESCRIPTION
I've run Zilliqa on my MacOS environment, and got build error when building.
There seems to be lack of jsoncpp & json-rpc-cpp library path in some CMakeLists.txt.
Please have a review to see if it's necessary to add them.

Maybe it's not the best solution because I used absolute path inside...
link_directories(${JSONCPP_LIBDIR} /usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib)
