### PR TITLE
[WIP] Modernize the codebase using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,7 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
+# TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
+# Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
+Checks:          '-*,modernize-avoid-bind'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*,modernize-use-noexcept,modernize-use-transparent-functors,modernize-use-override,modernize-use-transparent-functors,modernize-use-using'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-*,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,-modernize-use-default-member-init,-modernize-use-auto'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-*,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,-modernize-use-default-member-init,-modernize-use-auto'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-*,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,-modernize-use-default-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-default-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr,modernize-deprecated-headers'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr,modernize-deprecated-headers'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-random-shuffle,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-*,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,-modernize-use-default-member-init'
+Checks:          '-*,modernize-*,-modernize-use-default-member-init'
+# -modernize-use-default-member-init is intentionally disabled
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*,modernize-use-noexcept,modernize-use-transparent-functors,modernize-use-override'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-default-member-init'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # TODO: enable more checks, run 'clang-tidy -list-checks -checks="*"' to see more
 # Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-*'
-Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*,modernize-use-noexcept,modernize-use-transparent-functors,modernize-use-override'
+Checks:          '-*,modernize-avoid-bind,modernize-make-*,modernize-replace-*,modernize-use-nullptr,modernize-deprecated-headers,modernize-loop-convert,modernize-unary-static-assert,modernize-return-braced-init-list,modernize-avoid-bind,modernize-pass-by-value,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-shrink-to-fit,modernize-use-bool-literals,modernize-use-equals-*,modernize-use-noexcept,modernize-use-transparent-functors,modernize-use-override,modernize-use-transparent-functors,modernize-use-using'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/cmake/LLVMExtraTools.cmake
+++ b/cmake/LLVMExtraTools.cmake
@@ -94,6 +94,10 @@ find_program(
     PATHS "${CMAKE_SOURCE_DIR}/scripts/"
 )
 
+# a workaround to exclude the third-party headers in 'src/depends'
+# This is a known issue https://reviews.llvm.org/D34654
+set(HEADER_DIR_REGEX "^${CMAKE_SOURCE_DIR}/\"(src/(common|lib)|tests)\"")
+
 if(CLANG_TIDY)
     execute_process(
         COMMAND "${CLANG_TIDY}" --version
@@ -111,6 +115,7 @@ if(CLANG_TIDY)
             COMMAND "${RUN_CLANG_TIDY}"
             -clang-tidy-binary ${CLANG_TIDY}
             -config=''
+            -header-filter ${HEADER_DIR_REGEX}
             -style='file'
             ${ALL_CXX_SOURCES}
         )
@@ -123,6 +128,7 @@ if(CLANG_TIDY)
                 -fix
                 -format
                 -config=''
+                -header-filter ${HEADER_DIR_REGEX}
                 -style='file'
                 ${ALL_CXX_SOURCES}
             )

--- a/cmake/LLVMExtraTools.cmake
+++ b/cmake/LLVMExtraTools.cmake
@@ -117,6 +117,7 @@ if(CLANG_TIDY)
             -config=''
             -header-filter ${HEADER_DIR_REGEX}
             -style='file'
+            -warnings-as-errors='*'
             ${ALL_CXX_SOURCES}
         )
         if(CLANG_APPLY_REPLACEMENTS)

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -29,5 +29,6 @@ mkdir build && cd build
 cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j${n_parallel}
 make clang-format
+make clang-tidy
 ctest --output-on-failure
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -17,6 +17,7 @@ case $os in
         n_parallel=$(nproc)
         ;;
     'Darwin')
+        source venv/bin/activate
         n_parallel=$(sysctl -n hw.ncpu)
         ;;
     *)

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -57,7 +57,7 @@ brew install \
 # avoid from interfering with system python
 virtualenv venv -p python
 source venv/bin/activate
-pip install pyyaml
+pip install --trusted-host pypi.python.org pyyaml
 }
 
 if [ "${TRAVIS}" != "true" -a "${CI}" != "true" ]

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -51,9 +51,13 @@ brew install \
 # install developement deps
 brew install \
     ccache \
-    llvm@5
+    llvm@5 \
+    pyenv-virtualenv
 
-pip2 install pyyaml
+# avoid from interfering with system python
+virtualenv venv -p python
+source venv/bin/activate
+pip install pyyaml
 }
 
 if [ "${TRAVIS}" != "true" -a "${CI}" != "true" ]

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -5,6 +5,13 @@
 
 set -e
 
+# common instructions
+function common_deps() {
+
+# install developement deps
+pip install pyyaml
+}
+
 # presently a docker version ubuntu 16.04 is used
 function on_sudoless_ubuntu() {
 
@@ -72,10 +79,12 @@ case $os in
     'Linux')
         echo "Installing dependencies on Linux ..."
         on_sudoless_ubuntu || echo "Hint: Try re-run with sudo right, if failed"
+        common_deps
         ;;
     'Darwin')
         echo "Installing dependencies on OSX ..."
         on_osx
+        common_deps
         ;;
     *)
         echo "Error: Unknown OS, no dependencies installed"

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -5,13 +5,6 @@
 
 set -e
 
-# common instructions
-function common_deps() {
-
-# install developement deps
-pip install pyyaml
-}
-
 # presently a docker version ubuntu 16.04 is used
 function on_sudoless_ubuntu() {
 
@@ -37,7 +30,10 @@ apt-get install -y \
     ccache \
     clang-format-5.0 \
     clang-tidy-5.0 \
-    clang-5.0
+    clang-5.0 \
+    python-pip
+
+pip install pyyaml
 }
 
 function on_osx() {
@@ -50,12 +46,14 @@ brew install \
     pkg-config \
     jsoncpp \
     leveldb \
-    libjson-rpc-cpp \
+    libjson-rpc-cpp
 
 # install developement deps
 brew install \
     ccache \
     llvm@5
+
+pip2 install pyyaml
 }
 
 if [ "${TRAVIS}" != "true" -a "${CI}" != "true" ]
@@ -79,12 +77,10 @@ case $os in
     'Linux')
         echo "Installing dependencies on Linux ..."
         on_sudoless_ubuntu || echo "Hint: Try re-run with sudo right, if failed"
-        common_deps
         ;;
     'Darwin')
         echo "Installing dependencies on OSX ..."
         on_osx
-        common_deps
         ;;
     *)
         echo "Error: Unknown OS, no dependencies installed"

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -52,10 +52,11 @@ brew install \
 brew install \
     ccache \
     llvm@5 \
+    python3 \
     pyenv-virtualenv
 
 # avoid from interfering with system python
-virtualenv venv -p python
+virtualenv venv -p python3
 source venv/bin/activate
 pip install --trusted-host pypi.python.org pyyaml
 }

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -76,7 +76,7 @@ def make_absolute(f, directory):
 
 def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
                         header_filter, extra_arg, extra_arg_before, quiet,
-                        config):
+                        config, warn_as_erro):
   """Gets a command line for clang-tidy."""
   start = [clang_tidy_binary]
   if header_filter is not None:
@@ -102,6 +102,8 @@ def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
       start.append('-quiet')
   if config:
       start.append('-config=' + config)
+  if warn_as_erro:
+      start.append('-warnings-as-errors=' + warn_as_erro)
   start.append(f)
   return start
 
@@ -160,7 +162,8 @@ def run_tidy(args, tmpdir, build_path, queue, failed_files):
     invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
                                      tmpdir, build_path, args.header_filter,
                                      args.extra_arg, args.extra_arg_before,
-                                     args.quiet, args.config)
+                                     args.quiet, args.config,
+                                     args.warnings_as_errors)
     sys.stdout.write(' '.join(invocation) + '\n')
     return_code = subprocess.call(invocation)
     if return_code != 0:
@@ -219,6 +222,9 @@ def main():
                       'command line.')
   parser.add_argument('-quiet', action='store_true',
                       help='Run clang-tidy in quiet mode')
+  parser.add_argument('-warnings-as-errors', action=None,
+                      help="Upgrades warnings to errors. Same format as    "
+                      "'-checks'.")
   args = parser.parse_args()
 
   db_path = 'compile_commands.json'

--- a/src/common/Broadcastable.h
+++ b/src/common/Broadcastable.h
@@ -48,7 +48,7 @@ public:
     }
 
     /// Virtual destructor.
-    virtual ~Broadcastable() {}
+    virtual ~Broadcastable() = default;
 };
 
 #endif // __BROADCASTABLE_H__

--- a/src/common/Broadcastable.h
+++ b/src/common/Broadcastable.h
@@ -31,8 +31,7 @@ public:
     {
         LOG_MARKER();
         std::vector<Peer> peers = PeerStore::GetStore().GetAllPeers();
-        for (std::vector<Peer>::iterator peer = peers.begin();
-             peer != peers.end(); peer++)
+        for (auto peer = peers.begin(); peer != peers.end(); peer++)
         {
             if ((peer->m_ipAddress == broadcast_originator.m_ipAddress)
                 && (peer->m_listenPortHost

--- a/src/common/Executable.h
+++ b/src/common/Executable.h
@@ -30,7 +30,7 @@ public:
         = 0;
 
     /// Virtual destructor.
-    virtual ~Executable() {}
+    virtual ~Executable() = default;
 };
 
 #endif // __EXECUTABLE_H__

--- a/src/common/Serializable.h
+++ b/src/common/Serializable.h
@@ -33,7 +33,7 @@ public:
         = 0;
 
     /// Virtual destructor.
-    virtual ~Serializable() {}
+    virtual ~Serializable() = default;
 
     /// Template function for extracting a number from the source byte stream at the specified offset.
     /// Returns 0 if there are not enough bytes to read from the stream.

--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -16,6 +16,8 @@
 **/
 
 #include "ConsensusBackup.h"
+
+#include <memory>
 #include "common/Constants.h"
 #include "common/Messages.h"
 #include "libNetwork/P2PComm.h"
@@ -450,8 +452,8 @@ bool ConsensusBackup::GenerateCommitMessage(vector<unsigned char>& commit,
     // Generate new commit
     // ===================
 
-    m_commitSecret.reset(new CommitSecret());
-    m_commitPoint.reset(new CommitPoint(*m_commitSecret));
+    m_commitSecret = std::make_shared<CommitSecret>();
+    m_commitPoint = std::make_shared<CommitPoint>(*m_commitSecret);
 
     // Assemble commit message body
     // ============================

--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -274,7 +274,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
+    auto consensus_id = Serializable::GetNumber<uint32_t>(
         announcement, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
@@ -302,7 +302,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
     curr_offset += BLOCK_HASH_SIZE;
 
     // 2-byte leader id
-    uint16_t leader_id = Serializable::GetNumber<uint16_t>(
+    auto leader_id = Serializable::GetNumber<uint16_t>(
         announcement, curr_offset, sizeof(uint16_t));
     curr_offset += sizeof(uint16_t);
 
@@ -526,7 +526,7 @@ bool ConsensusBackup::ProcessMessageChallengeCore(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
+    auto consensus_id = Serializable::GetNumber<uint32_t>(
         challenge, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
@@ -554,8 +554,8 @@ bool ConsensusBackup::ProcessMessageChallengeCore(
     curr_offset += BLOCK_HASH_SIZE;
 
     // 2-byte leader id
-    uint16_t leader_id = Serializable::GetNumber<uint16_t>(
-        challenge, curr_offset, sizeof(uint16_t));
+    auto leader_id = Serializable::GetNumber<uint16_t>(challenge, curr_offset,
+                                                       sizeof(uint16_t));
     curr_offset += sizeof(uint16_t);
 
     // Check the leader id
@@ -748,7 +748,7 @@ bool ConsensusBackup::ProcessMessageCollectiveSigCore(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
+    auto consensus_id = Serializable::GetNumber<uint32_t>(
         collectivesig, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
@@ -776,7 +776,7 @@ bool ConsensusBackup::ProcessMessageCollectiveSigCore(
     curr_offset += BLOCK_HASH_SIZE;
 
     // 2-byte leader id
-    uint16_t leader_id = Serializable::GetNumber<uint16_t>(
+    auto leader_id = Serializable::GetNumber<uint16_t>(
         collectivesig, curr_offset, sizeof(uint16_t));
     curr_offset += sizeof(uint16_t);
 

--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -17,12 +17,12 @@
 
 #include "ConsensusBackup.h"
 
-#include <memory>
 #include "common/Constants.h"
 #include "common/Messages.h"
 #include "libNetwork/P2PComm.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/Logger.h"
+#include <memory>
 
 using namespace std;
 

--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -930,7 +930,7 @@ ConsensusBackup::ConsensusBackup(
     m_msgContentValidator = msg_validator;
 }
 
-ConsensusBackup::~ConsensusBackup() {}
+ConsensusBackup::~ConsensusBackup() = default;
 
 bool ConsensusBackup::ProcessMessage(const vector<unsigned char>& message,
                                      unsigned int offset, const Peer& from)

--- a/src/libConsensus/ConsensusBackup.h
+++ b/src/libConsensus/ConsensusBackup.h
@@ -113,7 +113,7 @@ public:
 
     /// Function to process any consensus message received.
     bool ProcessMessage(const std::vector<unsigned char>& message,
-                        unsigned int offset, const Peer& from);
+                        unsigned int offset, const Peer& from) override;
 };
 
 #endif // __CONSENSUSBACKUP_H__

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -17,12 +17,12 @@
 
 #include "ConsensusCommon.h"
 
-#include <utility>
 #include "common/Constants.h"
 #include "common/Messages.h"
 #include "libNetwork/P2PComm.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -16,6 +16,8 @@
 **/
 
 #include "ConsensusCommon.h"
+
+#include <utility>
 #include "common/Constants.h"
 #include "common/Messages.h"
 #include "libNetwork/P2PComm.h"
@@ -86,18 +88,15 @@ unsigned int SetBitVector(vector<unsigned char>& dst, unsigned int offset,
     return length_needed;
 }
 
-ConsensusCommon::ConsensusCommon(uint32_t consensus_id,
-                                 const vector<unsigned char>& block_hash,
-                                 uint16_t my_id, const PrivKey& privkey,
-                                 const deque<PubKey>& pubkeys,
-                                 const deque<Peer>& peer_info,
-                                 unsigned char class_byte,
-                                 unsigned char ins_byte)
+ConsensusCommon::ConsensusCommon(
+    uint32_t consensus_id, vector<unsigned char> block_hash, uint16_t my_id,
+    const PrivKey& privkey, const deque<PubKey>& pubkeys, deque<Peer> peer_info,
+    unsigned char class_byte, unsigned char ins_byte)
     : TOLERANCE_FRACTION((double)0.667)
-    , m_blockHash(block_hash)
+    , m_blockHash(std::move(block_hash))
     , m_myPrivKey(privkey)
     , m_pubKeys(pubkeys)
-    , m_peerInfo(peer_info)
+    , m_peerInfo(std::move(peer_info))
     , m_responseMap(pubkeys.size(), false)
 {
     m_consensusID = consensus_id;

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -105,7 +105,7 @@ ConsensusCommon::ConsensusCommon(
     m_insByte = ins_byte;
 }
 
-ConsensusCommon::~ConsensusCommon() {}
+ConsensusCommon::~ConsensusCommon() = default;
 
 Signature ConsensusCommon::SignMessage(const vector<unsigned char>& msg,
                                        unsigned int offset, unsigned int size)

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -28,9 +28,8 @@
 #include "libNetwork/PeerStore.h"
 #include "libUtils/TimeLockedFunction.h"
 
-typedef std::function<bool(const std::vector<unsigned char>& input,
-                           std::vector<unsigned char>& errorMsg)>
-    MsgContentValidatorFunc;
+using MsgContentValidatorFunc = std::function<bool(
+    const std::vector<unsigned char>&, std::vector<unsigned char>&)>;
 
 unsigned int GetBitVectorLengthInBytes(unsigned int length_in_bits);
 vector<bool> GetBitVector(const vector<unsigned char>& src, unsigned int offset,

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -114,10 +114,9 @@ protected:
 
     /// Constructor.
     ConsensusCommon(uint32_t consensus_id,
-                    const std::vector<unsigned char>& block_hash,
-                    uint16_t my_id, const PrivKey& privkey,
-                    const std::deque<PubKey>& pubkeys,
-                    const std::deque<Peer>& peer_info, unsigned char class_byte,
+                    std::vector<unsigned char> block_hash, uint16_t my_id,
+                    const PrivKey& privkey, const std::deque<PubKey>& pubkeys,
+                    std::deque<Peer> peer_info, unsigned char class_byte,
                     unsigned char ins_byte);
 
     /// Destructor.

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -274,8 +274,8 @@ bool ConsensusLeader::ProcessMessageCommitCore(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
-        commit, curr_offset, sizeof(uint32_t));
+    auto consensus_id = Serializable::GetNumber<uint32_t>(commit, curr_offset,
+                                                          sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
     // Check the consensus id
@@ -302,8 +302,8 @@ bool ConsensusLeader::ProcessMessageCommitCore(
     curr_offset += BLOCK_HASH_SIZE;
 
     // 2-byte backup id
-    uint16_t backup_id = Serializable::GetNumber<uint16_t>(commit, curr_offset,
-                                                           sizeof(uint16_t));
+    auto backup_id = Serializable::GetNumber<uint16_t>(commit, curr_offset,
+                                                       sizeof(uint16_t));
     curr_offset += sizeof(uint16_t);
 
     // Check the backup id
@@ -567,7 +567,7 @@ bool ConsensusLeader::ProcessMessageCommitFailure(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
+    auto consensus_id = Serializable::GetNumber<uint32_t>(
         commitFailureMsg, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
@@ -594,7 +594,7 @@ bool ConsensusLeader::ProcessMessageCommitFailure(
     curr_offset += BLOCK_HASH_SIZE;
 
     // 2-byte backup id
-    uint16_t backup_id = Serializable::GetNumber<uint16_t>(
+    auto backup_id = Serializable::GetNumber<uint16_t>(
         commitFailureMsg, curr_offset, sizeof(uint16_t));
     curr_offset += sizeof(uint16_t);
 
@@ -778,8 +778,8 @@ bool ConsensusLeader::ProcessMessageResponseCore(
     unsigned int curr_offset = offset;
 
     // 4-byte consensus id
-    uint32_t consensus_id = Serializable::GetNumber<uint32_t>(
-        response, curr_offset, sizeof(uint32_t));
+    auto consensus_id = Serializable::GetNumber<uint32_t>(response, curr_offset,
+                                                          sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
     // Check the consensus id

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -1076,7 +1076,7 @@ ConsensusLeader::ConsensusLeader(
     m_shardCommitFailureHandlerFunc = shardCommitFailureHandlerFunc;
 }
 
-ConsensusLeader::~ConsensusLeader() {}
+ConsensusLeader::~ConsensusLeader() = default;
 
 bool ConsensusLeader::StartConsensus(const vector<unsigned char>& message)
 {

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -353,8 +353,8 @@ bool ConsensusLeader::ProcessMessageCommitCore(
         // 33-byte commit
         if (m_commitCounter < m_numForConsensus)
         {
-            m_commitPoints.push_back(
-                CommitPoint(commit, curr_offset - COMMIT_POINT_SIZE));
+            m_commitPoints.emplace_back(commit,
+                                        curr_offset - COMMIT_POINT_SIZE);
             m_commitPointMap.at(backup_id)
                 = CommitPoint(commit, curr_offset - COMMIT_POINT_SIZE);
             m_commitMap.at(backup_id) = true;

--- a/src/libConsensus/ConsensusLeader.h
+++ b/src/libConsensus/ConsensusLeader.h
@@ -133,7 +133,7 @@ public:
 
     /// Function to process any consensus message received.
     bool ProcessMessage(const std::vector<unsigned char>& message,
-                        unsigned int offset, const Peer& from);
+                        unsigned int offset, const Peer& from) override;
 };
 
 #endif // __CONSENSUSLEADER_H__

--- a/src/libConsensus/ConsensusLeader.h
+++ b/src/libConsensus/ConsensusLeader.h
@@ -29,11 +29,10 @@
 #include "libNetwork/PeerStore.h"
 #include "libUtils/TimeLockedFunction.h"
 
-typedef std::function<bool(const vector<unsigned char>& errorMsg, unsigned int,
-                           const Peer& from)>
-    NodeCommitFailureHandlerFunc;
-typedef std::function<bool(std::map<unsigned int, std::vector<unsigned char>>)>
-    ShardCommitFailureHandlerFunc;
+using NodeCommitFailureHandlerFunc = std::function<bool(
+    const vector<unsigned char>&, unsigned int, const Peer&)>;
+using ShardCommitFailureHandlerFunc
+    = std::function<bool(std::map<unsigned int, std::vector<unsigned char>>)>;
 
 /// Implements the functionality for the consensus committee leader.
 class ConsensusLeader : public ConsensusCommon

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -19,6 +19,7 @@
 
 #include "common/Messages.h"
 #include "libUtils/Logger.h"
+#include <memory>
 #include <utility>
 
 using namespace std;
@@ -91,14 +92,14 @@ bool ConsensusUser::ProcessSetLeader(const vector<unsigned char>& message,
 
     if (m_leaderOrBackup == false) // Leader
     {
-        m_consensus.reset(new ConsensusLeader(
+        m_consensus = std::make_shared<ConsensusLeader>(
             dummy_consensus_id, dummy_block_hash, my_id, m_selfKey.first,
             pubkeys, peer_info,
             static_cast<unsigned char>(MessageType::CONSENSUSUSER),
             static_cast<unsigned char>(InstructionType::CONSENSUS),
             std::function<bool(const vector<unsigned char>& errorMsg,
                                unsigned int, const Peer& from)>(),
-            std::function<bool(map<unsigned int, vector<unsigned char>>)>()));
+            std::function<bool(map<unsigned int, vector<unsigned char>>)>());
     }
     else // Backup
     {
@@ -107,11 +108,11 @@ bool ConsensusUser::ProcessSetLeader(const vector<unsigned char>& message,
             return MyMsgValidatorFunc(message, errorMsg);
         };
 
-        m_consensus.reset(new ConsensusBackup(
+        m_consensus = std::make_shared<ConsensusBackup>(
             dummy_consensus_id, dummy_block_hash, my_id, leader_id,
             m_selfKey.first, pubkeys, peer_info,
             static_cast<unsigned char>(MessageType::CONSENSUSUSER),
-            static_cast<unsigned char>(InstructionType::CONSENSUS), func));
+            static_cast<unsigned char>(InstructionType::CONSENSUS), func);
     }
 
     if (m_consensus == nullptr)

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -39,7 +39,7 @@ bool ConsensusUser::ProcessSetLeader(const vector<unsigned char>& message,
         return false;
     }
 
-    uint16_t leader_id
+    auto leader_id
         = Serializable::GetNumber<uint16_t>(message, offset, sizeof(uint16_t));
 
     uint32_t dummy_consensus_id = 0xFACEFACE;
@@ -142,7 +142,7 @@ bool ConsensusUser::ProcessStartConsensus(const vector<unsigned char>& message,
         return false;
     }
 
-    ConsensusLeader* cl = dynamic_cast<ConsensusLeader*>(m_consensus.get());
+    auto* cl = dynamic_cast<ConsensusLeader*>(m_consensus.get());
     if (cl == nullptr)
     {
         LOG_MESSAGE("Error: I'm a backup, you can't start consensus "

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -17,9 +17,9 @@
 
 #include "ConsensusUser.h"
 
-#include <utility>
 #include "common/Messages.h"
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -16,6 +16,8 @@
 **/
 
 #include "ConsensusUser.h"
+
+#include <utility>
 #include "common/Messages.h"
 #include "libUtils/Logger.h"
 
@@ -179,9 +181,9 @@ bool ConsensusUser::ProcessConsensusMessage(
     return result;
 }
 
-ConsensusUser::ConsensusUser(const pair<PrivKey, PubKey>& key, const Peer& peer)
-    : m_selfKey(key)
-    , m_selfPeer(peer)
+ConsensusUser::ConsensusUser(pair<PrivKey, PubKey> key, Peer peer)
+    : m_selfKey(std::move(key))
+    , m_selfPeer(std::move(peer))
     , m_consensus(nullptr)
 {
     m_leaderOrBackup = false;

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -198,7 +198,7 @@ bool ConsensusUser::Execute(const vector<unsigned char>& message,
 
     bool result = false;
 
-    typedef bool (ConsensusUser::*InstructionHandler)(
+    using InstructionHandler = bool (ConsensusUser::*)(
         const vector<unsigned char>&, unsigned int, const Peer&);
 
     InstructionHandler ins_handlers[] = {

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -73,9 +73,9 @@ bool ConsensusUser::ProcessSetLeader(const vector<unsigned char>& message,
 
     // Now I need to find my index in the sorted list (this will be my ID for the consensus)
     uint16_t my_id = 0;
-    for (auto i = pubkeys.begin(); i != pubkeys.end(); i++)
+    for (auto& pubkey : pubkeys)
     {
-        if (*i == m_selfKey.second)
+        if (pubkey == m_selfKey.second)
         {
             LOG_MESSAGE("My node ID for this consensus is " << my_id);
             break;

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -141,7 +141,7 @@ bool ConsensusUser::ProcessStartConsensus(const vector<unsigned char>& message,
     }
 
     ConsensusLeader* cl = dynamic_cast<ConsensusLeader*>(m_consensus.get());
-    if (cl == NULL)
+    if (cl == nullptr)
     {
         LOG_MESSAGE("Error: I'm a backup, you can't start consensus "
                     "(announcement) thru me");

--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -189,7 +189,7 @@ ConsensusUser::ConsensusUser(pair<PrivKey, PubKey> key, Peer peer)
     m_leaderOrBackup = false;
 }
 
-ConsensusUser::~ConsensusUser() {}
+ConsensusUser::~ConsensusUser() = default;
 
 bool ConsensusUser::Execute(const vector<unsigned char>& message,
                             unsigned int offset, const Peer& from)

--- a/src/libConsensus/ConsensusUser.h
+++ b/src/libConsensus/ConsensusUser.h
@@ -48,10 +48,10 @@ public:
     };
 
     ConsensusUser(std::pair<PrivKey, PubKey> key, Peer peer);
-    ~ConsensusUser();
+    ~ConsensusUser() override;
 
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
-                 const Peer& from);
+                 const Peer& from) override;
 
     bool MyMsgValidatorFunc(
         const std::vector<unsigned char>& message,

--- a/src/libConsensus/ConsensusUser.h
+++ b/src/libConsensus/ConsensusUser.h
@@ -47,7 +47,7 @@ public:
         = 0x02 // These are messages that ConsensusLeader or ConsensusBackup will process (transparent to user)
     };
 
-    ConsensusUser(const std::pair<PrivKey, PubKey>& key, const Peer& peer);
+    ConsensusUser(std::pair<PrivKey, PubKey> key, Peer peer);
     ~ConsensusUser();
 
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,

--- a/src/libCrypto/MultiSig.cpp
+++ b/src/libCrypto/MultiSig.cpp
@@ -22,7 +22,6 @@ using namespace std;
 
 CommitSecret::CommitSecret()
     : m_s(BN_new(), BN_clear_free)
-    , m_initialized(false)
 {
     // commit->secret should be in [2,...,order-1]
     // -1 means no constraint on the MSB of kpriv->d
@@ -150,7 +149,6 @@ bool CommitSecret::operator==(const CommitSecret& r) const
 CommitPoint::CommitPoint()
     : m_p(EC_POINT_new(Schnorr::GetInstance().GetCurve().m_group.get()),
           EC_POINT_clear_free)
-    , m_initialized(false)
 {
     if (m_p == nullptr)
     {
@@ -293,7 +291,6 @@ bool CommitPoint::operator==(const CommitPoint& r) const
 
 Challenge::Challenge()
     : m_c(BN_new(), BN_clear_free)
-    , m_initialized(false)
 {
     if (m_c == nullptr)
     {
@@ -487,7 +484,6 @@ bool Challenge::operator==(const Challenge& r) const
 
 Response::Response()
     : m_r(BN_new(), BN_clear_free)
-    , m_initialized(false)
 {
     if (m_r == nullptr)
     {

--- a/src/libCrypto/MultiSig.cpp
+++ b/src/libCrypto/MultiSig.cpp
@@ -90,7 +90,7 @@ CommitSecret::CommitSecret(const CommitSecret& src)
     }
 }
 
-CommitSecret::~CommitSecret() {}
+CommitSecret::~CommitSecret() = default;
 
 bool CommitSecret::Initialized() const { return m_initialized; }
 
@@ -202,7 +202,7 @@ CommitPoint::CommitPoint(const CommitPoint& src)
     }
 }
 
-CommitPoint::~CommitPoint() {}
+CommitPoint::~CommitPoint() = default;
 
 bool CommitPoint::Initialized() const { return m_initialized; }
 
@@ -344,7 +344,7 @@ Challenge::Challenge(const Challenge& src)
     }
 }
 
-Challenge::~Challenge() {}
+Challenge::~Challenge() = default;
 
 bool Challenge::Initialized() const { return m_initialized; }
 
@@ -538,7 +538,7 @@ Response::Response(const Response& src)
     }
 }
 
-Response::~Response() {}
+Response::~Response() = default;
 
 bool Response::Initialized() const { return m_initialized; }
 

--- a/src/libCrypto/MultiSig.cpp
+++ b/src/libCrypto/MultiSig.cpp
@@ -48,7 +48,8 @@ CommitSecret::CommitSecret()
             break;
         }
 
-        err = (BN_nnmod(m_s.get(), m_s.get(), curve.m_order.get(), NULL) == 0);
+        err = (BN_nnmod(m_s.get(), m_s.get(), curve.m_order.get(), nullptr)
+               == 0);
         if (err)
         {
             LOG_MESSAGE("Error: Value to commit gen failed");
@@ -74,7 +75,7 @@ CommitSecret::CommitSecret(const CommitSecret& src)
 {
     if (m_s != nullptr)
     {
-        if (BN_copy(m_s.get(), src.m_s.get()) == NULL)
+        if (BN_copy(m_s.get(), src.m_s.get()) == nullptr)
         {
             LOG_MESSAGE("Error: CommitSecret copy failed");
         }
@@ -256,7 +257,7 @@ void CommitPoint::Set(const CommitSecret& secret)
     }
 
     if (EC_POINT_mul(Schnorr::GetInstance().GetCurve().m_group.get(), m_p.get(),
-                     secret.m_s.get(), NULL, NULL, NULL)
+                     secret.m_s.get(), nullptr, nullptr, nullptr)
         != 1)
     {
         LOG_MESSAGE("Error: Commit gen failed");
@@ -330,7 +331,7 @@ Challenge::Challenge(const Challenge& src)
 {
     if (m_c != nullptr)
     {
-        if (BN_copy(m_c.get(), src.m_c.get()) == NULL)
+        if (BN_copy(m_c.get(), src.m_c.get()) == nullptr)
         {
             LOG_MESSAGE("Error: Challenge copy failed");
         }
@@ -426,7 +427,7 @@ void Challenge::Set(const CommitPoint& aggregatedCommit,
     // Convert the committment to octets first
     if (EC_POINT_point2oct(curve.m_group.get(), aggregatedCommit.m_p.get(),
                            POINT_CONVERSION_COMPRESSED, buf.data(),
-                           Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                           Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
         != Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES)
     {
         LOG_MESSAGE("Error: Could not convert commitment to octets");
@@ -442,7 +443,7 @@ void Challenge::Set(const CommitPoint& aggregatedCommit,
     // Convert the public key to octets
     if (EC_POINT_point2oct(curve.m_group.get(), aggregatedPubkey.m_P.get(),
                            POINT_CONVERSION_COMPRESSED, buf.data(),
-                           Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                           Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
         != Schnorr::PUBKEY_COMPRESSED_SIZE_BYTES)
     {
         LOG_MESSAGE("Error: Could not convert public key to octets");
@@ -457,13 +458,13 @@ void Challenge::Set(const CommitPoint& aggregatedCommit,
     vector<unsigned char> digest = sha2.Finalize();
 
     // Build the challenge
-    if ((BN_bin2bn(digest.data(), digest.size(), m_c.get())) == NULL)
+    if ((BN_bin2bn(digest.data(), digest.size(), m_c.get())) == nullptr)
     {
         LOG_MESSAGE("Error: Digest to challenge failed");
         return;
     }
 
-    if (BN_nnmod(m_c.get(), m_c.get(), curve.m_order.get(), NULL) == 0)
+    if (BN_nnmod(m_c.get(), m_c.get(), curve.m_order.get(), nullptr) == 0)
     {
         LOG_MESSAGE("Error: Could not reduce challenge modulo group order");
         return;
@@ -525,7 +526,7 @@ Response::Response(const Response& src)
 {
     if (m_r != nullptr)
     {
-        if (BN_copy(m_r.get(), src.m_r.get()) == NULL)
+        if (BN_copy(m_r.get(), src.m_r.get()) == nullptr)
         {
             LOG_MESSAGE("Error: Response copy failed");
         }
@@ -681,7 +682,7 @@ shared_ptr<PubKey> MultiSig::AggregatePubKeys(const vector<PubKey>& pubkeys)
     {
         if (EC_POINT_add(curve.m_group.get(), aggregatedPubkey->m_P.get(),
                          aggregatedPubkey->m_P.get(), pubkeys.at(i).m_P.get(),
-                         NULL)
+                         nullptr)
             == 0)
         {
             LOG_MESSAGE("Error: Pubkey aggregation failed");
@@ -716,7 +717,7 @@ MultiSig::AggregateCommits(const vector<CommitPoint>& commitPoints)
     {
         if (EC_POINT_add(curve.m_group.get(), aggregatedCommit->m_p.get(),
                          aggregatedCommit->m_p.get(),
-                         commitPoints.at(i).m_p.get(), NULL)
+                         commitPoints.at(i).m_p.get(), nullptr)
             == 0)
         {
             LOG_MESSAGE("Error: Commit aggregation failed");
@@ -793,13 +794,13 @@ MultiSig::AggregateSign(const Challenge& challenge,
         return nullptr;
     }
 
-    if (BN_copy(result->m_r.get(), challenge.m_c.get()) == NULL)
+    if (BN_copy(result->m_r.get(), challenge.m_c.get()) == nullptr)
     {
         LOG_MESSAGE("Error: Signature generation (copy challenge) failed");
         return nullptr;
     }
 
-    if (BN_copy(result->m_s.get(), aggregatedResponse.m_r.get()) == NULL)
+    if (BN_copy(result->m_s.get(), aggregatedResponse.m_r.get()) == nullptr)
     {
         LOG_MESSAGE("Error: Signature generation (copy response) failed");
         return nullptr;

--- a/src/libCrypto/MultiSig.h
+++ b/src/libCrypto/MultiSig.h
@@ -33,7 +33,7 @@ struct CommitSecret : public Serializable
     std::shared_ptr<BIGNUM> m_s;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Constructor for generating a new commitment secret.
     CommitSecret();
@@ -71,7 +71,7 @@ struct CommitPoint : public Serializable
     std::shared_ptr<EC_POINT> m_p;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor for an uninitialized point.
     CommitPoint();
@@ -115,7 +115,7 @@ struct Challenge : public Serializable
     std::shared_ptr<BIGNUM> m_c;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor for an uninitialized challenge.
     Challenge();
@@ -163,7 +163,7 @@ struct Response : public Serializable
     std::shared_ptr<BIGNUM> m_r;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor for an uninitialized response.
     Response();

--- a/src/libCrypto/MultiSig.h
+++ b/src/libCrypto/MultiSig.h
@@ -45,17 +45,18 @@ struct CommitSecret : public Serializable
     CommitSecret(const CommitSecret& src);
 
     /// Destructor.
-    ~CommitSecret();
+    ~CommitSecret() override;
 
     /// Indicates if secret parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Assignment operator.
     CommitSecret& operator=(const CommitSecret&);
@@ -86,17 +87,18 @@ struct CommitPoint : public Serializable
     CommitPoint(const CommitPoint&);
 
     /// Destructor.
-    ~CommitPoint();
+    ~CommitPoint() override;
 
     /// Indicates if commitment point parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Sets the commitment point value based on the specified CommitSecret.
     void Set(const CommitSecret& secret);
@@ -132,17 +134,18 @@ struct Challenge : public Serializable
     Challenge(const Challenge& src);
 
     /// Destructor.
-    ~Challenge();
+    ~Challenge() override;
 
     /// Indicates if challenge parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Sets the challenge value based on the specified input parameters.
     void Set(const CommitPoint& aggregatedCommit,
@@ -179,17 +182,18 @@ struct Response : public Serializable
     Response(const Response& src);
 
     /// Destructor.
-    ~Response();
+    ~Response() override;
 
     /// Indicates if response parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Sets the response value based on the specified input parameters.
     void Set(const CommitSecret& secret, const Challenge& challenge,

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -58,7 +58,7 @@ Curve::Curve()
     }
 }
 
-Curve::~Curve() {}
+Curve::~Curve() = default;
 
 shared_ptr<BIGNUM> BIGNUMSerialize::GetNumber(const vector<unsigned char>& src,
                                               unsigned int offset,
@@ -246,7 +246,7 @@ PrivKey::PrivKey(const PrivKey& src)
     }
 }
 
-PrivKey::~PrivKey() {}
+PrivKey::~PrivKey() = default;
 
 bool PrivKey::Initialized() const { return m_initialized; }
 
@@ -386,7 +386,7 @@ PubKey::PubKey(const PubKey& src)
     }
 }
 
-PubKey::~PubKey() {}
+PubKey::~PubKey() = default;
 
 bool PubKey::Initialized() const { return m_initialized; }
 
@@ -548,7 +548,7 @@ Signature::Signature(const Signature& src)
     }
 }
 
-Signature::~Signature() {}
+Signature::~Signature() = default;
 
 bool Signature::Initialized() const { return m_initialized; }
 
@@ -619,9 +619,9 @@ bool Signature::operator==(const Signature& r) const
                 && (BN_cmp(m_s.get(), r.m_s.get()) == 0)));
 }
 
-Schnorr::Schnorr() {}
+Schnorr::Schnorr() = default;
 
-Schnorr::~Schnorr() {}
+Schnorr::~Schnorr() = default;
 
 Schnorr& Schnorr::GetInstance()
 {

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -188,7 +188,6 @@ void ECPOINTSerialize::SetNumber(vector<unsigned char>& dst,
 
 PrivKey::PrivKey()
     : m_d(BN_new(), BN_clear_free)
-    , m_initialized(false)
 {
     // kpriv->d should be in [1,...,order-1]
     // -1 means no constraint on the MSB of kpriv->d
@@ -305,7 +304,6 @@ bool PrivKey::operator==(const PrivKey& r) const
 PubKey::PubKey()
     : m_P(EC_POINT_new(Schnorr::GetInstance().GetCurve().m_group.get()),
           EC_POINT_clear_free)
-    , m_initialized(false)
 {
     if (m_P == nullptr)
     {
@@ -504,7 +502,6 @@ bool PubKey::operator==(const PubKey& r) const
 Signature::Signature()
     : m_r(BN_new(), BN_clear_free)
     , m_s(BN_new(), BN_clear_free)
-    , m_initialized(false)
 {
     if ((m_r == nullptr) || (m_s == nullptr))
     {

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -51,7 +51,7 @@ Curve::Curve()
     }
 
     // Get group order
-    if (!EC_GROUP_get_order(m_group.get(), m_order.get(), NULL))
+    if (!EC_GROUP_get_order(m_group.get(), m_order.get(), nullptr))
     {
         LOG_MESSAGE("Error: Recover curve order failed");
         // throw exception();
@@ -69,8 +69,8 @@ shared_ptr<BIGNUM> BIGNUMSerialize::GetNumber(const vector<unsigned char>& src,
 
     if (offset + size <= src.size())
     {
-        BIGNUM* ret = BN_bin2bn(src.data() + offset, size, NULL);
-        if (ret != NULL)
+        BIGNUM* ret = BN_bin2bn(src.data() + offset, size, nullptr);
+        if (ret != nullptr)
         {
             return shared_ptr<BIGNUM>(ret, BN_clear_free);
         }
@@ -147,8 +147,8 @@ ECPOINTSerialize::GetNumber(const vector<unsigned char>& src,
 
         EC_POINT* ret
             = EC_POINT_bn2point(Schnorr::GetInstance().GetCurve().m_group.get(),
-                                bnvalue.get(), NULL, ctx.get());
-        if (ret != NULL)
+                                bnvalue.get(), nullptr, ctx.get());
+        if (ret != nullptr)
         {
             return shared_ptr<EC_POINT>(ret, EC_POINT_clear_free);
         }
@@ -173,7 +173,7 @@ void ECPOINTSerialize::SetNumber(vector<unsigned char>& dst,
 
         bnvalue.reset(
             EC_POINT_point2bn(Schnorr::GetInstance().GetCurve().m_group.get(),
-                              value.get(), POINT_CONVERSION_COMPRESSED, NULL,
+                              value.get(), POINT_CONVERSION_COMPRESSED, nullptr,
                               ctx.get()),
             BN_clear_free);
         if (bnvalue == nullptr)
@@ -231,7 +231,7 @@ PrivKey::PrivKey(const PrivKey& src)
 {
     if (m_d != nullptr)
     {
-        if (BN_copy(m_d.get(), src.m_d.get()) == NULL)
+        if (BN_copy(m_d.get(), src.m_d.get()) == nullptr)
         {
             LOG_MESSAGE("Error: PrivKey copy failed");
         }
@@ -341,7 +341,7 @@ PubKey::PubKey(const PrivKey& privkey)
         }
 
         if (EC_POINT_mul(curve.m_group.get(), m_P.get(), privkey.m_d.get(),
-                         NULL, NULL, NULL)
+                         nullptr, nullptr, nullptr)
             == 0)
         {
             LOG_MESSAGE("Error: Public key generation failed");
@@ -447,12 +447,12 @@ bool PubKey::operator<(const PubKey& r) const
 
     shared_ptr<BIGNUM> lhs_bnvalue(
         EC_POINT_point2bn(Schnorr::GetInstance().GetCurve().m_group.get(),
-                          m_P.get(), POINT_CONVERSION_COMPRESSED, NULL,
+                          m_P.get(), POINT_CONVERSION_COMPRESSED, nullptr,
                           ctx.get()),
         BN_clear_free);
     shared_ptr<BIGNUM> rhs_bnvalue(
         EC_POINT_point2bn(Schnorr::GetInstance().GetCurve().m_group.get(),
-                          r.m_P.get(), POINT_CONVERSION_COMPRESSED, NULL,
+                          r.m_P.get(), POINT_CONVERSION_COMPRESSED, nullptr,
                           ctx.get()),
         BN_clear_free);
 
@@ -472,12 +472,12 @@ bool PubKey::operator>(const PubKey& r) const
 
     shared_ptr<BIGNUM> lhs_bnvalue(
         EC_POINT_point2bn(Schnorr::GetInstance().GetCurve().m_group.get(),
-                          m_P.get(), POINT_CONVERSION_COMPRESSED, NULL,
+                          m_P.get(), POINT_CONVERSION_COMPRESSED, nullptr,
                           ctx.get()),
         BN_clear_free);
     shared_ptr<BIGNUM> rhs_bnvalue(
         EC_POINT_point2bn(Schnorr::GetInstance().GetCurve().m_group.get(),
-                          r.m_P.get(), POINT_CONVERSION_COMPRESSED, NULL,
+                          r.m_P.get(), POINT_CONVERSION_COMPRESSED, nullptr,
                           ctx.get()),
         BN_clear_free);
 
@@ -532,13 +532,13 @@ Signature::Signature(const Signature& src)
     {
         m_initialized = true;
 
-        if (BN_copy(m_r.get(), src.m_r.get()) == NULL)
+        if (BN_copy(m_r.get(), src.m_r.get()) == nullptr)
         {
             LOG_MESSAGE("Error: Signature challenge copy failed");
             m_initialized = false;
         }
 
-        if (BN_copy(m_s.get(), src.m_s.get()) == NULL)
+        if (BN_copy(m_s.get(), src.m_s.get()) == nullptr)
         {
             LOG_MESSAGE("Error: Signature response copy failed");
             m_initialized = false;
@@ -735,8 +735,8 @@ bool Schnorr::Sign(const vector<unsigned char>& message, unsigned int offset,
                      || (BN_cmp(k.get(), m_curve.m_order.get()) != -1));
 
             // 2. Compute the commitment Q = kG, where G is the base point
-            err = (EC_POINT_mul(m_curve.m_group.get(), Q.get(), k.get(), NULL,
-                                NULL, NULL)
+            err = (EC_POINT_mul(m_curve.m_group.get(), Q.get(), k.get(),
+                                nullptr, nullptr, nullptr)
                    == 0);
             if (err)
             {
@@ -749,7 +749,7 @@ bool Schnorr::Sign(const vector<unsigned char>& message, unsigned int offset,
             // Convert the committment to octets first
             err = (EC_POINT_point2oct(m_curve.m_group.get(), Q.get(),
                                       POINT_CONVERSION_COMPRESSED, buf.data(),
-                                      PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                                      PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
                    != PUBKEY_COMPRESSED_SIZE_BYTES);
             if (err)
             {
@@ -766,7 +766,7 @@ bool Schnorr::Sign(const vector<unsigned char>& message, unsigned int offset,
             // Convert the public key to octets
             err = (EC_POINT_point2oct(m_curve.m_group.get(), pubkey.m_P.get(),
                                       POINT_CONVERSION_COMPRESSED, buf.data(),
-                                      PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                                      PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
                    != PUBKEY_COMPRESSED_SIZE_BYTES);
             if (err)
             {
@@ -783,7 +783,7 @@ bool Schnorr::Sign(const vector<unsigned char>& message, unsigned int offset,
 
             // Build the challenge
             err = ((BN_bin2bn(digest.data(), digest.size(), result.m_r.get()))
-                   == NULL);
+                   == nullptr);
             if (err)
             {
                 LOG_MESSAGE("Error: Digest to challenge failed");
@@ -791,7 +791,7 @@ bool Schnorr::Sign(const vector<unsigned char>& message, unsigned int offset,
             }
 
             err = (BN_nnmod(result.m_r.get(), result.m_r.get(),
-                            m_curve.m_order.get(), NULL)
+                            m_curve.m_order.get(), nullptr)
                    == 0);
             if (err)
             {
@@ -954,7 +954,7 @@ bool Schnorr::Verify(const vector<unsigned char>& message, unsigned int offset,
             // 4.1 Convert the committment to octets first
             err2 = (EC_POINT_point2oct(m_curve.m_group.get(), Q.get(),
                                        POINT_CONVERSION_COMPRESSED, buf.data(),
-                                       PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                                       PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
                     != PUBKEY_COMPRESSED_SIZE_BYTES);
             err = err || err2;
             if (err2)
@@ -972,7 +972,7 @@ bool Schnorr::Verify(const vector<unsigned char>& message, unsigned int offset,
             // 4.2 Convert the public key to octets
             err2 = (EC_POINT_point2oct(m_curve.m_group.get(), pubkey.m_P.get(),
                                        POINT_CONVERSION_COMPRESSED, buf.data(),
-                                       PUBKEY_COMPRESSED_SIZE_BYTES, NULL)
+                                       PUBKEY_COMPRESSED_SIZE_BYTES, nullptr)
                     != PUBKEY_COMPRESSED_SIZE_BYTES);
             err = err || err2;
             if (err2)
@@ -991,7 +991,7 @@ bool Schnorr::Verify(const vector<unsigned char>& message, unsigned int offset,
             // 5. return r' == r
             err2 = (BN_bin2bn(digest.data(), digest.size(),
                               challenge_built.get())
-                    == NULL);
+                    == nullptr);
             err = err || err2;
             if (err2)
             {
@@ -1000,7 +1000,7 @@ bool Schnorr::Verify(const vector<unsigned char>& message, unsigned int offset,
             }
 
             err2 = (BN_nnmod(challenge_built.get(), challenge_built.get(),
-                             m_curve.m_order.get(), NULL)
+                             m_curve.m_order.get(), nullptr)
                     == 0);
             err = err || err2;
             if (err2)
@@ -1039,7 +1039,7 @@ void Schnorr::PrintPoint(const EC_POINT* point)
     {
         // Get affine coordinates for the point
         if (EC_POINT_get_affine_coordinates_GFp(m_curve.m_group.get(), point,
-                                                x.get(), y.get(), NULL))
+                                                x.get(), y.get(), nullptr))
         {
             unique_ptr<char, void (*)(void*)> x_str(BN_bn2hex(x.get()), free);
             unique_ptr<char, void (*)(void*)> y_str(BN_bn2hex(y.get()), free);

--- a/src/libCrypto/Schnorr.h
+++ b/src/libCrypto/Schnorr.h
@@ -82,7 +82,7 @@ struct PrivKey : public Serializable
     std::shared_ptr<BIGNUM> m_d;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor for generating a new key.
     PrivKey();
@@ -132,7 +132,7 @@ struct PubKey : public Serializable
     std::shared_ptr<EC_POINT> m_P;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor for an uninitialized key.
     PubKey();
@@ -194,7 +194,7 @@ struct Signature : public Serializable
     std::shared_ptr<BIGNUM> m_s;
 
     /// Flag to indicate if parameters have been initialized.
-    bool m_initialized;
+    bool m_initialized{false};
 
     /// Default constructor.
     Signature();

--- a/src/libCrypto/Schnorr.h
+++ b/src/libCrypto/Schnorr.h
@@ -94,17 +94,18 @@ struct PrivKey : public Serializable
     PrivKey(const PrivKey& src);
 
     /// Destructor.
-    ~PrivKey();
+    ~PrivKey() override;
 
     /// Indicates if key parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Assignment operator.
     PrivKey& operator=(const PrivKey&);
@@ -147,17 +148,18 @@ struct PubKey : public Serializable
     PubKey(const PubKey&);
 
     /// Destructor.
-    ~PubKey();
+    ~PubKey() override;
 
     /// Indicates if key parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Assignment operator.
     PubKey& operator=(const PubKey& src);
@@ -206,17 +208,18 @@ struct Signature : public Serializable
     Signature(const Signature&);
 
     /// Destructor.
-    ~Signature();
+    ~Signature() override;
 
     /// Indicates if signature parameters have been initialized.
     bool Initialized() const;
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Assignment operator.
     Signature& operator=(const Signature&);

--- a/src/libCrypto/Sha2.h
+++ b/src/libCrypto/Sha2.h
@@ -60,7 +60,7 @@ public:
     }
 
     /// Destructor.
-    ~SHA2() {}
+    ~SHA2() = default;
 
     /// Hash update function.
     void Update(const std::vector<unsigned char>& input)

--- a/src/libCrypto/Sha3.h
+++ b/src/libCrypto/Sha3.h
@@ -49,7 +49,7 @@ public:
     }
 
     /// Destructor.
-    ~SHA3() {}
+    ~SHA3() = default;
 
     /// Hash update function.
     void Update(const std::vector<unsigned char>& input)

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -5,10 +5,10 @@
 
 #include "Account.h"
 
-#include <utility>
 #include "depends/common/FixedHash.h"
 #include "libCrypto/Sha2.h"
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -4,6 +4,8 @@
 **/
 
 #include "Account.h"
+
+#include <utility>
 #include "depends/common/FixedHash.h"
 #include "libCrypto/Sha2.h"
 #include "libUtils/Logger.h"
@@ -21,9 +23,9 @@ Account::Account(const vector<unsigned char>& src, unsigned int offset)
     }
 }
 
-Account::Account(const uint256_t& balance, const uint256_t& nonce)
-    : m_balance(balance)
-    , m_nonce(nonce)
+Account::Account(uint256_t balance, uint256_t nonce)
+    : m_balance(std::move(balance))
+    , m_nonce(std::move(nonce))
 {
 }
 

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -13,7 +13,7 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-Account::Account() {}
+Account::Account() = default;
 
 Account::Account(const vector<unsigned char>& src, unsigned int offset)
 {

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -39,8 +39,8 @@ public:
     Account(const std::vector<unsigned char>& src, unsigned int offset);
 
     /// Constructor with account balance, and nonce.
-    Account(const boost::multiprecision::uint256_t& balance,
-            const boost::multiprecision::uint256_t& nonce);
+    Account(boost::multiprecision::uint256_t balance,
+            boost::multiprecision::uint256_t nonce);
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -44,10 +44,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Increases account balance by the specified delta amount.
     bool IncreaseBalance(const boost::multiprecision::uint256_t& delta);

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -33,10 +33,7 @@ AccountStore::AccountStore()
     m_state = SecureTrieDB<Address, dev::OverlayDB>(&m_db);
 }
 
-AccountStore::~AccountStore()
-{
-    // boost::filesystem::remove_all("./state");
-}
+AccountStore::~AccountStore() = default;
 
 void AccountStore::Init()
 {

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -49,7 +49,7 @@ class AccountStore : public Serializable
     dev::h256 prevRoot;
 
     AccountStore();
-    ~AccountStore();
+    ~AccountStore() override;
 
     static bool Compare(const Account& l, const Account& r);
 
@@ -65,10 +65,11 @@ public:
     void Init();
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Verifies existence of Account in the list.
     bool DoesAccountExist(const Address& address);

--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -28,7 +28,7 @@ unsigned char LOW_BITS_MASK = 0x0F;
 unsigned char ACC_COND = 0x1;
 unsigned char TX_COND = 0x2;
 
-Transaction::Transaction() {}
+Transaction::Transaction() = default;
 
 Transaction::Transaction(const vector<unsigned char>& src, unsigned int offset)
 {

--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -18,6 +18,7 @@
 #include "libCrypto/Sha2.h"
 #include "libUtils/Logger.h"
 #include <algorithm>
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;
@@ -34,15 +35,15 @@ Transaction::Transaction(const vector<unsigned char>& src, unsigned int offset)
     Deserialize(src, offset);
 }
 
-Transaction::Transaction(uint32_t version, const uint256_t& nonce,
+Transaction::Transaction(uint32_t version, uint256_t nonce,
                          const Address& toAddr, const PubKey& senderPubKey,
-                         const uint256_t& amount,
+                         uint256_t amount,
                          const array<unsigned char, TRAN_SIG_SIZE>& signature)
     : m_version(version)
-    , m_nonce(nonce)
+    , m_nonce(std::move(nonce))
     , m_toAddr(toAddr)
     , m_senderPubKey(senderPubKey)
-    , m_amount(amount)
+    , m_amount(std::move(amount))
     , m_signature(signature) //, m_pred(pred)
 {
     // [TODO] m_signature should be generated from the rest

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -48,9 +48,9 @@ public:
     Transaction();
 
     /// Constructor with specified transaction fields.
-    Transaction(uint32_t version, const boost::multiprecision::uint256_t& nonce,
+    Transaction(uint32_t version, boost::multiprecision::uint256_t nonce,
                 const Address& toAddr, const PubKey& senderPubKey,
-                const boost::multiprecision::uint256_t& amount,
+                boost::multiprecision::uint256_t amount,
                 const std::array<unsigned char, TRAN_SIG_SIZE>& signature);
 
     /// Constructor for loading transaction information from a byte stream.

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -58,14 +58,15 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Searilize data without signature;
     unsigned int SerializeWithoutSignature(std::vector<unsigned char>& dst,
                                            unsigned int offset) const;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the size in bytes when serializing the transaction.
     static unsigned int GetSerializedSize();

--- a/src/libData/BlockChainData/DSBlockChain.cpp
+++ b/src/libData/BlockChainData/DSBlockChain.cpp
@@ -22,7 +22,7 @@ using namespace boost::multiprecision;
 
 DSBlockChain::DSBlockChain() { m_dsBlocks.resize(DS_BLOCKCHAIN_SIZE); }
 
-DSBlockChain::~DSBlockChain() {}
+DSBlockChain::~DSBlockChain() = default;
 
 void DSBlockChain::Reset() { m_dsBlocks.resize(DS_BLOCKCHAIN_SIZE); }
 

--- a/src/libData/BlockChainData/TxBlockChain.cpp
+++ b/src/libData/BlockChainData/TxBlockChain.cpp
@@ -22,7 +22,7 @@ using namespace boost::multiprecision;
 
 TxBlockChain::TxBlockChain() { m_txBlocks.resize(TX_BLOCKCHAIN_SIZE); }
 
-TxBlockChain::~TxBlockChain() {}
+TxBlockChain::~TxBlockChain() = default;
 
 void TxBlockChain::Reset() { m_txBlocks.resize(TX_BLOCKCHAIN_SIZE); }
 

--- a/src/libData/BlockData/Block/BlockBase.cpp
+++ b/src/libData/BlockData/Block/BlockBase.cpp
@@ -20,4 +20,4 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-BlockBase::BlockBase() {}
+BlockBase::BlockBase() = default;

--- a/src/libData/BlockData/Block/DSBlock.cpp
+++ b/src/libData/BlockData/Block/DSBlock.cpp
@@ -23,7 +23,7 @@ using namespace std;
 using namespace boost::multiprecision;
 
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
-DSBlock::DSBlock() {}
+DSBlock::DSBlock() = default;
 
 // To-do: handle exceptions. Will be deprecated.
 DSBlock::DSBlock(const vector<unsigned char>& src, unsigned int offset)

--- a/src/libData/BlockData/Block/DSBlock.cpp
+++ b/src/libData/BlockData/Block/DSBlock.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "DSBlock.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -32,9 +34,9 @@ DSBlock::DSBlock(const vector<unsigned char>& src, unsigned int offset)
     }
 }
 
-DSBlock::DSBlock(const DSBlockHeader& header,
+DSBlock::DSBlock(DSBlockHeader header,
                  const array<unsigned char, BLOCK_SIG_SIZE>& signature)
-    : m_header(header)
+    : m_header(std::move(header))
     , m_signature(signature)
 {
 }

--- a/src/libData/BlockData/Block/DSBlock.cpp
+++ b/src/libData/BlockData/Block/DSBlock.cpp
@@ -16,8 +16,8 @@
 
 #include "DSBlock.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/Block/DSBlock.h
+++ b/src/libData/BlockData/Block/DSBlock.h
@@ -47,10 +47,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the size in bytes when serializing the DS block.
     static unsigned int GetSerializedSize();

--- a/src/libData/BlockData/Block/DSBlock.h
+++ b/src/libData/BlockData/Block/DSBlock.h
@@ -42,7 +42,7 @@ public:
     DSBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
     /// Constructor with specified DS block parameters.
-    DSBlock(const DSBlockHeader& header,
+    DSBlock(DSBlockHeader header,
             const std::array<unsigned char, BLOCK_SIG_SIZE>& signature);
 
     /// Implements the Serialize function inherited from Serializable.

--- a/src/libData/BlockData/Block/MicroBlock.cpp
+++ b/src/libData/BlockData/Block/MicroBlock.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "MicroBlock.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -133,12 +135,12 @@ MicroBlock::MicroBlock(const vector<unsigned char>& src, unsigned int offset)
     }
 }
 
-MicroBlock::MicroBlock(const MicroBlockHeader& header,
+MicroBlock::MicroBlock(MicroBlockHeader header,
                        const array<unsigned char, BLOCK_SIG_SIZE>& signature,
-                       const vector<TxnHash>& tranHashes)
-    : m_header(header)
+                       vector<TxnHash> tranHashes)
+    : m_header(std::move(header))
     , m_headerSig(signature)
-    , m_tranHashes(tranHashes)
+    , m_tranHashes(std::move(tranHashes))
 {
     assert(m_header.GetNumTxs() == m_tranHashes.size());
 }

--- a/src/libData/BlockData/Block/MicroBlock.cpp
+++ b/src/libData/BlockData/Block/MicroBlock.cpp
@@ -125,7 +125,7 @@ unsigned int MicroBlock::GetMinSize()
 }
 
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
-MicroBlock::MicroBlock() {}
+MicroBlock::MicroBlock() = default;
 
 MicroBlock::MicroBlock(const vector<unsigned char>& src, unsigned int offset)
 {

--- a/src/libData/BlockData/Block/MicroBlock.cpp
+++ b/src/libData/BlockData/Block/MicroBlock.cpp
@@ -16,8 +16,8 @@
 
 #include "MicroBlock.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/Block/MicroBlock.h
+++ b/src/libData/BlockData/Block/MicroBlock.h
@@ -44,9 +44,9 @@ public:
     MicroBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
     /// Constructor with predefined member values.
-    MicroBlock(const MicroBlockHeader& header,
+    MicroBlock(MicroBlockHeader header,
                const std::array<unsigned char, BLOCK_SIG_SIZE>& signature,
-               const std::vector<TxnHash>& tranHashes);
+               std::vector<TxnHash> tranHashes);
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,

--- a/src/libData/BlockData/Block/MicroBlock.h
+++ b/src/libData/BlockData/Block/MicroBlock.h
@@ -50,10 +50,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the expected size of this microblock when serialized into a byte stream.
     unsigned int GetSerializedSize() const;

--- a/src/libData/BlockData/Block/TxBlock.cpp
+++ b/src/libData/BlockData/Block/TxBlock.cpp
@@ -16,8 +16,8 @@
 
 #include "TxBlock.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/Block/TxBlock.cpp
+++ b/src/libData/BlockData/Block/TxBlock.cpp
@@ -142,7 +142,7 @@ unsigned int TxBlock::GetMinSize()
 }
 
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
-TxBlock::TxBlock() {}
+TxBlock::TxBlock() = default;
 
 TxBlock::TxBlock(const vector<unsigned char>& src, unsigned int offset)
 {

--- a/src/libData/BlockData/Block/TxBlock.cpp
+++ b/src/libData/BlockData/Block/TxBlock.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "TxBlock.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -150,14 +152,14 @@ TxBlock::TxBlock(const vector<unsigned char>& src, unsigned int offset)
     }
 }
 
-TxBlock::TxBlock(const TxBlockHeader& header,
+TxBlock::TxBlock(TxBlockHeader header,
                  const array<unsigned char, BLOCK_SIG_SIZE>& signature,
-                 const vector<bool>& isMicroBlockEmpty,
-                 const vector<TxnHash>& microBlockTxHashes)
-    : m_header(header)
+                 vector<bool> isMicroBlockEmpty,
+                 vector<TxnHash> microBlockTxHashes)
+    : m_header(std::move(header))
     , m_headerSig(signature)
-    , m_isMicroBlockEmpty(isMicroBlockEmpty)
-    , m_microBlockHashes(microBlockTxHashes)
+    , m_isMicroBlockEmpty(std::move(isMicroBlockEmpty))
+    , m_microBlockHashes(std::move(microBlockTxHashes))
 {
     assert(m_header.GetNumMicroBlockHashes() == m_microBlockHashes.size());
 }

--- a/src/libData/BlockData/Block/TxBlock.h
+++ b/src/libData/BlockData/Block/TxBlock.h
@@ -46,10 +46,10 @@ public:
     TxBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
     /// Constructor with specified Tx block parameters.
-    TxBlock(const TxBlockHeader& header,
+    TxBlock(TxBlockHeader header,
             const std::array<unsigned char, BLOCK_SIG_SIZE>& signature,
-            const std::vector<bool>& isMicroBlockEmpty,
-            const std::vector<TxnHash>& microBlockHashes);
+            std::vector<bool> isMicroBlockEmpty,
+            std::vector<TxnHash> microBlockHashes);
 
     uint32_t SerializeIsMicroBlockEmpty() const;
 

--- a/src/libData/BlockData/Block/TxBlock.h
+++ b/src/libData/BlockData/Block/TxBlock.h
@@ -55,12 +55,13 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     std::vector<bool> DeserializeIsMicroBlockEmpty(uint32_t arg);
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the size in bytes when serializing the block.
     unsigned int GetSerializedSize() const;

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.cpp
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.cpp
@@ -20,4 +20,4 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-BlockHeaderBase::BlockHeaderBase() {}
+BlockHeaderBase::BlockHeaderBase() = default;

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "DSBlockHeader.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -35,19 +37,18 @@ DSBlockHeader::DSBlockHeader(const vector<unsigned char>& src,
 }
 
 DSBlockHeader::DSBlockHeader(const uint8_t difficulty,
-                             const BlockHash& prevHash, const uint256_t& nonce,
+                             const BlockHash& prevHash, uint256_t nonce,
                              const PubKey& minerPubKey,
-                             const PubKey& leaderPubKey,
-                             const uint256_t& blockNum,
-                             const uint256_t& timestamp,
+                             const PubKey& leaderPubKey, uint256_t blockNum,
+                             uint256_t timestamp,
                              const unsigned int viewChangeCount)
     : m_difficulty(difficulty)
     , m_prevHash(prevHash)
-    , m_nonce(nonce)
+    , m_nonce(std::move(nonce))
     , m_minerPubKey(minerPubKey)
     , m_leaderPubKey(leaderPubKey)
-    , m_blockNum(blockNum)
-    , m_timestamp(timestamp)
+    , m_blockNum(std::move(blockNum))
+    , m_timestamp(std::move(timestamp))
     , m_viewChangeCounter(viewChangeCount)
 {
 }

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -16,8 +16,8 @@
 
 #include "DSBlockHeader.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -57,10 +57,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the difficulty of the PoW puzzle.
     const uint8_t& GetDifficulty() const;

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -49,10 +49,10 @@ public:
 
     /// Constructor with specified DS block header parameters.
     DSBlockHeader(const uint8_t difficulty, const BlockHash& prevHash,
-                  const boost::multiprecision::uint256_t& nonce,
+                  boost::multiprecision::uint256_t nonce,
                   const PubKey& minerPubKey, const PubKey& leaderPubKey,
-                  const boost::multiprecision::uint256_t& blockNum,
-                  const boost::multiprecision::uint256_t& timestamp,
+                  boost::multiprecision::uint256_t blockNum,
+                  boost::multiprecision::uint256_t timestamp,
                   unsigned int viewChangeCounter);
 
     /// Implements the Serialize function inherited from Serializable.

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "MicroBlockHeader.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -35,22 +37,21 @@ MicroBlockHeader::MicroBlockHeader(const vector<unsigned char>& src,
 }
 
 MicroBlockHeader::MicroBlockHeader(
-    uint8_t type, uint32_t version, const uint256_t& gasLimit,
-    const uint256_t& gasUsed, const BlockHash& prevHash,
-    const uint256_t& blockNum, const uint256_t& timestamp,
+    uint8_t type, uint32_t version, uint256_t gasLimit, uint256_t gasUsed,
+    const BlockHash& prevHash, uint256_t blockNum, uint256_t timestamp,
     const TxnHash& txRootHash, uint32_t numTxs, const PubKey& minerPubKey,
-    const uint256_t& dsBlockNum, const BlockHash& dsBlockHeader)
+    uint256_t dsBlockNum, const BlockHash& dsBlockHeader)
     : m_type(type)
     , m_version(version)
-    , m_gasLimit(gasLimit)
-    , m_gasUsed(gasUsed)
+    , m_gasLimit(std::move(gasLimit))
+    , m_gasUsed(std::move(gasUsed))
     , m_prevHash(prevHash)
-    , m_blockNum(blockNum)
-    , m_timestamp(timestamp)
+    , m_blockNum(std::move(blockNum))
+    , m_timestamp(std::move(timestamp))
     , m_txRootHash(txRootHash)
     , m_numTxs(numTxs)
     , m_minerPubKey(minerPubKey)
-    , m_dsBlockNum(dsBlockNum)
+    , m_dsBlockNum(std::move(dsBlockNum))
     , m_dsBlockHeader(dsBlockHeader)
 {
 }

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
@@ -16,8 +16,8 @@
 
 #include "MicroBlockHeader.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
@@ -54,14 +54,14 @@ public:
 
     /// Constructor with predefined member values.
     MicroBlockHeader(const uint8_t type, const uint32_t version,
-                     const boost::multiprecision::uint256_t& gasLimit,
-                     const boost::multiprecision::uint256_t& gasUsed,
+                     boost::multiprecision::uint256_t gasLimit,
+                     boost::multiprecision::uint256_t gasUsed,
                      const BlockHash& prevHash,
-                     const boost::multiprecision::uint256_t& blockNum,
-                     const boost::multiprecision::uint256_t& timestamp,
+                     boost::multiprecision::uint256_t blockNum,
+                     boost::multiprecision::uint256_t timestamp,
                      const TxnHash& txRootHash, const uint32_t numTxs,
                      const PubKey& minerPubKey,
-                     const boost::multiprecision::uint256_t& dsBlockNum,
+                     boost::multiprecision::uint256_t dsBlockNum,
                      const BlockHash& dsBlockHeader);
 
     /// Implements the Serialize function inherited from Serializable.

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
@@ -66,10 +66,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     // [TODO] These methods are all supposed to be moved into BlockHeaderBase, so no need to add Doxygen tags for now
     const uint8_t& GetType() const;

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -16,8 +16,8 @@
 
 #include "TxBlockHeader.h"
 
-#include <utility>
 #include "libUtils/Logger.h"
+#include <utility>
 
 using namespace std;
 using namespace boost::multiprecision;

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -15,6 +15,8 @@
 **/
 
 #include "TxBlockHeader.h"
+
+#include <utility>
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -35,27 +37,28 @@ TxBlockHeader::TxBlockHeader(const vector<unsigned char>& src,
     }
 }
 
-TxBlockHeader::TxBlockHeader(
-    uint8_t type, uint32_t version, const uint256_t& gasLimit,
-    const uint256_t& gasUsed, const BlockHash& prevHash,
-    const uint256_t& blockNum, const uint256_t& timestamp,
-    const TxnHash& txRootHash, const StateHash& stateRootHash, uint32_t numTxs,
-    uint32_t numMicroBlockHashes, const PubKey& minerPubKey,
-    const uint256_t& dsBlockNum, const BlockHash& dsBlockHeader,
-    unsigned int viewChangeCounter)
+TxBlockHeader::TxBlockHeader(uint8_t type, uint32_t version, uint256_t gasLimit,
+                             uint256_t gasUsed, const BlockHash& prevHash,
+                             uint256_t blockNum, uint256_t timestamp,
+                             const TxnHash& txRootHash,
+                             const StateHash& stateRootHash, uint32_t numTxs,
+                             uint32_t numMicroBlockHashes,
+                             const PubKey& minerPubKey, uint256_t dsBlockNum,
+                             const BlockHash& dsBlockHeader,
+                             unsigned int viewChangeCounter)
     : m_type(type)
     , m_version(version)
-    , m_gasLimit(gasLimit)
-    , m_gasUsed(gasUsed)
+    , m_gasLimit(std::move(gasLimit))
+    , m_gasUsed(std::move(gasUsed))
     , m_prevHash(prevHash)
-    , m_blockNum(blockNum)
-    , m_timestamp(timestamp)
+    , m_blockNum(std::move(blockNum))
+    , m_timestamp(std::move(timestamp))
     , m_txRootHash(txRootHash)
     , m_stateRootHash(stateRootHash)
     , m_numTxs(numTxs)
     , m_numMicroBlockHashes(numMicroBlockHashes)
     , m_minerPubKey(minerPubKey)
-    , m_dsBlockNum(dsBlockNum)
+    , m_dsBlockNum(std::move(dsBlockNum))
     , m_dsBlockHeader(dsBlockHeader)
     , m_viewChangeCounter(viewChangeCounter)
 {

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.h
@@ -64,15 +64,15 @@ public:
 
     /// Constructor with specified Tx block header parameters.
     TxBlockHeader(const uint8_t type, const uint32_t version,
-                  const boost::multiprecision::uint256_t& gasLimit,
-                  const boost::multiprecision::uint256_t& gasUsed,
+                  boost::multiprecision::uint256_t gasLimit,
+                  boost::multiprecision::uint256_t gasUsed,
                   const BlockHash& prevHash,
-                  const boost::multiprecision::uint256_t& blockNum,
-                  const boost::multiprecision::uint256_t& timestamp,
+                  boost::multiprecision::uint256_t blockNum,
+                  boost::multiprecision::uint256_t timestamp,
                   const TxnHash& txRootHash, const StateHash& stateRootHash,
                   const uint32_t numTxs, const uint32_t numMicroBlockHashes,
                   const PubKey& minerPubKey,
-                  const boost::multiprecision::uint256_t& dsBlockNum,
+                  boost::multiprecision::uint256_t dsBlockNum,
                   const BlockHash& dsBlockHeader,
                   const unsigned int viewChangeCounter);
 

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.h
@@ -78,10 +78,11 @@ public:
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 
     /// Returns the type of the block.
     const uint8_t& GetType() const;

--- a/src/libData/DataStructures/CircularArray.h
+++ b/src/libData/DataStructures/CircularArray.h
@@ -52,7 +52,7 @@ public:
     CircularArray& operator=(const CircularArray<T>& circularArray) = delete;
 
     /// Destructor.
-    ~CircularArray() {}
+    ~CircularArray() = default;
 
     /// Index operator.
     T& operator[](boost::multiprecision::uint256_t index)

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -128,8 +128,7 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary()
         return false;
     }
 
-    ConsensusLeader* cl
-        = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
+    auto* cl = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
 
     vector<unsigned char> m;
     {

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -823,7 +823,7 @@ bool DirectoryService::ProcessAllPoWConnRequest(
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "I am sending AllPowConn to requester");
 
-    uint32_t requesterListeningPort
+    auto requesterListeningPort
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
 
     //  Contruct the message and send to the requester
@@ -871,7 +871,7 @@ bool DirectoryService::ProcessAllPoWConnResponse(
 
     unsigned int cur_offset = offset;
     // 32-byte block number
-    uint32_t sizeeOfAllPowConn = Serializable::GetNumber<uint32_t>(
+    auto sizeeOfAllPowConn = Serializable::GetNumber<uint32_t>(
         message, cur_offset, sizeof(uint32_t));
     cur_offset += sizeof(uint32_t);
 
@@ -957,7 +957,7 @@ bool DirectoryService::ProcessLastDSBlockRequest(
                  "DEBUG: I am sending the last ds block to the requester.");
 
     // Deserialize the message and get the port
-    uint32_t requesterListeningPort
+    auto requesterListeningPort
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
 
     // Craft the last block message

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1337,7 +1337,7 @@ bool DirectoryService::Execute(const vector<unsigned char>& message,
 
     bool result = false;
 
-    typedef bool (DirectoryService::*InstructionHandler)(
+    using InstructionHandler = bool (DirectoryService::*)(
         const vector<unsigned char>&, unsigned int, const Peer&);
 
 #ifndef IS_LOOKUP_NODE

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -704,10 +704,9 @@ bool DirectoryService::ProcessSetPrimary(const vector<unsigned char>& message,
 
     // Now I need to find my index in the sorted list (this will be my ID for the consensus)
     m_consensusMyID = 0;
-    for (auto i = m_mediator.m_DSCommitteePubKeys.begin();
-         i != m_mediator.m_DSCommitteePubKeys.end(); i++)
+    for (auto& m_DSCommitteePubKey : m_mediator.m_DSCommitteePubKeys)
     {
-        if (*i == m_mediator.m_selfKey.second)
+        if (m_DSCommitteePubKey == m_mediator.m_selfKey.second)
         {
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "My node ID for this PoW1 consensus is "

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -53,7 +53,7 @@ DirectoryService::DirectoryService(Mediator& mediator)
     m_viewChangeCounter = 0;
 }
 
-DirectoryService::~DirectoryService() {}
+DirectoryService::~DirectoryService() = default;
 
 #ifndef IS_LOOKUP_NODE
 bool DirectoryService::CheckState(Action action)

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -358,15 +358,16 @@ public:
     DirectoryService(Mediator& mediator);
 
     /// Destructor.
-    ~DirectoryService();
+    ~DirectoryService() override;
 
 #ifndef IS_LOOKUP_NODE
     /// Sets the value of m_state.
     void SetState(DirState state);
 
     /// Implements the GetBroadcastList function inherited from Broadcastable.
-    std::vector<Peer> GetBroadcastList(unsigned char ins_type,
-                                       const Peer& broadcast_originator);
+    std::vector<Peer>
+    GetBroadcastList(unsigned char ins_type,
+                     const Peer& broadcast_originator) override;
 
     /// Launches separate thread to execute sharding consensus after wait_window seconds.
     void ScheduleShardingConsensus(const unsigned int wait_window);
@@ -374,7 +375,7 @@ public:
 
     /// Implements the Execute function inherited from Executable.
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
-                 const Peer& from);
+                 const Peer& from) override;
 };
 
 #endif // __DIRECTORYSERVICE_H__

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -303,7 +303,7 @@ void DirectoryService::AppendSharingSetupToFinalBlockMessage(
                                           num_nodes, sizeof(uint32_t));
         curr_offset += sizeof(uint32_t);
 
-        map<PubKey, Peer>::const_iterator node_peer = shard.begin();
+        auto node_peer = shard.begin();
         for (unsigned int j = 0; j < num_nodes; j++)
         {
             node_peer->second.Serialize(finalBlockMessage, curr_offset);
@@ -477,8 +477,7 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary()
         return false;
     }
 
-    ConsensusLeader* cl
-        = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
+    auto* cl = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
 #ifdef STAT_TEST
     if (m_mode == PRIMARY_DS)
     {
@@ -807,7 +806,7 @@ void DirectoryService::SaveTxnBodySharingAssignment(
 
     // To-do: Put in the logic here for checking the sharing configuration
 
-    uint32_t num_ds_nodes = Serializable::GetNumber<uint32_t>(
+    auto num_ds_nodes = Serializable::GetNumber<uint32_t>(
         finalblock, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -846,17 +846,15 @@ void DirectoryService::SaveTxnBodySharingAssignment(
     if ((i_am_forwarder == true)
         && (m_mediator.m_DSCommitteeNetworkInfo.size() > num_ds_nodes))
     {
-        for (unsigned int i = 0; i < m_mediator.m_DSCommitteeNetworkInfo.size();
-             i++)
+        for (auto& i : m_mediator.m_DSCommitteeNetworkInfo)
         {
             bool is_a_receiver = false;
 
             if (num_ds_nodes > 0)
             {
-                for (unsigned int j = 0; j < ds_receivers.size(); j++)
+                for (const auto& ds_receiver : ds_receivers)
                 {
-                    if (m_mediator.m_DSCommitteeNetworkInfo.at(i)
-                        == ds_receivers.at(j))
+                    if (i == ds_receiver)
                     {
                         is_a_receiver = true;
                         break;
@@ -867,8 +865,7 @@ void DirectoryService::SaveTxnBodySharingAssignment(
 
             if (is_a_receiver == false)
             {
-                m_sharingAssignment.push_back(
-                    m_mediator.m_DSCommitteeNetworkInfo.at(i));
+                m_sharingAssignment.push_back(i);
             }
         }
     }

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -827,7 +827,7 @@ void DirectoryService::SaveTxnBodySharingAssignment(
         // }
         // ds_receivers.push_back(tempPeer);
         // TODO: Handle exceptions
-        ds_receivers.push_back(Peer(finalblock, curr_offset));
+        ds_receivers.emplace_back(finalblock, curr_offset);
         curr_offset += IP_SIZE + PORT_SIZE;
 
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -163,7 +163,7 @@ bool DirectoryService::ProcessMicroblockSubmission(
     }
 #endif // STAT_TEST
 
-        // TODO: Re-request from shard leader if microblock is not received after a certain time.
+// TODO: Re-request from shard leader if microblock is not received after a certain time.
 #endif // IS_LOOKUP_NODE
     return true;
 }

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -76,8 +76,8 @@ bool DirectoryService::ProcessMicroblockSubmission(
     }
 
     // 4-byte consensus id
-    uint32_t consensusID = Serializable::GetNumber<uint32_t>(
-        message, curr_offset, sizeof(uint32_t));
+    auto consensusID = Serializable::GetNumber<uint32_t>(message, curr_offset,
+                                                         sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
     if (consensusID != m_consensusID)
@@ -90,8 +90,8 @@ bool DirectoryService::ProcessMicroblockSubmission(
     }
 
     // 4-byte shard ID
-    uint32_t shardId = Serializable::GetNumber<uint32_t>(message, curr_offset,
-                                                         sizeof(uint32_t));
+    auto shardId = Serializable::GetNumber<uint32_t>(message, curr_offset,
+                                                     sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "shard_id " << shardId);

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -163,7 +163,7 @@ bool DirectoryService::ProcessMicroblockSubmission(
     }
 #endif // STAT_TEST
 
-// TODO: Re-request from shard leader if microblock is not received after a certain time.
+        // TODO: Re-request from shard leader if microblock is not received after a certain time.
 #endif // IS_LOOKUP_NODE
     return true;
 }

--- a/src/libDirectoryService/PoW1Processing.cpp
+++ b/src/libDirectoryService/PoW1Processing.cpp
@@ -203,7 +203,7 @@ bool DirectoryService::ParseMessageAndVerifyPOW1(
                 return false;
             }
 
-            m_allPoW1s.push_back(make_pair(key, nonce));
+            m_allPoW1s.emplace_back(key, nonce);
         }
     }
     else

--- a/src/libDirectoryService/PoW1Processing.cpp
+++ b/src/libDirectoryService/PoW1Processing.cpp
@@ -130,8 +130,8 @@ bool DirectoryService::ParseMessageAndVerifyPOW1(
     }
 
     // 4-byte listening port
-    uint32_t portNo = Serializable::GetNumber<uint32_t>(message, curr_offset,
-                                                        sizeof(uint32_t));
+    auto portNo = Serializable::GetNumber<uint32_t>(message, curr_offset,
+                                                    sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
     uint128_t ipAddr = from.m_ipAddress;

--- a/src/libDirectoryService/PoW2Processing.cpp
+++ b/src/libDirectoryService/PoW2Processing.cpp
@@ -64,8 +64,8 @@ bool DirectoryService::VerifyPOW2(const vector<unsigned char>& message,
     }
 
     // 4-byte listening port
-    uint32_t portNo = Serializable::GetNumber<uint32_t>(message, curr_offset,
-                                                        sizeof(uint32_t));
+    auto portNo = Serializable::GetNumber<uint32_t>(message, curr_offset,
+                                                    sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
     uint128_t ipAddr = from.m_ipAddress;
@@ -84,8 +84,8 @@ bool DirectoryService::VerifyPOW2(const vector<unsigned char>& message,
     // To-do: Reject PoW2 submissions from existing members of DS committee
 
     // 8-byte nonce
-    uint64_t nonce = Serializable::GetNumber<uint64_t>(message, curr_offset,
-                                                       sizeof(uint64_t));
+    auto nonce = Serializable::GetNumber<uint64_t>(message, curr_offset,
+                                                   sizeof(uint64_t));
     curr_offset += sizeof(uint64_t);
 
     // 32-byte resulting hash

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -61,23 +61,21 @@ unsigned int DirectoryService::SerializeEntireShardingStructure(
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                      "Shard size = " << it_vec->size());
 
-        for (auto it_map = it_vec->begin(); it_map != it_vec->end(); it_map++)
+        for (auto& it_map : *it_vec)
         {
             // 33-byte public key
-            (*it_map).first.Serialize(sharding_message, curr_offset);
+            it_map.first.Serialize(sharding_message, curr_offset);
             curr_offset += PUB_KEY_SIZE;
 
             // 16-byte ip + 4-byte port
-            (*it_map).second.Serialize(sharding_message, curr_offset);
+            it_map.second.Serialize(sharding_message, curr_offset);
             curr_offset += IP_SIZE + PORT_SIZE;
 
-            LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                         "PubKey: " << DataConversion::SerializableToHexStr(
-                                           (*it_map).first)
-                                    << " IP: "
-                                    << (*it_map).second.GetPrintableIPAddress()
-                                    << " Port: "
-                                    << (*it_map).second.m_listenPortHost);
+            LOG_MESSAGE2(
+                to_string(m_mediator.m_currentEpochNum).c_str(),
+                "PubKey: " << DataConversion::SerializableToHexStr(it_map.first)
+                           << " IP: " << it_map.second.GetPrintableIPAddress()
+                           << " Port: " << it_map.second.m_listenPortHost);
         }
     }
 
@@ -357,22 +355,17 @@ bool DirectoryService::ProcessShardingConsensus(
     }
     else if (state == ConsensusCommon::State::ERROR)
     {
-        for (unsigned int i = 0; i < m_mediator.m_DSCommitteeNetworkInfo.size();
-             i++)
+        for (auto& i : m_mediator.m_DSCommitteeNetworkInfo)
         {
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                         string(m_mediator.m_DSCommitteeNetworkInfo[i]
-                                    .GetPrintableIPAddress())
-                             + ":"
-                             + to_string(m_mediator.m_DSCommitteeNetworkInfo[i]
-                                             .m_listenPortHost));
+                         string(i.GetPrintableIPAddress()) + ":"
+                             + to_string(i.m_listenPortHost));
         }
-        for (unsigned int i = 0; i < m_mediator.m_DSCommitteePubKeys.size();
-             i++)
+        for (const auto& m_DSCommitteePubKey : m_mediator.m_DSCommitteePubKeys)
         {
-            LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                         DataConversion::SerializableToHexStr(
-                             m_mediator.m_DSCommitteePubKeys[i]));
+            LOG_MESSAGE2(
+                to_string(m_mediator.m_currentEpochNum).c_str(),
+                DataConversion::SerializableToHexStr(m_DSCommitteePubKey));
         }
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                      "Oops, no consensus reached - what to do now???");

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -55,7 +55,7 @@ void DirectoryService::ComputeSharding()
 
     for (unsigned int i = 0; i < numOfComms; i++)
     {
-        m_shards.push_back(map<PubKey, Peer>());
+        m_shards.emplace_back();
     }
 
     for (auto& kv : m_allPoW2s)
@@ -253,7 +253,7 @@ bool DirectoryService::ShardingValidator(
 
     for (unsigned int i = 0; i < numOfComms; i++)
     {
-        m_shards.push_back(map<PubKey, Peer>());
+        m_shards.emplace_back();
 
         // 4-byte committee size
         uint32_t shard_size = Serializable::GetNumber<uint32_t>(

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <memory>
 #include <thread>
 
 #include "DirectoryService.h"
@@ -175,7 +176,7 @@ bool DirectoryService::RunConsensusOnShardingWhenDSPrimary()
     m_consensusBlockHash.resize(BLOCK_HASH_SIZE);
     fill(m_consensusBlockHash.begin(), m_consensusBlockHash.end(), 0x77);
 
-    m_consensusObject.reset(new ConsensusLeader(
+    m_consensusObject = std::make_shared<ConsensusLeader>(
         consensusID, m_consensusBlockHash, m_consensusMyID,
         m_mediator.m_selfKey.first, m_mediator.m_DSCommitteePubKeys,
         m_mediator.m_DSCommitteeNetworkInfo,
@@ -183,7 +184,7 @@ bool DirectoryService::RunConsensusOnShardingWhenDSPrimary()
         static_cast<unsigned char>(SHARDINGCONSENSUS),
         std::function<bool(const vector<unsigned char>&, unsigned int,
                            const Peer&)>(),
-        std::function<bool(map<unsigned int, std::vector<unsigned char>>)>()));
+        std::function<bool(map<unsigned int, std::vector<unsigned char>>)>());
 
     if (m_consensusObject == nullptr)
     {
@@ -334,12 +335,12 @@ bool DirectoryService::RunConsensusOnShardingWhenDSBackup()
         return ShardingValidator(message, errorMsg);
     };
 
-    m_consensusObject.reset(new ConsensusBackup(
+    m_consensusObject = std::make_shared<ConsensusBackup>(
         consensusID, m_consensusBlockHash, m_consensusMyID, m_consensusLeaderID,
         m_mediator.m_selfKey.first, m_mediator.m_DSCommitteePubKeys,
         m_mediator.m_DSCommitteeNetworkInfo,
         static_cast<unsigned char>(DIRECTORY),
-        static_cast<unsigned char>(SHARDINGCONSENSUS), func));
+        static_cast<unsigned char>(SHARDINGCONSENSUS), func);
 
     if (m_consensusObject == nullptr)
     {

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -192,8 +192,7 @@ bool DirectoryService::RunConsensusOnShardingWhenDSPrimary()
         return false;
     }
 
-    ConsensusLeader* cl
-        = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
+    auto* cl = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "Waiting " << LEADER_SHARDING_PREPARATION_IN_SECONDS
@@ -244,7 +243,7 @@ bool DirectoryService::ShardingValidator(
     curr_offset += sizeof(unsigned int);
 
     // 4-byte num of committees
-    uint32_t numOfComms = Serializable::GetNumber<uint32_t>(
+    auto numOfComms = Serializable::GetNumber<uint32_t>(
         sharding_structure, curr_offset, sizeof(uint32_t));
     curr_offset += sizeof(uint32_t);
 
@@ -256,7 +255,7 @@ bool DirectoryService::ShardingValidator(
         m_shards.emplace_back();
 
         // 4-byte committee size
-        uint32_t shard_size = Serializable::GetNumber<uint32_t>(
+        auto shard_size = Serializable::GetNumber<uint32_t>(
             sharding_structure, curr_offset, sizeof(uint32_t));
         curr_offset += sizeof(uint32_t);
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -56,7 +56,7 @@ Lookup::Lookup(Mediator& mediator)
 #endif // IS_LOOKUP_NODE
 }
 
-Lookup::~Lookup() {}
+Lookup::~Lookup() = default;
 
 void Lookup::AppendTimestamp(vector<unsigned char>& message,
                              unsigned int& offset)

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -15,13 +15,13 @@
 **/
 
 #include <arpa/inet.h>
-#include <cstring>
 #include <cerrno>
+#include <cstdint>
+#include <cstring>
 #include <exception>
 #include <fstream>
 #include <netinet/in.h>
 #include <random>
-#include <cstdint>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <unordered_set>

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1663,8 +1663,8 @@ bool Lookup::Execute(const vector<unsigned char>& message, unsigned int offset,
 
     bool result = true;
 
-    typedef bool (Lookup::*InstructionHandler)(const vector<unsigned char>&,
-                                               unsigned int, const Peer&);
+    using InstructionHandler = bool (Lookup::*)(const vector<unsigned char>&,
+                                                unsigned int, const Peer&);
 
     InstructionHandler ins_handlers[]
         = {&Lookup::ProcessEntireShardingStructure,

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -687,7 +687,7 @@ bool Lookup::ProcessGetDSInfoFromSeed(const vector<unsigned char>& message,
     }
 
     // 4-byte listening port
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -798,7 +798,7 @@ bool Lookup::ProcessGetDSBlockFromSeed(const vector<unsigned char>& message,
     }
 
     // 4-byte portNo
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -851,7 +851,7 @@ bool Lookup::ProcessGetStateFromSeed(const vector<unsigned char>& message,
 
     // [Port number]
 
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -965,7 +965,7 @@ bool Lookup::ProcessGetTxBlockFromSeed(const vector<unsigned char>& message,
     }
 
     // 4-byte portNo
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -1019,7 +1019,7 @@ bool Lookup::ProcessGetTxBodyFromSeed(const vector<unsigned char>& message,
     curr_offset += Transaction::GetSerializedSize();
 
     // 4-byte portNo
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -1050,7 +1050,7 @@ bool Lookup::ProcessGetNetworkId(const vector<unsigned char>& message,
     LOG_MARKER();
 
     // 4-byte portNo
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -1129,7 +1129,7 @@ bool Lookup::ProcessSetDSInfoFromSeed(const vector<unsigned char>& message,
         return false;
     }
 
-    uint32_t numDSPeers
+    auto numDSPeers
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -1232,7 +1232,7 @@ bool Lookup::ProcessSetDSBlockFromSeed(const vector<unsigned char>& message,
         return false;
     }
 
-    uint64_t latestSynBlockNum
+    auto latestSynBlockNum
         = (uint64_t)m_mediator.m_dsBlockChain.GetBlockCount();
 
     if (latestSynBlockNum > highBlockNum)
@@ -1349,7 +1349,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const vector<unsigned char>& message,
                      << lowBlockNum.convert_to<string>() << " to "
                      << highBlockNum.convert_to<string>());
 
-    uint64_t latestSynBlockNum
+    auto latestSynBlockNum
         = (uint64_t)m_mediator.m_txBlockChain.GetBlockCount();
 
     if (latestSynBlockNum > highBlockNum)
@@ -1643,7 +1643,7 @@ bool Lookup::InitMining()
                      "I have successfully join the network");
 #ifndef IS_LOOKUP_NODE
         LOG_MESSAGE("Clean TxBodyDB except the last one");
-        int size_txBodyDBs
+        auto size_txBodyDBs
             = (int)BlockStorage::GetBlockStorage().GetTxBodyDBSize();
         for (int i = 0; i < size_txBodyDBs - 1; i++)
         {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1149,7 +1149,7 @@ bool Lookup::ProcessSetDSInfoFromSeed(const vector<unsigned char>& message,
 
     for (unsigned int i = 0; i < numDSPeers; i++)
     {
-        dsPubKeys.push_back(PubKey(message, offset));
+        dsPubKeys.emplace_back(message, offset);
         offset += PUB_KEY_SIZE;
 
         Peer peer(message, offset);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1172,8 +1172,8 @@ bool Lookup::ProcessSetDSInfoFromSeed(const vector<unsigned char>& message,
         m_mediator.m_DSCommitteeNetworkInfo = dsPeers;
     }
 
-//    Data::GetInstance().SetDSPeers(dsPeers);
-//#endif // IS_LOOKUP_NODE
+        //    Data::GetInstance().SetDSPeers(dsPeers);
+        //#endif // IS_LOOKUP_NODE
 
 #ifndef IS_LOOKUP_NODE
     m_mediator.s_toFetchDSInfo = false;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -427,7 +427,7 @@ bool Lookup::ProcessEntireShardingStructure(
     }
 
     // unsigned int view change count
-    unsigned int viewChangeCount = Serializable::GetNumber<uint32_t>(
+    auto viewChangeCount = Serializable::GetNumber<uint32_t>(
         message, offset, sizeof(unsigned int));
     offset += sizeof(unsigned int);
 
@@ -442,7 +442,7 @@ bool Lookup::ProcessEntireShardingStructure(
     }
 
     // 4-byte num of shards
-    uint32_t num_shards
+    auto num_shards
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -466,11 +466,11 @@ bool Lookup::ProcessEntireShardingStructure(
             return false;
         }
 
-        m_shards.push_back(map<PubKey, Peer>());
+        m_shards.emplace_back();
 
         // 4-byte shard size
-        uint32_t shard_size = Serializable::GetNumber<uint32_t>(
-            message, offset, sizeof(uint32_t));
+        auto shard_size = Serializable::GetNumber<uint32_t>(message, offset,
+                                                            sizeof(uint32_t));
         offset += sizeof(uint32_t);
 
         length_available = message.size() - offset;
@@ -558,7 +558,7 @@ bool Lookup::ProcessGetSeedPeersFromLookup(const vector<unsigned char>& message,
     }
 
     // 4-byte listening port
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(message, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1172,8 +1172,8 @@ bool Lookup::ProcessSetDSInfoFromSeed(const vector<unsigned char>& message,
         m_mediator.m_DSCommitteeNetworkInfo = dsPeers;
     }
 
-        //    Data::GetInstance().SetDSPeers(dsPeers);
-        //#endif // IS_LOOKUP_NODE
+//    Data::GetInstance().SetDSPeers(dsPeers);
+//#endif // IS_LOOKUP_NODE
 
 #ifndef IS_LOOKUP_NODE
     m_mediator.s_toFetchDSInfo = false;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -16,12 +16,12 @@
 
 #include <arpa/inet.h>
 #include <cstring>
-#include <errno.h>
+#include <cerrno>
 #include <exception>
 #include <fstream>
 #include <netinet/in.h>
 #include <random>
-#include <stdint.h>
+#include <cstdint>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <unordered_set>

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -88,7 +88,7 @@ public:
     Lookup(Mediator& mediator);
 
     /// Destructor.
-    ~Lookup();
+    ~Lookup() override;
 
 #ifndef IS_LOOKUP_NODE
     // Setting the lookup nodes
@@ -169,7 +169,7 @@ public:
                                  unsigned int offset, const Peer& from);
 
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
-                 const Peer& from);
+                 const Peer& from) override;
 
     bool InitMining();
     bool AlreadyJoinedNetwork();

--- a/src/libLookup/Synchronizer.cpp
+++ b/src/libLookup/Synchronizer.cpp
@@ -102,7 +102,7 @@ TxBlock Synchronizer::ConstructGenesisTxBlock()
     std::vector<TxnHash> tranHashes;
     for (int i = 0; i < 5; i++)
     {
-        tranHashes.push_back(TxnHash());
+        tranHashes.emplace_back();
     }
 
     return TxBlock(header, emptySig, vector<bool>(), tranHashes);

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -37,7 +37,7 @@ Mediator::Mediator(pair<PrivKey, PubKey> key, Peer peer)
     m_isRetrievedHistory = false;
 }
 
-Mediator::~Mediator() {}
+Mediator::~Mediator() = default;
 
 void Mediator::RegisterColleagues(DirectoryService* ds, Node* node,
                                   Lookup* lookup)

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -15,6 +15,7 @@
 **/
 
 #include <array>
+#include <utility>
 
 #include "Mediator.h"
 #include "common/Constants.h"
@@ -25,9 +26,9 @@
 
 using namespace std;
 
-Mediator::Mediator(const pair<PrivKey, PubKey>& key, const Peer& peer)
-    : m_selfKey(key)
-    , m_selfPeer(peer)
+Mediator::Mediator(pair<PrivKey, PubKey> key, Peer peer)
+    : m_selfKey(std::move(key))
+    , m_selfPeer(std::move(peer))
 {
     m_ds = nullptr;
     m_node = nullptr;

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -87,7 +87,7 @@ public:
     bool m_isRetrievedHistory;
 
     /// Constructor.
-    Mediator(const pair<PrivKey, PubKey>& key, const Peer& peer);
+    Mediator(pair<PrivKey, PubKey> key, Peer peer);
 
     /// Destructor.
     ~Mediator();

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <errno.h>
 #include <memory>
+#include <random>
 #include <netinet/in.h>
 #include <signal.h>
 #include <stdint.h>
@@ -568,7 +569,8 @@ void P2PComm::SendMessagePoolHelper(const Container& peers,
     {
         indexes.at(i) = i;
     }
-    random_shuffle(indexes.begin(), indexes.end());
+    shuffle(indexes.begin(), indexes.end(),
+            std::mt19937(std::random_device()()));
 
     auto sharedMessage = make_shared<vector<unsigned char>>(message);
     auto sharedMessageHash = make_shared<vector<unsigned char>>(message_hash);

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -61,9 +61,9 @@ static void close_socket(int* cli_sock)
     }
 }
 
-P2PComm::P2PComm() {}
+P2PComm::P2PComm() = default;
 
-P2PComm::~P2PComm() {}
+P2PComm::~P2PComm() = default;
 
 P2PComm& P2PComm::GetInstance()
 {

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -14,13 +14,13 @@
 * and which include a reference to GPLv3 in their program files.
 **/
 
-#include <cstring>
 #include <cerrno>
-#include <memory>
-#include <random>
-#include <netinet/in.h>
 #include <csignal>
 #include <cstdint>
+#include <cstring>
+#include <memory>
+#include <netinet/in.h>
+#include <random>
 #include <sys/socket.h>
 #include <unistd.h>
 

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -15,12 +15,12 @@
 **/
 
 #include <cstring>
-#include <errno.h>
+#include <cerrno>
 #include <memory>
 #include <random>
 #include <netinet/in.h>
-#include <signal.h>
-#include <stdint.h>
+#include <csignal>
+#include <cstdint>
 #include <sys/socket.h>
 #include <unistd.h>
 

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -54,7 +54,7 @@ struct hash_compare
 
 static void close_socket(int* cli_sock)
 {
-    if (cli_sock != NULL)
+    if (cli_sock != nullptr)
     {
         shutdown(*cli_sock, SHUT_RDWR);
         close(*cli_sock);

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -28,9 +28,8 @@
 #include "libUtils/Logger.h"
 #include "libUtils/ThreadPool.h"
 
-typedef std::function<std::vector<Peer>(unsigned char msg_type,
-                                        unsigned char ins_type, const Peer&)>
-    broadcast_list_func;
+using broadcast_list_func = std::function<std::vector<Peer>(
+    unsigned char, unsigned char, const Peer&)>;
 
 /// Provides network layer functionality.
 class P2PComm

--- a/src/libNetwork/Peer.cpp
+++ b/src/libNetwork/Peer.cpp
@@ -25,7 +25,6 @@ using namespace boost::multiprecision;
 
 Peer::Peer()
     : m_ipAddress(0)
-    , m_listenPortHost(0)
 {
 }
 

--- a/src/libNetwork/Peer.cpp
+++ b/src/libNetwork/Peer.cpp
@@ -18,6 +18,8 @@
 #include "common/Constants.h"
 #include <arpa/inet.h>
 
+#include <utility>
+
 using namespace std;
 using namespace boost::multiprecision;
 
@@ -27,8 +29,8 @@ Peer::Peer()
 {
 }
 
-Peer::Peer(const uint128_t& ip_address, uint32_t listen_port_host)
-    : m_ipAddress(ip_address)
+Peer::Peer(uint128_t ip_address, uint32_t listen_port_host)
+    : m_ipAddress(std::move(ip_address))
     , m_listenPortHost(listen_port_host)
 {
 }

--- a/src/libNetwork/Peer.h
+++ b/src/libNetwork/Peer.h
@@ -36,7 +36,7 @@ struct Peer : public Serializable
     Peer();
 
     /// Constructor with specified IP info.
-    Peer(const boost::multiprecision::uint128_t& ip_address,
+    Peer(boost::multiprecision::uint128_t ip_address,
          uint32_t listen_port_host);
 
     /// Constructor for loading peer information from a byte stream.

--- a/src/libNetwork/Peer.h
+++ b/src/libNetwork/Peer.h
@@ -30,7 +30,7 @@ struct Peer : public Serializable
     boost::multiprecision::uint128_t m_ipAddress; // net-encoded
 
     /// Peer listen port (host-encoded)
-    uint32_t m_listenPortHost; // host-encoded
+    uint32_t m_listenPortHost{0}; // host-encoded
 
     /// Default constructor.
     Peer();

--- a/src/libNetwork/Peer.h
+++ b/src/libNetwork/Peer.h
@@ -60,10 +60,11 @@ struct Peer : public Serializable
 
     /// Implements the Serialize function inherited from Serializable.
     unsigned int Serialize(std::vector<unsigned char>& dst,
-                           unsigned int offset) const;
+                           unsigned int offset) const override;
 
     /// Implements the Deserialize function inherited from Serializable.
-    int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+    int Deserialize(const std::vector<unsigned char>& src,
+                    unsigned int offset) override;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Peer& p)

--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -228,7 +228,7 @@ bool PeerManager::Execute(const vector<unsigned char>& message,
 
     bool result = false;
 
-    typedef bool (PeerManager::*InstructionHandler)(
+    using InstructionHandler = bool (PeerManager::*)(
         const vector<unsigned char>&, unsigned int, const Peer&);
 
     InstructionHandler ins_handlers[] = {

--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -219,7 +219,7 @@ PeerManager::PeerManager(std::pair<PrivKey, PubKey> key, Peer peer,
     }
 }
 
-PeerManager::~PeerManager() {}
+PeerManager::~PeerManager() = default;
 
 bool PeerManager::Execute(const vector<unsigned char>& message,
                           unsigned int offset, const Peer& from)

--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -19,6 +19,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <iostream>
+#include <utility>
 
 #include "P2PComm.h"
 #include "PeerManager.h"
@@ -173,10 +174,10 @@ bool PeerManager::ProcessBroadcast(const vector<unsigned char>& message,
     return true;
 }
 
-PeerManager::PeerManager(const std::pair<PrivKey, PubKey>& key,
-                         const Peer& peer, bool loadConfig)
-    : m_selfKey(key)
-    , m_selfPeer(peer)
+PeerManager::PeerManager(std::pair<PrivKey, PubKey> key, Peer peer,
+                         bool loadConfig)
+    : m_selfKey(std::move(key))
+    , m_selfPeer(std::move(peer))
 {
     LOG_MARKER();
 

--- a/src/libNetwork/PeerManager.h
+++ b/src/libNetwork/PeerManager.h
@@ -55,15 +55,16 @@ public:
     PeerManager(std::pair<PrivKey, PubKey> key, Peer peer, bool loadConfig);
 
     /// Destructor.
-    ~PeerManager();
+    ~PeerManager() override;
 
     /// Implements the Execute function inherited from Executable.
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
-                 const Peer& from);
+                 const Peer& from) override;
 
     /// Implements the GetBroadcastList function inherited from Broadcastable.
-    std::vector<Peer> GetBroadcastList(unsigned char ins_type,
-                                       const Peer& broadcast_originator);
+    std::vector<Peer>
+    GetBroadcastList(unsigned char ins_type,
+                     const Peer& broadcast_originator) override;
 };
 
 #endif // __PEERMANAGER_H__

--- a/src/libNetwork/PeerManager.h
+++ b/src/libNetwork/PeerManager.h
@@ -52,8 +52,7 @@ public:
     };
 
     /// Constructor.
-    PeerManager(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
-                bool loadConfig);
+    PeerManager(std::pair<PrivKey, PubKey> key, Peer peer, bool loadConfig);
 
     /// Destructor.
     ~PeerManager();

--- a/src/libNetwork/PeerStore.cpp
+++ b/src/libNetwork/PeerStore.cpp
@@ -18,9 +18,9 @@
 
 using namespace std;
 
-PeerStore::PeerStore() {}
+PeerStore::PeerStore() = default;
 
-PeerStore::~PeerStore() {}
+PeerStore::~PeerStore() = default;
 
 PeerStore& PeerStore::GetStore()
 {

--- a/src/libNetwork/PeerStore.cpp
+++ b/src/libNetwork/PeerStore.cpp
@@ -53,9 +53,9 @@ vector<Peer> PeerStore::GetAllPeers() const
 {
     vector<Peer> result;
 
-    for (auto it = m_store.begin(); it != m_store.end(); it++)
+    for (const auto& it : m_store)
     {
-        result.push_back(it->second);
+        result.push_back(it.second);
     }
 
     return result;
@@ -65,9 +65,9 @@ vector<PubKey> PeerStore::GetAllKeys() const
 {
     vector<PubKey> result;
 
-    for (auto it = m_store.begin(); it != m_store.end(); it++)
+    for (const auto& it : m_store)
     {
-        result.push_back(it->first);
+        result.push_back(it.first);
     }
 
     return result;

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -807,11 +807,11 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
                  "Forwarders inside the DS committee (" << num_ds_nodes
                                                         << "):");
 
-    nodes.push_back(vector<Peer>());
+    nodes.emplace_back();
 
     for (unsigned int i = 0; i < num_ds_nodes; i++)
     {
-        nodes.back().push_back(Peer(message, cur_offset));
+        nodes.back().emplace_back(message, cur_offset);
         cur_offset += IP_SIZE + PORT_SIZE;
 
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -829,7 +829,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
     {
         if (i == shard_id)
         {
-            nodes.push_back(vector<Peer>());
+            nodes.emplace_back();
 
             uint32_t num_recv = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
@@ -840,7 +840,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
 
             for (unsigned int j = 0; j < num_recv; j++)
             {
-                nodes.back().push_back(Peer(message, cur_offset));
+                nodes.back().emplace_back(message, cur_offset);
                 cur_offset += IP_SIZE + PORT_SIZE;
 
                 LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -852,7 +852,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
                 }
             }
 
-            nodes.push_back(vector<Peer>());
+            nodes.emplace_back();
 
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "  Shard " << i << " senders:");
@@ -863,7 +863,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
 
             for (unsigned int j = 0; j < num_send; j++)
             {
-                nodes.back().push_back(Peer(message, cur_offset));
+                nodes.back().emplace_back(message, cur_offset);
                 cur_offset += IP_SIZE + PORT_SIZE;
 
                 LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -877,7 +877,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
         }
         else
         {
-            nodes.push_back(vector<Peer>());
+            nodes.emplace_back();
 
             uint32_t num_recv = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
@@ -888,14 +888,14 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
 
             for (unsigned int j = 0; j < num_recv; j++)
             {
-                nodes.back().push_back(Peer(message, cur_offset));
+                nodes.back().emplace_back(message, cur_offset);
                 cur_offset += IP_SIZE + PORT_SIZE;
 
                 LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                              nodes.back().back());
             }
 
-            nodes.push_back(vector<Peer>());
+            nodes.emplace_back();
 
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "  Shard " << i << " senders:");
@@ -906,7 +906,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
 
             for (unsigned int j = 0; j < num_send; j++)
             {
-                nodes.back().push_back(Peer(message, cur_offset));
+                nodes.back().emplace_back(message, cur_offset);
                 cur_offset += IP_SIZE + PORT_SIZE;
 
                 LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -377,10 +377,8 @@ void Node::CommitMyShardsMicroBlock(const TxBlock& finalblock,
 
     // Loop through transactions in block
     const vector<TxnHash>& tx_hashes = m_microblock->GetTranHashes();
-    for (unsigned int i = 0; i < tx_hashes.size(); i++)
+    for (const auto& tx_hash : tx_hashes)
     {
-        const TxnHash& tx_hash = tx_hashes.at(i);
-
         if (FindTxnInSubmittedTxnsList(finalblock, blocknum, sharing_mode,
                                        txns_to_send, tx_hash))
         {
@@ -437,17 +435,16 @@ void Node::BroadcastTransactionsToSendingAssignment(
              forwardtxn_message.begin() + cur_offset);
         cur_offset += TRAN_HASH_SIZE;
 
-        for (unsigned int i = 0; i < txns_to_send.size(); i++)
+        for (auto& i : txns_to_send)
         {
             // txn body
-            txns_to_send.at(i).Serialize(forwardtxn_message, cur_offset);
+            i.Serialize(forwardtxn_message, cur_offset);
             cur_offset += Transaction::GetSerializedSize();
 
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                         "[TXN] ["
-                             << blocknum << "] Broadcasted   = 0x"
-                             << DataConversion::charArrToHexStr(
-                                    txns_to_send.at(i).GetTranID().asArray()));
+                         "[TXN] [" << blocknum << "] Broadcasted   = 0x"
+                                   << DataConversion::charArrToHexStr(
+                                          i.GetTranID().asArray()));
         }
 
         P2PComm::GetInstance().SendBroadcastMessage(sendingAssignment,
@@ -501,10 +498,8 @@ void Node::LoadForwardingAssignmentFromFinalBlock(
         peers.push_back(m_myShardMembersNetworkInfo.at(i));
     }
 
-    for (unsigned int i = 0; i < fellowForwarderNodes.size(); i++)
+    for (auto fellowforwarder : fellowForwarderNodes)
     {
-        Peer fellowforwarder = fellowForwarderNodes[i];
-
         for (unsigned int j = 0; j < peers.size(); j++)
         {
             if (peers.at(j) == fellowforwarder)
@@ -516,10 +511,9 @@ void Node::LoadForwardingAssignmentFromFinalBlock(
         }
     }
 
-    for (unsigned int i = 0; i < peers.size(); i++)
+    for (const auto& peer : peers)
     {
-        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                     peers.at(i));
+        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), peer);
     }
 }
 
@@ -953,9 +947,9 @@ void Node::CallActOnFinalBlockBasedOnSenderForwarderAssgn(
             }
 
             const vector<Peer>& shard = nodes.at(i);
-            for (unsigned int j = 0; j < shard.size(); j++)
+            for (const auto& j : shard)
             {
-                nodes_to_send.push_back(shard[j]);
+                nodes_to_send.push_back(j);
             }
         }
 
@@ -982,9 +976,9 @@ void Node::CallActOnFinalBlockBasedOnSenderForwarderAssgn(
             }
 
             const vector<Peer>& shard = nodes.at(i);
-            for (unsigned int j = 0; j < shard.size(); j++)
+            for (const auto& j : shard)
             {
-                fellowForwarderNodes.push_back(shard[j]);
+                fellowForwarderNodes.push_back(j);
             }
         }
 

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1094,7 +1094,7 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
         return false;
     }
 
-/*
+        /*
     unsigned int sleep_time_while_waiting = 100;
     if (m_state == MICROBLOCK_CONSENSUS)
     {
@@ -1298,17 +1298,17 @@ void Node::CommitForwardedTransactions(
             AccountStore::GetInstance().UpdateAccounts(tx);
         }
 
-// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-//              "[TXN] [" << blocknum << "] Body received = 0x" << tx.GetTranID());
+            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+            //              "[TXN] [" << blocknum << "] Body received = 0x" << tx.GetTranID());
 
-// Update from and to accounts
-// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Account store updated");
+            // Update from and to accounts
+            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Account store updated");
 
-// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-//              "Storing Transaction: " << tx.GetTranID() <<
-//              " with amount: " << tx.GetAmount() <<
-//              ", to: " << tx.GetToAddr() <<
-//              ", from: " << tx.GetFromAddr());
+            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+            //              "Storing Transaction: " << tx.GetTranID() <<
+            //              " with amount: " << tx.GetAmount() <<
+            //              ", to: " << tx.GetToAddr() <<
+            //              ", from: " << tx.GetFromAddr());
 #ifdef IS_LOOKUP_NODE
         Server::AddToRecentTransactions(tx.GetTranID());
 #endif //IS_LOOKUP_NODE

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1094,7 +1094,7 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
         return false;
     }
 
-        /*
+/*
     unsigned int sleep_time_while_waiting = 100;
     if (m_state == MICROBLOCK_CONSENSUS)
     {
@@ -1298,17 +1298,17 @@ void Node::CommitForwardedTransactions(
             AccountStore::GetInstance().UpdateAccounts(tx);
         }
 
-            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-            //              "[TXN] [" << blocknum << "] Body received = 0x" << tx.GetTranID());
+// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+//              "[TXN] [" << blocknum << "] Body received = 0x" << tx.GetTranID());
 
-            // Update from and to accounts
-            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Account store updated");
+// Update from and to accounts
+// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(), "Account store updated");
 
-            // LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-            //              "Storing Transaction: " << tx.GetTranID() <<
-            //              " with amount: " << tx.GetAmount() <<
-            //              ", to: " << tx.GetToAddr() <<
-            //              ", from: " << tx.GetFromAddr());
+// LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+//              "Storing Transaction: " << tx.GetTranID() <<
+//              " with amount: " << tx.GetAmount() <<
+//              ", to: " << tx.GetToAddr() <<
+//              ", from: " << tx.GetFromAddr());
 #ifdef IS_LOOKUP_NODE
         Server::AddToRecentTransactions(tx.GetTranID());
 #endif //IS_LOOKUP_NODE

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -63,8 +63,8 @@ bool Node::ReadAuxilliaryInfoFromFinalBlockMsg(
     }
 
     // 4-byte consensus id
-    uint32_t consensusID = Serializable::GetNumber<uint32_t>(
-        message, cur_offset, sizeof(uint32_t));
+    auto consensusID = Serializable::GetNumber<uint32_t>(message, cur_offset,
+                                                         sizeof(uint32_t));
     cur_offset += sizeof(uint32_t);
 
     if (consensusID != m_consensusID)
@@ -799,8 +799,8 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
     // ...
     LOG_MARKER();
 
-    uint32_t num_ds_nodes = Serializable::GetNumber<uint32_t>(
-        message, cur_offset, sizeof(uint32_t));
+    auto num_ds_nodes = Serializable::GetNumber<uint32_t>(message, cur_offset,
+                                                          sizeof(uint32_t));
     cur_offset += sizeof(uint32_t);
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -818,8 +818,8 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
                      nodes.back().back());
     }
 
-    uint32_t num_shards = Serializable::GetNumber<uint32_t>(message, cur_offset,
-                                                            sizeof(uint32_t));
+    auto num_shards = Serializable::GetNumber<uint32_t>(message, cur_offset,
+                                                        sizeof(uint32_t));
     cur_offset += sizeof(uint32_t);
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -831,7 +831,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
         {
             nodes.emplace_back();
 
-            uint32_t num_recv = Serializable::GetNumber<uint32_t>(
+            auto num_recv = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
             cur_offset += sizeof(uint32_t);
 
@@ -857,7 +857,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "  Shard " << i << " senders:");
 
-            uint32_t num_send = Serializable::GetNumber<uint32_t>(
+            auto num_send = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
             cur_offset += sizeof(uint32_t);
 
@@ -879,7 +879,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
         {
             nodes.emplace_back();
 
-            uint32_t num_recv = Serializable::GetNumber<uint32_t>(
+            auto num_recv = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
             cur_offset += sizeof(uint32_t);
 
@@ -900,7 +900,7 @@ void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "  Shard " << i << " senders:");
 
-            uint32_t num_send = Serializable::GetNumber<uint32_t>(
+            auto num_send = Serializable::GetNumber<uint32_t>(
                 message, cur_offset, sizeof(uint32_t));
             cur_offset += sizeof(uint32_t);
 
@@ -1126,7 +1126,7 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
 
     unsigned int cur_offset = offset;
 
-    uint8_t shard_id = (uint8_t)-1;
+    auto shard_id = (uint8_t)-1;
 
     // Reads and checks DS Block number, consensus ID and Shard ID
     if (!ReadAuxilliaryInfoFromFinalBlockMsg(message, cur_offset, shard_id))

--- a/src/libNode/MicroBlockProcessing.cpp
+++ b/src/libNode/MicroBlockProcessing.cpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <thread>
 
 #include <boost/multiprecision/cpp_int.hpp>
@@ -243,11 +244,11 @@ bool Node::ComposeMicroBlock()
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "Creating new micro block.")
-    m_microblock.reset(new MicroBlock(
+    m_microblock = std::make_shared<MicroBlock>(
         MicroBlockHeader(type, version, gasLimit, gasUsed, prevHash, blockNum,
                          timestamp, txRootHash, numTxs, minerPubKey, dsBlockNum,
                          dsBlockHeader),
-        signature, tranHashes));
+        signature, tranHashes);
 
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "Micro block proposed with "
@@ -394,12 +395,12 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader()
         = [this](const map<unsigned int, vector<unsigned char>>& m) mutable
         -> bool { return OnCommitFailure(m); };
 
-    m_consensusObject.reset(new ConsensusLeader(
+    m_consensusObject = std::make_shared<ConsensusLeader>(
         m_consensusID, m_consensusBlockHash, m_consensusMyID,
         m_mediator.m_selfKey.first, m_myShardMembersPubKeys,
         m_myShardMembersNetworkInfo, static_cast<unsigned char>(NODE),
         static_cast<unsigned char>(MICROBLOCKCONSENSUS), nodeMissingTxnsFunc,
-        commitFailureFunc));
+        commitFailureFunc);
 
     if (m_consensusObject == nullptr)
     {
@@ -443,12 +444,12 @@ bool Node::RunConsensusOnMicroBlockWhenShardBackup()
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "MS: m_consensusLeaderID: " << m_consensusLeaderID);
 
-    m_consensusObject.reset(new ConsensusBackup(
+    m_consensusObject = std::make_shared<ConsensusBackup>(
         m_consensusID, m_consensusBlockHash, m_consensusMyID,
         m_consensusLeaderID, m_mediator.m_selfKey.first,
         m_myShardMembersPubKeys, m_myShardMembersNetworkInfo,
         static_cast<unsigned char>(NODE),
-        static_cast<unsigned char>(MICROBLOCKCONSENSUS), func));
+        static_cast<unsigned char>(MICROBLOCKCONSENSUS), func);
 
     if (m_consensusObject == nullptr)
     {

--- a/src/libNode/MicroBlockProcessing.cpp
+++ b/src/libNode/MicroBlockProcessing.cpp
@@ -263,11 +263,11 @@ bool Node::OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
 {
     LOG_MARKER();
 
-    uint32_t numOfAbsentHashes
+    auto numOfAbsentHashes
         = Serializable::GetNumber<uint32_t>(errorMsg, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
-    uint32_t blockNum
+    auto blockNum
         = Serializable::GetNumber<uint32_t>(errorMsg, offset, sizeof(uint32_t));
     offset += sizeof(uint32_t);
 
@@ -284,7 +284,7 @@ bool Node::OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
         missingTransactions.push_back(txnHash);
     }
 
-    uint32_t portNo
+    auto portNo
         = Serializable::GetNumber<uint32_t>(errorMsg, offset, sizeof(uint32_t));
 
     uint128_t ipAddr = from.m_ipAddress;
@@ -413,8 +413,7 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader()
                          << m_mediator.m_selfPeer.GetPrintableIPAddress()
                          << "][" << m_mediator.m_currentEpochNum << "] BGIN");
 #endif // STAT_TEST
-    ConsensusLeader* cl
-        = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
+    auto* cl = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
     cl->StartConsensus(microblock);
 
     return true;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -90,8 +90,6 @@ Node::Node(Mediator& mediator, bool toRetrieveHistory)
     this->Prepare(runInitializeGenesisBlocks);
 }
 
-Node::~Node() {}
-
 void Node::Init()
 {
     // Zilliqa first epoch start from 1 not 0. So for the first DS epoch, there will be 1 less mini epoch only for the first DS epoch.
@@ -120,6 +118,8 @@ void Node::Prepare(bool runInitializeGenesisBlocks)
     POW::GetInstance().EthashConfigureLightClient(
         (uint64_t)m_mediator.m_dsBlockChain.GetBlockCount());
 }
+
+Node::~Node() = default;
 
 bool Node::StartRetrieveHistory()
 {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1247,8 +1247,8 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
 
     bool result = true;
 
-    typedef bool (Node::*InstructionHandler)(const vector<unsigned char>&,
-                                             unsigned int, const Peer&);
+    using InstructionHandler = bool (Node::*)(const vector<unsigned char>&,
+                                              unsigned int, const Peer&);
 
     InstructionHandler ins_handlers[]
         = {&Node::ProcessStartPoW1,

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -355,18 +355,19 @@ public:
     Node(Mediator& mediator, bool toRetrieveHistory);
 
     /// Destructor.
-    ~Node();
+    ~Node() override;
 
     /// Sets the value of m_state.
     void SetState(NodeState state);
 
     /// Implements the Execute function inherited from Executable.
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
-                 const Peer& from);
+                 const Peer& from) override;
 
     /// Implements the GetBroadcastList function inherited from Broadcastable.
-    std::vector<Peer> GetBroadcastList(unsigned char ins_type,
-                                       const Peer& broadcast_originator);
+    std::vector<Peer>
+    GetBroadcastList(unsigned char ins_type,
+                     const Peer& broadcast_originator) override;
 
     Mediator& GetMediator() { return m_mediator; }
 

--- a/src/libNode/PoW1Processing.cpp
+++ b/src/libNode/PoW1Processing.cpp
@@ -177,11 +177,10 @@ bool Node::ReadVariablesFromStartPoW1Message(
                  "DS nodes count    = " << numDS);
     for (unsigned int i = 0; i < numDS; i++)
     {
-        m_mediator.m_DSCommitteePubKeys.push_back(PubKey(message, cur_offset));
+        m_mediator.m_DSCommitteePubKeys.emplace_back(message, cur_offset);
         cur_offset += PUB_KEY_SIZE;
 
-        m_mediator.m_DSCommitteeNetworkInfo.push_back(
-            Peer(message, cur_offset));
+        m_mediator.m_DSCommitteeNetworkInfo.emplace_back(message, cur_offset);
         LOG_MESSAGE2(
             to_string(m_mediator.m_currentEpochNum).c_str(),
             "DS Node IP: "

--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -59,7 +59,7 @@ bool Node::ReadVariablesFromShardingMessage(
     }
 
     // view change counter
-    unsigned int viewChangeCounter = Serializable::GetNumber<unsigned int>(
+    auto viewChangeCounter = Serializable::GetNumber<unsigned int>(
         message, cur_offset, sizeof(unsigned int));
     cur_offset += sizeof(unsigned int);
 
@@ -95,8 +95,8 @@ bool Node::ReadVariablesFromShardingMessage(
     cur_offset += sizeof(uint32_t);
 
     // 4-byte committee size
-    uint32_t comm_size = Serializable::GetNumber<uint32_t>(message, cur_offset,
-                                                           sizeof(uint32_t));
+    auto comm_size = Serializable::GetNumber<uint32_t>(message, cur_offset,
+                                                       sizeof(uint32_t));
     cur_offset += sizeof(uint32_t);
 
     if (IsMessageSizeInappropriate(message.size(), cur_offset,

--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -116,10 +116,10 @@ bool Node::ReadVariablesFromShardingMessage(
     // All nodes; first entry is leader
     for (uint32_t i = 0; i < comm_size; i++)
     {
-        m_myShardMembersPubKeys.push_back(PubKey(message, cur_offset));
+        m_myShardMembersPubKeys.emplace_back(message, cur_offset);
         cur_offset += PUB_KEY_SIZE;
 
-        m_myShardMembersNetworkInfo.push_back(Peer(message, cur_offset));
+        m_myShardMembersNetworkInfo.emplace_back(message, cur_offset);
         cur_offset += IP_SIZE + PORT_SIZE;
 
         // Zero out my IP to avoid sending to myself

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -175,7 +175,7 @@ ethash_mining_result_t POW::MineLight(ethash_light_t& light,
                                       ethash_h256_t const& header_hash,
                                       ethash_h256_t& difficulty)
 {
-    uint64_t nonce = std::time(0);
+    uint64_t nonce = std::time(nullptr);
     while (shouldMine)
     {
         ethash_return_value_t mineResult
@@ -198,7 +198,7 @@ ethash_mining_result_t POW::MineFull(ethash_full_t& full,
                                      ethash_h256_t const& header_hash,
                                      ethash_h256_t& difficulty)
 {
-    uint64_t nonce = std::time(0);
+    uint64_t nonce = std::time(nullptr);
     while (shouldMine)
     {
         ethash_return_value_t mineResult
@@ -305,7 +305,7 @@ POW::PoWMine(const boost::multiprecision::uint256_t& blockNum,
 
     if (fullDataset)
     {
-        ethash_callback_t CallBack = NULL;
+        ethash_callback_t CallBack = nullptr;
         ethash_full_t fullClient
             = POW::EthashFullNew(ethash_light_client, CallBack);
         result = MineFull(fullClient, headerHash, diffForPoW);
@@ -354,7 +354,7 @@ bool POW::PoWVerify(const boost::multiprecision::uint256_t& blockNum,
     bool result;
     if (fullDataset)
     {
-        ethash_callback_t CallBack = NULL;
+        ethash_callback_t CallBack = nullptr;
         ethash_full_t fullClient
             = POW::EthashFullNew(ethash_light_client, CallBack);
         result = VerifyFull(fullClient, headerHash, winning_nonce, diffForPoW,

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -19,8 +19,8 @@
 
 #include <array>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <mutex>
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -20,7 +20,7 @@
 #include <array>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <mutex>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <thread>
 #include <vector>

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -32,13 +32,15 @@
 #include "libUtils/Logger.h"
 
 /// Stores the result of PoW mining.
-typedef struct ethash_mining_result
+struct ethash_mining_result
 {
     std::string result;
     std::string mix_hash;
     uint64_t winning_nonce;
     bool success;
-} ethash_mining_result_t;
+};
+
+using ethash_mining_result_t = ethash_mining_result;
 
 /// Implements the proof-of-work functionality.
 class POW

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -161,7 +161,7 @@ bool BlockStorage::GetDSBlock(const boost::multiprecision::uint256_t& blockNum,
 
     LOG_MESSAGE(blockString);
     LOG_MESSAGE(blockString.length());
-    const unsigned char* raw_memory
+    const auto* raw_memory
         = reinterpret_cast<const unsigned char*>(blockString.c_str());
     // FIXME: Handle exceptions
     block = std::make_shared<DSBlock>(
@@ -180,7 +180,7 @@ bool BlockStorage::GetTxBlock(const boost::multiprecision::uint256_t& blockNum,
         return false;
     }
 
-    const unsigned char* raw_memory
+    const auto* raw_memory
         = reinterpret_cast<const unsigned char*>(blockString.c_str());
     // FIXME: Handle exceptions
     block = std::make_shared<TxBlock>(
@@ -207,7 +207,7 @@ bool BlockStorage::GetTxBody(const dev::h256& key, TxBodySharedPtr& body)
         return false;
     }
 
-    const unsigned char* raw_memory
+    const auto* raw_memory
         = reinterpret_cast<const unsigned char*>(bodyString.c_str());
     // FIXME: Handle exceptions
     body = std::make_shared<Transaction>(
@@ -274,7 +274,7 @@ bool BlockStorage::GetAllDSBlocks(std::list<DSBlockSharedPtr>& blocks)
             LOG_MESSAGE("ERROR: Lost one block in the chain");
             return false;
         }
-        const unsigned char* raw_memory
+        const auto* raw_memory
             = reinterpret_cast<const unsigned char*>(blockString.c_str());
         DSBlockSharedPtr block = std::make_shared<DSBlock>(
             std::vector<unsigned char>(raw_memory,
@@ -311,7 +311,7 @@ bool BlockStorage::GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks)
             LOG_MESSAGE("ERROR: Lost one block in the chain");
             return false;
         }
-        const unsigned char* raw_memory
+        const auto* raw_memory
             = reinterpret_cast<const unsigned char*>(blockString.c_str());
         TxBlockSharedPtr block = std::make_shared<TxBlock>(
             std::vector<unsigned char>(raw_memory,
@@ -370,7 +370,7 @@ bool BlockStorage::GetMetadata(MetaType type, std::vector<unsigned char>& data)
         return false;
     }
 
-    const unsigned char* raw_memory
+    const auto* raw_memory
         = reinterpret_cast<const unsigned char*>(metaString.c_str());
     data = std::vector<unsigned char>(raw_memory,
                                       raw_memory + metaString.size());

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
@@ -163,9 +164,9 @@ bool BlockStorage::GetDSBlock(const boost::multiprecision::uint256_t& blockNum,
     const unsigned char* raw_memory
         = reinterpret_cast<const unsigned char*>(blockString.c_str());
     // FIXME: Handle exceptions
-    block = DSBlockSharedPtr(new DSBlock(
+    block = std::make_shared<DSBlock>(
         std::vector<unsigned char>(raw_memory, raw_memory + blockString.size()),
-        0));
+        0);
     return true;
 }
 
@@ -182,9 +183,9 @@ bool BlockStorage::GetTxBlock(const boost::multiprecision::uint256_t& blockNum,
     const unsigned char* raw_memory
         = reinterpret_cast<const unsigned char*>(blockString.c_str());
     // FIXME: Handle exceptions
-    block = TxBlockSharedPtr(new TxBlock(
+    block = std::make_shared<TxBlock>(
         std::vector<unsigned char>(raw_memory, raw_memory + blockString.size()),
-        0));
+        0);
     return true;
 }
 
@@ -209,9 +210,9 @@ bool BlockStorage::GetTxBody(const dev::h256& key, TxBodySharedPtr& body)
     const unsigned char* raw_memory
         = reinterpret_cast<const unsigned char*>(bodyString.c_str());
     // FIXME: Handle exceptions
-    body = TxBodySharedPtr(new Transaction(
+    body = std::make_shared<Transaction>(
         std::vector<unsigned char>(raw_memory, raw_memory + bodyString.size()),
-        0));
+        0);
     return true;
 }
 
@@ -275,10 +276,10 @@ bool BlockStorage::GetAllDSBlocks(std::list<DSBlockSharedPtr>& blocks)
         }
         const unsigned char* raw_memory
             = reinterpret_cast<const unsigned char*>(blockString.c_str());
-        DSBlockSharedPtr block = DSBlockSharedPtr(
-            new DSBlock(std::vector<unsigned char>(
-                            raw_memory, raw_memory + blockString.size()),
-                        0));
+        DSBlockSharedPtr block = std::make_shared<DSBlock>(
+            std::vector<unsigned char>(raw_memory,
+                                       raw_memory + blockString.size()),
+            0);
 
         blocks.push_back(block);
     }
@@ -312,10 +313,10 @@ bool BlockStorage::GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks)
         }
         const unsigned char* raw_memory
             = reinterpret_cast<const unsigned char*>(blockString.c_str());
-        TxBlockSharedPtr block = TxBlockSharedPtr(
-            new TxBlock(std::vector<unsigned char>(
-                            raw_memory, raw_memory + blockString.size()),
-                        0));
+        TxBlockSharedPtr block = std::make_shared<TxBlock>(
+            std::vector<unsigned char>(raw_memory,
+                                       raw_memory + blockString.size()),
+            0);
         blocks.push_back(block);
     }
 

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -25,10 +25,10 @@
 #include "depends/libDatabase/LevelDB.h"
 #include "libData/BlockData/Block.h"
 
-typedef std::shared_ptr<DSBlock> DSBlockSharedPtr;
-typedef std::shared_ptr<TxBlock> TxBlockSharedPtr;
-typedef std::shared_ptr<MicroBlock> MicroBlockSharedPtr;
-typedef std::shared_ptr<Transaction> TxBodySharedPtr;
+using DSBlockSharedPtr = std::shared_ptr<DSBlock>;
+using TxBlockSharedPtr = std::shared_ptr<TxBlock>;
+using MicroBlockSharedPtr = std::shared_ptr<MicroBlock>;
+using TxBodySharedPtr = std::shared_ptr<Transaction>;
 
 /// Manages persistent storage of DS and Tx blocks.
 class BlockStorage

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 #include <exception>
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 
 #include <boost/filesystem.hpp>

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -17,8 +17,8 @@
 #include "Retriever.h"
 
 #include <algorithm>
-#include <exception>
 #include <cstdlib>
+#include <exception>
 #include <vector>
 
 #include <boost/filesystem.hpp>

--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -64,10 +64,7 @@ Server::Server(Mediator& mediator, HttpServer& httpserver)
     m_RecentTransactions.resize(TXN_PAGE_SIZE);
 }
 
-Server::~Server()
-{
-    // destructor
-}
+Server::~Server() = default;
 
 string Server::GetClientVersion() { return "Hello"; }
 

--- a/src/libServer/Server.h
+++ b/src/libServer/Server.h
@@ -433,44 +433,44 @@ class Server : public AbstractZServer
 
 public:
     Server(Mediator& mediator, jsonrpc::HttpServer& httpserver);
-    ~Server();
+    ~Server() override;
 
-    virtual std::string GetClientVersion();
-    virtual std::string GetNetworkId();
-    virtual std::string GetProtocolVersion();
-    virtual std::string CreateTransaction(const Json::Value& _json);
-    virtual Json::Value GetTransaction(const std::string& transactionHash);
-    virtual Json::Value GetDsBlock(const std::string& blockNum);
-    virtual Json::Value GetTxBlock(const std::string& blockNum);
-    virtual Json::Value GetLatestDsBlock();
-    virtual Json::Value GetLatestTxBlock();
-    virtual Json::Value GetBalance(const std::string& address);
-    virtual std::string GetGasPrice();
-    virtual std::string GetStorageAt(const std::string& address,
-                                     const std::string& position);
-    virtual Json::Value GetTransactionHistory(const std::string& address);
-    virtual std::string GetBlockTransactionCount(const std::string& blockHash);
-    virtual std::string GetCode(const std::string& address);
-    virtual std::string CreateMessage(const Json::Value& _json);
-    virtual std::string GetGasEstimate(const Json::Value& _json);
-    virtual Json::Value
-    GetTransactionReceipt(const std::string& transactionHash);
-    virtual bool isNodeSyncing();
-    virtual bool isNodeMining();
-    virtual std::string GetHashrate();
-    virtual unsigned int GetNumPeers();
-    virtual std::string GetNumTxBlocks();
-    virtual std::string GetNumDSBlocks();
-    virtual std::string GetNumTransactions();
-    virtual double GetTransactionRate();
-    virtual double GetTxBlockRate();
-    virtual double GetDSBlockRate();
-    virtual std::string GetCurrentMiniEpoch();
-    virtual std::string GetCurrentDSEpoch();
-    virtual Json::Value DSBlockListing(unsigned int page);
-    virtual Json::Value TxBlockListing(unsigned int page);
-    virtual Json::Value GetBlockchainInfo();
-    virtual Json::Value GetRecentTransactions();
+    std::string GetClientVersion() override;
+    std::string GetNetworkId() override;
+    std::string GetProtocolVersion() override;
+    std::string CreateTransaction(const Json::Value& _json) override;
+    Json::Value GetTransaction(const std::string& transactionHash) override;
+    Json::Value GetDsBlock(const std::string& blockNum) override;
+    Json::Value GetTxBlock(const std::string& blockNum) override;
+    Json::Value GetLatestDsBlock() override;
+    Json::Value GetLatestTxBlock() override;
+    Json::Value GetBalance(const std::string& address) override;
+    std::string GetGasPrice() override;
+    std::string GetStorageAt(const std::string& address,
+                             const std::string& position) override;
+    Json::Value GetTransactionHistory(const std::string& address) override;
+    std::string GetBlockTransactionCount(const std::string& blockHash) override;
+    std::string GetCode(const std::string& address) override;
+    std::string CreateMessage(const Json::Value& _json) override;
+    std::string GetGasEstimate(const Json::Value& _json) override;
+    Json::Value
+    GetTransactionReceipt(const std::string& transactionHash) override;
+    bool isNodeSyncing() override;
+    bool isNodeMining() override;
+    std::string GetHashrate() override;
+    unsigned int GetNumPeers() override;
+    std::string GetNumTxBlocks() override;
+    std::string GetNumDSBlocks() override;
+    std::string GetNumTransactions() override;
+    double GetTransactionRate() override;
+    double GetTxBlockRate() override;
+    double GetDSBlockRate() override;
+    std::string GetCurrentMiniEpoch() override;
+    std::string GetCurrentDSEpoch() override;
+    Json::Value DSBlockListing(unsigned int page) override;
+    Json::Value TxBlockListing(unsigned int page) override;
+    Json::Value GetBlockchainInfo() override;
+    Json::Value GetRecentTransactions() override;
     static void AddToRecentTransactions(const dev::h256& txhash);
 
     //gets the number of transaction starting from block blockNum to most recent block

--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -58,7 +58,7 @@ Logger::Logger(const char* prefix, bool log_to_file, streampos max_file_size)
 
     if (log_to_file)
     {
-        if (prefix == NULL)
+        if (prefix == nullptr)
         {
             fname_prefix = "common";
         }
@@ -264,12 +264,12 @@ void Logger::LogMessageAndPayload(const char* msg,
 ScopeMarker::ScopeMarker(const char* function)
     : function(function)
 {
-    Logger& logger = Logger::GetLogger(NULL, true);
+    Logger& logger = Logger::GetLogger(nullptr, true);
     logger.LogMessage("BEGIN", this->function.c_str());
 }
 
 ScopeMarker::~ScopeMarker()
 {
-    Logger& logger = Logger::GetLogger(NULL, true);
+    Logger& logger = Logger::GetLogger(nullptr, true);
     logger.LogMessage("END", function.c_str());
 }

--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -36,7 +36,7 @@ namespace
         return syscall(SYS_gettid);
 #elif defined(__APPLE__) && defined(__MACH__)
         uint64_t tid64;
-        pthread_threadid_np(NULL, &tid64);
+        pthread_threadid_np(nullptr, &tid64);
         return static_cast<pid_t>(tid64);
 #else
 #error // not implemented in this platform

--- a/src/libUtils/Scheduler.cpp
+++ b/src/libUtils/Scheduler.cpp
@@ -19,9 +19,9 @@
 
 using namespace std;
 
-Scheduler::Scheduler() {}
+Scheduler::Scheduler() = default;
 
-Scheduler::~Scheduler() {}
+Scheduler::~Scheduler() = default;
 
 void Scheduler::ServiceQueue()
 {

--- a/src/libUtils/ThreadPool.h
+++ b/src/libUtils/ThreadPool.h
@@ -38,7 +38,7 @@ class
     ThreadPool // This class requires a number of c++11 features be present in your compiler.
 {
 public:
-/// Constructor.
+    /// Constructor.
 #if CONTIGUOUS_JOBS_MEMORY
     explicit ThreadPool(const unsigned int threadCount, std::string poolName,
                         const unsigned int jobsReserveCount = 0)
@@ -165,7 +165,7 @@ private:
                     return;
                 }
 
-// Get job from the queue
+                    // Get job from the queue
 #if CONTIGUOUS_JOBS_MEMORY
                 job = _queue.back();
                 _queue.pop_back();

--- a/src/libUtils/ThreadPool.h
+++ b/src/libUtils/ThreadPool.h
@@ -53,7 +53,7 @@ public:
         _threads.reserve(threadCount);
         for (unsigned int index = 0; index < threadCount; ++index)
         {
-            _threads.push_back(std::thread([this] { this->Task(); }));
+            _threads.emplace_back([this] { this->Task(); });
         }
 
 #if CONTIGUOUS_JOBS_MEMORY

--- a/src/libUtils/ThreadPool.h
+++ b/src/libUtils/ThreadPool.h
@@ -38,7 +38,7 @@ class
     ThreadPool // This class requires a number of c++11 features be present in your compiler.
 {
 public:
-    /// Constructor.
+/// Constructor.
 #if CONTIGUOUS_JOBS_MEMORY
     explicit ThreadPool(const unsigned int threadCount, std::string poolName,
                         const unsigned int jobsReserveCount = 0)
@@ -165,7 +165,7 @@ private:
                     return;
                 }
 
-                    // Get job from the queue
+// Get job from the queue
 #if CONTIGUOUS_JOBS_MEMORY
                 job = _queue.back();
                 _queue.pop_back();

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -106,7 +106,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 #endif // IS_LOOKUP_NODE
 }
 
-Zilliqa::~Zilliqa() {}
+Zilliqa::~Zilliqa() = default;
 
 void Zilliqa::Dispatch(const vector<unsigned char>& message, const Peer& from)
 {

--- a/tests/Crypto/Test_MultiSig.cpp
+++ b/tests/Crypto/Test_MultiSig.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(test_multisig)
     vector<CommitPoint> points;
     for (unsigned int i = 0; i < nbsigners; i++)
     {
-        points.push_back(CommitPoint(secrets.at(i)));
+        points.emplace_back(secrets.at(i));
     }
 
     // Aggregate commits
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(test_multisig)
     vector<Response> responses;
     for (unsigned int i = 0; i < nbsigners; i++)
     {
-        responses.push_back(Response(secrets.at(i), challenge, privkeys.at(i)));
+        responses.emplace_back(secrets.at(i), challenge, privkeys.at(i));
         BOOST_CHECK_MESSAGE(responses.back().Initialized() == true,
                             "Response generation failed");
     }
@@ -147,10 +147,10 @@ BOOST_AUTO_TEST_CASE(test_serialization)
     {
         vector<unsigned char> tmp1, tmp2;
         secrets.at(i).Serialize(tmp1, 0);
-        secrets1.push_back(CommitSecret(tmp1, 0));
-        points.push_back(CommitPoint(secrets.at(i)));
+        secrets1.emplace_back(tmp1, 0);
+        points.emplace_back(secrets.at(i));
         points.back().Serialize(tmp2, 0);
-        points1.push_back(CommitPoint(tmp2, 0));
+        points1.emplace_back(tmp2, 0);
     }
 
     // Aggregate commits
@@ -178,12 +178,12 @@ BOOST_AUTO_TEST_CASE(test_serialization)
     vector<Response> responses1;
     for (unsigned int i = 0; i < nbsigners; i++)
     {
-        responses.push_back(Response(secrets.at(i), challenge, privkeys.at(i)));
+        responses.emplace_back(secrets.at(i), challenge, privkeys.at(i));
         BOOST_CHECK_MESSAGE(responses.back().Initialized() == true,
                             "Response generation failed");
         vector<unsigned char> tmp;
         responses.back().Serialize(tmp, 0);
-        responses1.push_back(Response(tmp, 0));
+        responses1.emplace_back(tmp, 0);
         // Verify response
         BOOST_CHECK_MESSAGE(MultiSig::VerifyResponse(responses.at(i), challenge,
                                                      pubkeys.at(i),

--- a/tests/Crypto/Test_Schnorr.cpp
+++ b/tests/Crypto/Test_Schnorr.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(test_curve_setup)
         EC_POINT_point2hex(
             schnorr.GetCurve().m_group.get(),
             EC_GROUP_get0_generator(schnorr.GetCurve().m_group.get()),
-            POINT_CONVERSION_COMPRESSED, NULL),
+            POINT_CONVERSION_COMPRESSED, nullptr),
         free);
     BOOST_CHECK_MESSAGE(strcmp(basept_expected, basept_actual.get()) == 0,
                         "Wrong basept generated");
@@ -65,13 +65,14 @@ BOOST_AUTO_TEST_CASE(test_curve_setup)
     {
         BOOST_CHECK_MESSAGE(
             EC_GROUP_get_curve_GFp(schnorr.GetCurve().m_group.get(), p.get(),
-                                   a.get(), b.get(), NULL)
+                                   a.get(), b.get(), nullptr)
                 != 0,
             "EC_GROUP_get_curve_GFp failed");
-        BOOST_CHECK_MESSAGE(EC_GROUP_get_cofactor(
-                                schnorr.GetCurve().m_group.get(), h.get(), NULL)
-                                != 0,
-                            "EC_GROUP_get_cofactor failed");
+        BOOST_CHECK_MESSAGE(
+            EC_GROUP_get_cofactor(schnorr.GetCurve().m_group.get(), h.get(),
+                                  nullptr)
+                != 0,
+            "EC_GROUP_get_cofactor failed");
 
         unique_ptr<char, void (*)(void*)> p_actual(BN_bn2hex(p.get()), free);
         unique_ptr<char, void (*)(void*)> a_actual(BN_bn2hex(a.get()), free);
@@ -105,11 +106,12 @@ BOOST_AUTO_TEST_CASE(test_keys)
                         "Key generation check #2 failed");
 
     BOOST_CHECK_MESSAGE(EC_POINT_mul(schnorr.GetCurve().m_group.get(), P.get(),
-                                     keypair.first.m_d.get(), NULL, NULL, NULL)
+                                     keypair.first.m_d.get(), nullptr, nullptr,
+                                     nullptr)
                             != 0,
                         "Key generation check #3 failed");
     BOOST_CHECK_MESSAGE(EC_POINT_cmp(schnorr.GetCurve().m_group.get(),
-                                     keypair.second.m_P.get(), P.get(), NULL)
+                                     keypair.second.m_P.get(), P.get(), nullptr)
                             == 0,
                         "Key generation check #4 failed");
 }

--- a/tests/Lookup/Test_LookupNodeForTxBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForTxBlock.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(testTxBlockStoring)
 
     for (int i = 0; i < 5; i++)
     {
-        tranHashes.push_back(TxnHash());
+        tranHashes.emplace_back();
     }
 
     TxBlock txblock(header, emptySig, vector<bool>(), tranHashes);

--- a/tests/POW/test_POW.cpp
+++ b/tests/POW/test_POW.cpp
@@ -330,8 +330,8 @@ BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_size_mismatch)
 BOOST_AUTO_TEST_CASE(test_ethash_get_default_dirname)
 {
     char result[256];
-    // this is really not an easy thing to test for in a unit test
-    // TODO: Improve this test ...
+// this is really not an easy thing to test for in a unit test
+// TODO: Improve this test ...
 #ifdef _WIN32
     char homedir[256];
     BOOST_REQUIRE(SUCCEEDED(

--- a/tests/POW/test_POW.cpp
+++ b/tests/POW/test_POW.cpp
@@ -330,8 +330,8 @@ BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_size_mismatch)
 BOOST_AUTO_TEST_CASE(test_ethash_get_default_dirname)
 {
     char result[256];
-// this is really not an easy thing to test for in a unit test
-// TODO: Improve this test ...
+    // this is really not an easy thing to test for in a unit test
+    // TODO: Improve this test ...
 #ifdef _WIN32
     char homedir[256];
     BOOST_REQUIRE(SUCCEEDED(

--- a/tests/Persistence/Test_DSPersistence.cpp
+++ b/tests/Persistence/Test_DSPersistence.cpp
@@ -338,9 +338,9 @@ BOOST_AUTO_TEST_CASE(testThreadSafety)
     std::cout << "Launched from the main\n";
 
     //Join the threads with the main thread
-    for (int i = 0; i < num_threads; ++i)
+    for (auto& i : t)
     {
-        t[i].join();
+        i.join();
     }
 }
 

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -281,9 +281,9 @@ BOOST_AUTO_TEST_CASE(testThreadSafety)
     std::cout << "Launched from the main\n";
 
     //Join the threads with the main thread
-    for (int i = 0; i < num_threads; ++i)
+    for (auto& i : t)
     {
-        t[i].join();
+        i.join();
     }
 }
 

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -65,14 +65,14 @@ TxBlock constructDummyTxBlock(int instanceNum)
 
     for (int i = 0; i < 5; i++)
     {
-        tranHashes.push_back(TxnHash());
+        tranHashes.emplace_back();
     }
 
     vector<TxnHash> microBlockHashes;
 
     for (int i = 0; i < 6; i++)
     {
-        microBlockHashes.push_back(TxnHash());
+        microBlockHashes.emplace_back();
     }
 
     return TxBlock(header, emptySig, vector<bool>(), microBlockHashes);

--- a/tests/Utils/Test_BoostBigNum.cpp
+++ b/tests/Utils/Test_BoostBigNum.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(testBoostBigNum)
 
     uint128_t ipaddr_big_2
         = Serializable::GetNumber<uint128_t>(v1, 0, UINT128_SIZE);
-    uint32_t ipaddr_normal_2
+    auto ipaddr_normal_2
         = Serializable::GetNumber<uint32_t>(v2, 0, sizeof(uint32_t));
 
     cout << "ORIG BIG    = " << ipaddr_big << endl;

--- a/tests/Zilliqa/main.cpp
+++ b/tests/Zilliqa/main.cpp
@@ -15,7 +15,7 @@
 **/
 
 #include <execinfo.h> // for backtrace
-#include <signal.h>
+#include <csignal>
 
 #include "libUtils/Logger.h"
 #include <algorithm>

--- a/tests/Zilliqa/main.cpp
+++ b/tests/Zilliqa/main.cpp
@@ -14,8 +14,8 @@
 * and which include a reference to GPLv3 in their program files.
 **/
 
-#include <execinfo.h> // for backtrace
 #include <csignal>
+#include <execinfo.h> // for backtrace
 
 #include "libUtils/Logger.h"
 #include <algorithm>

--- a/tests/Zilliqa/send_txn.cpp
+++ b/tests/Zilliqa/send_txn.cpp
@@ -41,7 +41,7 @@ int main(int argc, const char* argv[])
         cout << "Available commands: cmd " << endl;
     }
 
-    uint32_t listen_port = static_cast<unsigned int>(atoi(argv[1]));
+    auto listen_port = static_cast<unsigned int>(atoi(argv[1]));
     struct in_addr ip_addr;
     inet_aton("127.0.0.1", &ip_addr);
     Peer my_port((uint128_t)ip_addr.s_addr, listen_port);

--- a/tests/Zilliqa/sendcmd.cpp
+++ b/tests/Zilliqa/sendcmd.cpp
@@ -108,7 +108,7 @@ void process_broadcast(int numargs, const char* progname, const char* cmdname,
         inet_aton("127.0.0.1", &ip_addr);
         Peer my_port((uint128_t)ip_addr.s_addr, listen_port);
 
-        unsigned int numbytes = static_cast<unsigned int>(atoi(args[0]));
+        auto numbytes = static_cast<unsigned int>(atoi(args[0]));
         vector<unsigned char> broadcast_message(numbytes + MessageOffset::BODY,
                                                 0xAA);
         broadcast_message.at(MessageOffset::TYPE) = MessageType::PEER;

--- a/tests/Zilliqa/sendcmd.cpp
+++ b/tests/Zilliqa/sendcmd.cpp
@@ -161,17 +161,14 @@ int main(int argc, const char* argv[])
         {"cmd", &process_cmd},
     };
 
-    const int num_handlers
-        = sizeof(message_handlers) / sizeof(message_handlers[0]);
-
     bool processed = false;
-    for (int i = 0; i < num_handlers; i++)
+    for (auto message_handler : message_handlers)
     {
-        if (!strcmp(instruction, message_handlers[i].ins))
+        if (!strcmp(instruction, message_handler.ins))
         {
-            (*message_handlers[i].func)(
-                argc - 3, argv[0], argv[2],
-                static_cast<unsigned int>(atoi(argv[1])), argv + 3);
+            (*message_handler.func)(argc - 3, argv[0], argv[2],
+                                    static_cast<unsigned int>(atoi(argv[1])),
+                                    argv + 3);
             processed = true;
             break;
         }

--- a/tests/Zilliqa/sendcmd.cpp
+++ b/tests/Zilliqa/sendcmd.cpp
@@ -27,8 +27,8 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-typedef void (*handler_func)(int, const char*, const char*, uint32_t,
-                             const char* []);
+using handler_func
+    = void (*)(int, const char*, const char*, uint32_t, const char**);
 struct message_handler
 {
     const char* ins;

--- a/tests/depends/Trie/Test_TriePerformance.cpp
+++ b/tests/depends/Trie/Test_TriePerformance.cpp
@@ -29,7 +29,7 @@
 #include "depends/libDatabase/OverlayDB.h"
 #include "libData/AccountData/Address.h"
 #include "libUtils/Logger.h"
-#include <time.h>
+#include <ctime>
 
 BOOST_AUTO_TEST_SUITE(TriePerformance)
 


### PR DESCRIPTION
**Workflow**
1. FInd out one *available* and *useful* checker option from `clang-tidy -list-checks "-checks=*"`
2. Add the checker explicitly (e.g. `misc-unused-parameters`) to `.clang-tidy`
3. Run `make clang-tidy-fix` to apply the fix
4. Commit the change with the message `clang-fix: CHECKER_NAME` (see the existing ones)

> Note: comment this pr to request a new item to be appended to the TODOs

**TODOs**
- [ ] misc-unused-parameters (blocked by #156)
- [x] modernize-make-*


-----------------
**Update 1**
#154 introduces several helper commands, and a config file (`.clang-tidy`) listing the enabled checkers.

**Update 2**
The workflow above only works for one build (either `./build.sh` or `./build_lookup.sh`).