### PR TITLE
Enable ccache speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: generic
+cache:
+  directories:
+    - $HOME/.ccache/
 
 # multiplied by platform
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       docker pull ubuntu:16.04;
-      docker run -d -v $(pwd):/zilliqa -w /zilliqa --name ci ubuntu:16.04 tail -f /dev/null;
+      docker run -d -v $(pwd):/zilliqa -v $HOME/.ccache:/root/.ccache -w /zilliqa --name ci ubuntu:16.04 tail -f /dev/null;
     fi
 
 install:
@@ -28,6 +28,7 @@ install:
         apt-get install -y cmake build-essential pkg-config libssl-dev;
         apt-get install -y libboost-all-dev libleveldb-dev libsnappy-dev;
         apt-get install -y libjsoncpp-dev libmicrohttpd-dev libjsonrpccpp-dev;
+        apt-get install -y ccache;
       ";
     else
       brew update;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
       ";
     else
       brew update;
-      brew install pkg-config jsoncpp leveldb libjson-rpc-cpp;
+      brew install pkg-config jsoncpp leveldb libjson-rpc-cpp ccache;
     fi
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
+    message(STATUS "Found ccache")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(Zilliqa)
 # detect operating system
 message(STATUS "We are on a ${CMAKE_SYSTEM_NAME} system")


### PR DESCRIPTION
This pr enables `ccache` in `cmake` in a failsafe way - nothing changed for the system without `ccache`. `ccache` will speed up the building process without worrying about clean up the temporary files, such as `make clean` or `git clean -dfx`.

It also accelerates the travis build on both linux and osx platforms. It's [now](https://travis-ci.org/Zilliqa/Zilliqa/builds/355508477) around 5 minutes, 2x speedup.

Currently, the installing of `ccache` is not documented in `README.md`.