### PR TITLE
Fix several issues with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
         apt-get install -y clang-format-5.0 clang-tidy-5.0;
       ";
     else
-      brew update;
       brew install pkg-config jsoncpp leveldb libjson-rpc-cpp ccache;
       brew install llvm@5;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: generic
 cache:
   directories:
     - $HOME/.ccache/
-    - $HOME/Library/Caches/Homebrew # for OSX only
 
 # multiplied by platform
 os:


### PR DESCRIPTION
It (1) fixes the problem that caching the Homebrew directory takes too long to tar and upload the cache; (2) stops updating homebrew everytime since [doc](https://docs.travis-ci.com/user/reference/osx/#Homebrew) says it will be updated by travis.