### PR TITLE
Improvement and fixup for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ os:
 
 # multiplied by BUILD_COMMAND
 env:
+  global:
+    - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
     - BUILD_COMMAND=./build.sh
     - BUILD_COMMAND=./build_lookup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
         apt-get install -y libboost-all-dev libleveldb-dev libsnappy-dev;
         apt-get install -y libjsoncpp-dev libmicrohttpd-dev libjsonrpccpp-dev;
         apt-get install -y ccache;
-        apt-get install -y clang-format-5.0 clang-tidy-5.0;
+        apt-get install -y clang-format-5.0 clang-tidy-5.0 clang-5.0;
       ";
     else
       brew install pkg-config jsoncpp leveldb libjson-rpc-cpp ccache;


### PR DESCRIPTION
- Stop auto-updating brew when `brew install`, which saves some time as per travis [doc](https://docs.travis-ci.com/user/reference/osx/#Homebrew)
- Fix the dep instruction for linux