### PR TITLE
Remove json_spirit from depends

### DIFF
--- a/src/depends/CMakeLists.txt
+++ b/src/depends/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory (common)
-add_subdirectory (json_spirit)
 add_subdirectory (libDatabase)
 add_subdirectory (libethash)
 add_subdirectory (libTrie)


### PR DESCRIPTION
It's broken in certain test cases. And we no longer need it (based on the successful build results on Travis)

The benchmark for JSON library is [here](https://github.com/miloyip/nativejson-benchmark) and jsoncpp seems fine but no better than [RapidJSON](https://github.com/Tencent/rapidjson).