### PR TITLE
fixed time in getTxBlockRate

### DIFF
--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -426,7 +426,7 @@ double Server::GetTxBlockRate()
         }
     }
     boost::multiprecision::uint256_t TimeDiff
-        = m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetTimestamp()
+        = m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetTimestamp()
         - m_StartTimeTx;
 
     if (TimeDiff == 0)


### PR DESCRIPTION
Issue : getTxBlockRate was accessing DS blockchain, instead should access the Tx.