### PR TITLE
Enable CMAKE_EXPORT_COMPILE_COMMANDS for development use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,9 @@ else()
     message(STATUS "  package 'SNAPPY' not found")
 endif()
 
+# export compile commands
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 add_definitions(-DSTAT_TEST)
 
 if(IS_LOOKUP_NODE)


### PR DESCRIPTION
It will generate a file `compile_commands.json` in the root directory. It will be needed by development tools like [YouCompleteMe](https://github.com/Valloric/YouCompleteMe).
