### PR TITLE
Docker image for Zilliqa

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,44 @@
+# escape=\
+FROM ubuntu:16.04
+
+ARG REPO=https://github.com/Zilliqa/Zilliqa.git
+ARG BRANCH=master
+ARG CONFIG=Debug
+
+#--------------------------------------------------------------------
+# PACKAGES - UPDATE DATABASE
+#--------------------------------------------------------------------
+RUN apt-get -qq update
+
+#--------------------------------------------------------------------
+# PACKAGES - BUILDING
+#--------------------------------------------------------------------
+RUN apt-get install -y pkg-config
+RUN apt-get install -y build-essential
+RUN apt-get install -y cmake
+RUN apt-get install -y git
+
+#--------------------------------------------------------------------
+# PACKAGES - SOURCE DEPENDENCIES
+#--------------------------------------------------------------------
+RUN apt-get install -y libboost-all-dev
+RUN apt-get install -y libssl-dev
+RUN apt-get install -y libleveldb-dev
+RUN apt-get install -y libjsoncpp-dev
+RUN apt-get install -y libsnappy-dev
+RUN apt-get install -y libmicrohttpd-dev
+RUN apt-get install -y libjsonrpccpp-dev
+
+#--------------------------------------------------------------------
+# GET SOURCES
+#--------------------------------------------------------------------
+RUN git clone -b ${BRANCH} ${REPO}
+
+#--------------------------------------------------------------------
+# CONFIGURE
+#--------------------------------------------------------------------
+WORKDIR Zilliqa
+RUN cmake -DCMAKE_BUILD_TYPE=${CONFIG} .
+RUN cmake --build .
+
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,6 @@
 # escape=\
 FROM ubuntu:16.04
 
-ARG REPO=https://github.com/Zilliqa/Zilliqa.git
-ARG BRANCH=master
-ARG CONFIG=Debug
-
 #--------------------------------------------------------------------
 # PACKAGES - UPDATE DATABASE
 #--------------------------------------------------------------------
@@ -32,11 +28,16 @@ RUN apt-get install -y libjsonrpccpp-dev
 #--------------------------------------------------------------------
 # GET SOURCES
 #--------------------------------------------------------------------
+ARG REPO=https://github.com/Zilliqa/Zilliqa.git
+ARG BRANCH=master
+
 RUN git clone -b ${BRANCH} ${REPO}
 
 #--------------------------------------------------------------------
 # CONFIGURE
 #--------------------------------------------------------------------
+ARG CONFIG=Debug
+
 WORKDIR Zilliqa
 RUN cmake -DCMAKE_BUILD_TYPE=${CONFIG} .
 RUN cmake --build .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+#Zilliqa container
+
+##Overview
+This repository contains a Dockerfile that can built into a Docker image containing the Zilliqa binaries.
+
+##Building the Docker image
+Executing the following command will start building a Docker image of Zilliqa:
+
+> docker build --rm -t zilliqa .
+
+This build step will fetch the Zilliqa sources, gather it's dependencies and build Zilliqa from source. The result is a Docker image that can be used to start up a Docker container.
+
+> Note: by default the 'master' branch of the Zilliqa repo will be built in 'Debug' mode. You can specify an other branch and/or configuration by providing build arguments like so:
+> docker build --build-arg BRANCH=<branchname> --build-arg CONFIG=<Debug/Release> --rm -t zilliqa . 
+
+##Running a Docker container
+To start up a Docker container from the previously built Docker image, you can run the following command:
+
+> docker run --rm -i -t zilliqa
+
+This will spawn a Docker container (running Ubuntu 16.04) which contains the entire source- and buildtree of Zilliqa. From there, you can run the deamon, test scripts, etc...

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,9 +1,9 @@
-#Zilliqa container
+# Zilliqa container (Experimental)
 
-##Overview
+## Overview
 This repository contains a Dockerfile that can built into a Docker image containing the Zilliqa binaries.
 
-##Building the Docker image
+## Building the Docker image
 Executing the following command will start building a Docker image of Zilliqa:
 
 > docker build --rm -t zilliqa .
@@ -13,7 +13,7 @@ This build step will fetch the Zilliqa sources, gather it's dependencies and bui
 > Note: by default the 'master' branch of the Zilliqa repo will be built in 'Debug' mode. You can specify an other branch and/or configuration by providing build arguments like so:
 > docker build --build-arg BRANCH=<branchname> --build-arg CONFIG=<Debug/Release> --rm -t zilliqa . 
 
-##Running a Docker container
+## Running a Docker container
 To start up a Docker container from the previously built Docker image, you can run the following command:
 
 > docker run --rm -i -t zilliqa


### PR DESCRIPTION
Added a Dockerfile that allows building a Docker image of Zilliqa. From this image, you can spawn Docker containers (running Ubuntu 16.04) which contain the entire Zilliqa source tree and it's built binaries.

Currently by spawning a container from this image, you can enter an interactive shell. This image can however be used to flexibly define several Docker services running a specific Zilliqa node. For example:

- one Docker service for running a Zilliqa _testnet_ node listening on _localhost_ on port _20_
- one Docker service for running a Zilliqa _mainnet_ node listening on _another IP_ on port _40_
- ...

These services would all use the same (prebuilt) Docker image to spawn their own container instance.

Let me know what you think or if you have any questions.