### PR TITLE
Fixed number of peers to include DS peers

### DIFF
--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -275,7 +275,8 @@ unsigned int Server::GetNumPeers()
 {
     LOG_MARKER();
     unsigned int numPeers = m_mediator.m_lookup->GetNodePeers().size();
-    return numPeers;
+    lock_guard<mutex> g(m_mediator.m_mutexDSCommitteeNetworkInfo);
+    return numPeers + m_mediator.m_DSCommitteeNetworkInfo.size();
 }
 
 string Server::GetNumTxBlocks()


### PR DESCRIPTION
Now GetNumPeers() returns the sum of normal nodes + DS nodes