### PR TITLE
New Node Joining After Persistence Recovery; Root Check Failure Rejoining

### DIFF
--- a/src/depends/libDatabase/LevelDB.cpp
+++ b/src/depends/libDatabase/LevelDB.cpp
@@ -377,6 +377,7 @@ bool LevelDB::ResetDB()
     {
         LOG_MESSAGE("DB in subdirectory cannot be reset");
     }
+    LOG_MESSAGE("Error: Didn't reset DB, investigate why!");
     return false;
 }
 #else // IS_LOOKUP_NODE

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -487,9 +487,12 @@ bool AccountStore::RetrieveFromDisk()
         Account account(account_data[0], account_data[1]);
         m_addressToAccount.insert({address, account});
     }
-    m_db.ResetDB();
+    return true;
+}
+
+void AccountStore::RepopulateStateTrie()
+{
     m_state.init();
     prevRoot = m_state.root();
     UpdateStateTrieAll();
-    return true;
 }

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -460,6 +460,7 @@ void AccountStore::PrintAccountState()
     {
         LOG_MESSAGE(entry.first << " " << entry.second);
     }
+    LOG_MESSAGE("State Root: " << GetStateRootHash());
 }
 
 bool AccountStore::RetrieveFromDisk()

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -40,6 +40,7 @@ AccountStore::~AccountStore()
 
 void AccountStore::Init()
 {
+    LOG_MARKER();
     m_db.ResetDB();
     m_addressToAccount.clear();
     m_state.init();
@@ -107,7 +108,7 @@ int AccountStore::Deserialize(const vector<unsigned char>& src,
         Address address;
         Account account;
         unsigned int numberOfAccountDeserialze = 0;
-        Init();
+        this->Init();
         while (numberOfAccountDeserialze < totalNumOfAccounts)
         {
             numberOfAccountDeserialze++;

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -41,8 +41,8 @@ AccountStore::~AccountStore()
 void AccountStore::Init()
 {
     LOG_MARKER();
-    m_db.ResetDB();
     m_addressToAccount.clear();
+    m_db.ResetDB();
     m_state.init();
     prevRoot = m_state.root();
 }
@@ -487,5 +487,9 @@ bool AccountStore::RetrieveFromDisk()
         Account account(account_data[0], account_data[1]);
         m_addressToAccount.insert({address, account});
     }
+    m_db.ResetDB();
+    m_state.init();
+    prevRoot = m_state.root();
+    UpdateStateTrieAll();
     return true;
 }

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -492,6 +492,7 @@ bool AccountStore::RetrieveFromDisk()
 
 void AccountStore::RepopulateStateTrie()
 {
+    LOG_MARKER();
     m_state.init();
     prevRoot = m_state.root();
     UpdateStateTrieAll();

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -111,6 +111,7 @@ public:
     void PrintAccountState();
 
     bool RetrieveFromDisk();
+    void RepopulateStateTrie();
 };
 
 #endif // __ACCOUNTSTORE_H__

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1362,13 +1362,6 @@ bool DirectoryService::Execute(const vector<unsigned char>& message,
     const unsigned int ins_handlers_count
         = sizeof(ins_handlers) / sizeof(InstructionHandler);
 
-    if (!m_mediator.m_isConnectedToNetwork)
-    {
-        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
-                     "Not connected to network yet, ignore message");
-        return false;
-    }
-
     if (ins_byte < ins_handlers_count)
     {
         result = (this->*ins_handlers[ins_byte])(message, offset + 1, from);

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1362,6 +1362,13 @@ bool DirectoryService::Execute(const vector<unsigned char>& message,
     const unsigned int ins_handlers_count
         = sizeof(ins_handlers) / sizeof(InstructionHandler);
 
+    if (!m_mediator.m_isConnectedToNetwork)
+    {
+        LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+                     "Not connected to network yet, ignore message");
+        return false;
+    }
+
     if (ins_byte < ins_handlers_count)
     {
         result = (this->*ins_handlers[ins_byte])(message, offset + 1, from);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1371,6 +1371,9 @@ bool Lookup::ProcessSetTxBlockFromSeed(const vector<unsigned char>& message,
             LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                          "txBlock.GetHeader().GetMinerPubKey(): "
                              << txBlock.GetHeader().GetMinerPubKey());
+            LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
+                         "txBlock.GetHeader().GetStateRootHash(): "
+                             << txBlock.GetHeader().GetStateRootHash());
 
             m_mediator.m_txBlockChain.AddBlock(txBlock);
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1509,18 +1509,21 @@ bool Lookup::ProcessSetTxBodyFromSeed(const vector<unsigned char>& message,
 bool Lookup::CheckStateRoot()
 {
     StateHash stateRoot = AccountStore::GetInstance().GetStateRootHash();
+    StateHash rootInFinalBlock = m_mediator.m_txBlockChain.GetLastBlock()
+                                     .GetHeader()
+                                     .GetStateRootHash();
 
-    if (stateRoot
-        == m_mediator.m_txBlockChain.GetLastBlock()
-               .GetHeader()
-               .GetStateRootHash())
+    if (stateRoot == rootInFinalBlock)
     {
         LOG_MESSAGE("CheckStateRoot match");
         return true;
     }
     else
     {
-        LOG_MESSAGE("FAIL: CheckStateRoot doesn't match");
+        LOG_MESSAGE("Error: State root doesn't match. Calculated = "
+                    << stateRoot << ". "
+                    << "StoredInBlock = " << rootInFinalBlock);
+
         return false;
     }
 }
@@ -1585,6 +1588,7 @@ bool Lookup::InitMining()
         }
         else
         {
+            m_mediator.s_toFetchState = true;
             return false;
         }
     }

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -175,6 +175,16 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
                      "Error: Not in POW2_SUBMISSION state");
         return false;
     }
+
+    // For running from genesis
+    if (!m_mediator.m_isConnectedToNetwork)
+    {
+        m_mediator.m_isConnectedToNetwork = true;
+        if (m_isNewNode)
+        {
+            m_isNewNode = false;
+        }
+    }
 #else
     LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                  "I the lookup node have received the DS Block");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -937,6 +937,28 @@ void Node::SubmitTransactions()
                          << m_myShardID << "][" << txn_sent_count << "] CONT");
 #endif // STAT_TEST
 }
+
+bool Node::ToBlockMessage(unsigned char ins_byte)
+{
+    if (!m_mediator.m_isConnectedToNetwork)
+    {
+        if (!m_isNewNode)
+        {
+            if (ins_byte != NodeInstructionType::SHARDING)
+            {
+                return = true;
+            }
+        }
+        else
+        {
+            if (m_runFromLate && ins_byte != NodeInstructionType::SHARDING)
+            {
+                return = true;
+            }
+        }
+    }
+    return false;
+}
 #endif // IS_LOOKUP_NODE
 
 bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
@@ -966,10 +988,8 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
 
 #ifndef IS_LOOKUP_NODE
     // If the node failed and waiting for recovery, block the unwanted msg
-    if (!m_mediator.m_isConnectedToNetwork
-        && ((!m_isNewNode && ins_byte != NodeInstructionType::SHARDING)
-            || (m_isNewNode && m_runFromLate
-                && ins_byte != NodeInstructionType::SHARDING)))
+
+    if (ToBlockMessage(ins_byte))
     {
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                      "Node not connected to network yet, ignore message");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -992,6 +992,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
                 m_mediator.m_isConnectedToNetwork = false;
                 this->Init();
                 this->Prepare(true);
+                this->StartSynchronization();
             }
 #endif
         }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -969,7 +969,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
     if (!m_mediator.m_isConnectedToNetwork
         && ((!m_isNewNode && ins_byte != NodeInstructionType::SHARDING)
             || (m_isNewNode
-                && ((!m_runFromLate && ins_byte == NodeInstructionType::DSBLOCK)
+                && ((m_runFromLate && ins_byte == NodeInstructionType::DSBLOCK)
                     || ins_byte == NodeInstructionType::SHARDING))))
     {
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -69,30 +69,10 @@ Node::Node(Mediator& mediator, bool toRetrieveHistory)
 
     if (runInitializeGenesisBlocks)
     {
-        // Zilliqa first epoch start from 1 not 0. So for the first DS epoch, there will be 1 less mini epoch only for the first DS epoch.
-        // Hence, we have to set consensusID for first epoch to 1.
-        // m_consensusID = 1;
-        // m_consensusLeaderID = 1;
-
-        // m_retriever->CleanAll();
-        // m_retriever.reset();
-        // m_mediator.m_dsBlockChain.Reset();
-        // m_mediator.m_txBlockChain.Reset();
-        // m_committedTransactions.clear();
-        // AccountStore::GetInstance().Init();
-
-        // m_synchronizer.InitializeGenesisBlocks(m_mediator.m_dsBlockChain,
-        //                                        m_mediator.m_txBlockChain);
         this->Init();
     }
 
-    m_mediator.m_currentEpochNum
-        = (uint64_t)m_mediator.m_txBlockChain.GetBlockCount();
-    m_mediator.UpdateDSBlockRand(runInitializeGenesisBlocks);
-    m_mediator.UpdateTxBlockRand(runInitializeGenesisBlocks);
-    SetState(POW1_SUBMISSION);
-    POW::GetInstance().EthashConfigureLightClient(
-        (uint64_t)m_mediator.m_dsBlockChain.GetBlockCount());
+    this->Prepare(runInitializeGenesisBlocks);
 }
 
 Node::~Node() {}
@@ -111,6 +91,17 @@ void Node::Init()
 
     m_synchronizer.InitializeGenesisBlocks(m_mediator.m_dsBlockChain,
                                            m_mediator.m_txBlockChain);
+}
+
+void Node::Prepare(bool runInitializeGenesisBlocks)
+{
+    m_mediator.m_currentEpochNum
+        = (uint64_t)m_mediator.m_txBlockChain.GetBlockCount();
+    m_mediator.UpdateDSBlockRand(runInitializeGenesisBlocks);
+    m_mediator.UpdateTxBlockRand(runInitializeGenesisBlocks);
+    SetState(POW1_SUBMISSION);
+    POW::GetInstance().EthashConfigureLightClient(
+        (uint64_t)m_mediator.m_dsBlockChain.GetBlockCount());
 }
 
 bool Node::StartRetrieveHistory()
@@ -1000,7 +991,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
             {
                 m_mediator.m_isConnectedToNetwork = false;
                 this->Init();
-                StartSynchronization();
+                this->Prepare(true);
             }
 #endif
         }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -968,9 +968,8 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
     // If the node failed and waiting for recovery, block the unwanted msg
     if (!m_mediator.m_isConnectedToNetwork
         && ((!m_isNewNode && ins_byte != NodeInstructionType::SHARDING)
-            || (m_isNewNode
-                && ((m_runFromLate && ins_byte == NodeInstructionType::DSBLOCK)
-                    || ins_byte == NodeInstructionType::SHARDING))))
+            || (m_isNewNode && m_runFromLate
+                && ins_byte != NodeInstructionType::SHARDING)))
     {
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                      "Node not connected to network yet, ignore message");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -973,6 +973,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
     const unsigned int ins_handlers_count
         = sizeof(ins_handlers) / sizeof(InstructionHandler);
 
+#ifndef IS_LOOKUP_NODE
     // If the node failed and waiting for recovery, block the unwanted msg
     if (!m_mediator.m_isConnectedToNetwork && !m_isNewNode
         && ins_byte != NodeInstructionType::SHARDING)
@@ -981,6 +982,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
                      "Node not connected to network yet, ignore message");
         return false;
     }
+#endif
 
     if (ins_byte < ins_handlers_count)
     {
@@ -989,6 +991,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
         {
             // To-do: Error recovery
 
+#ifndef IS_LOOKUP_NODE
             // Rejoin network as a new node if FinalBlockProcessing failed
             // in CheckStateRoot
             bool isVacuousEpoch = (m_consensusID >= (NUM_FINAL_BLOCK_PER_POW
@@ -999,6 +1002,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
                 this->Init();
                 StartSynchronization();
             }
+#endif
         }
     }
     else

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -946,14 +946,14 @@ bool Node::ToBlockMessage(unsigned char ins_byte)
         {
             if (ins_byte != NodeInstructionType::SHARDING)
             {
-                return = true;
+                return true;
             }
         }
         else
         {
             if (m_runFromLate && ins_byte != NodeInstructionType::SHARDING)
             {
-                return = true;
+                return true;
             }
         }
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -989,7 +989,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
         result = (this->*ins_handlers[ins_byte])(message, offset + 1, from);
         if (result == false)
         {
-            // To-do: Error recovery
+        // To-do: Error recovery
 
 #ifndef IS_LOOKUP_NODE
             // Rejoin network as a new node if FinalBlockProcessing failed

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -966,8 +966,11 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
 
 #ifndef IS_LOOKUP_NODE
     // If the node failed and waiting for recovery, block the unwanted msg
-    if (!m_mediator.m_isConnectedToNetwork && !m_isNewNode
-        && ins_byte != NodeInstructionType::SHARDING)
+    if (!m_mediator.m_isConnectedToNetwork
+        && ((!m_isNewNode && ins_byte != NodeInstructionType::SHARDING)
+            || (m_isNewNode
+                && ((!m_runFromLate && ins_byte == NodeInstructionType::DSBLOCK)
+                    || ins_byte == NodeInstructionType::SHARDING))))
     {
         LOG_MESSAGE2(to_string(m_mediator.m_currentEpochNum).c_str(),
                      "Node not connected to network yet, ignore message");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -79,6 +79,8 @@ Node::~Node() {}
 
 void Node::Init()
 {
+    // Zilliqa first epoch start from 1 not 0. So for the first DS epoch, there will be 1 less mini epoch only for the first DS epoch.
+    // Hence, we have to set consensusID for first epoch to 1.
     m_consensusID = 1;
     m_consensusLeaderID = 1;
 

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -100,9 +100,6 @@ class Node : public Executable, public Broadcastable
     // DS committee information
     bool m_isDSNode = true;
 
-    // Is New Node
-    bool m_isNewNode = false;
-
     // Consensus variables
     std::shared_ptr<ConsensusCommon> m_consensusObject;
 
@@ -142,6 +139,7 @@ class Node : public Executable, public Broadcastable
         m_forwardingAssignment;
 
     bool CheckState(Action action);
+    void Init();
 
 #ifndef IS_LOOKUP_NODE
     // internal calls from ProcessStartPoW1
@@ -316,6 +314,9 @@ public:
         WAITING_FINALBLOCK,
         ERROR
     };
+
+    // Is New Node
+    bool m_isNewNode = false;
 
     std::condition_variable m_cvAllMicroBlocksRecvd;
     std::mutex m_mutexAllMicroBlocksRecvd;

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -304,6 +304,8 @@ class Node : public Executable, public Broadcastable
 
     // Is New Node
     bool m_isNewNode = true;
+
+    bool ToBlockMessage(unsigned char ins_byte);
 #endif // IS_LOOKUP_NODE
 
 public:

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -300,6 +300,9 @@ class Node : public Executable, public Broadcastable
     bool ActOnFinalBlock(uint8_t tx_sharing_mode,
                          vector<Peer> my_shard_receivers,
                          const vector<Peer>& fellowForwarderNodes);
+
+    // Is New Node
+    bool m_isNewNode = true;
 #endif // IS_LOOKUP_NODE
 
 public:
@@ -314,9 +317,6 @@ public:
         WAITING_FINALBLOCK,
         ERROR
     };
-
-    // Is New Node
-    bool m_isNewNode = false;
 
     std::condition_variable m_cvAllMicroBlocksRecvd;
     std::mutex m_mutexAllMicroBlocksRecvd;

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -140,6 +140,7 @@ class Node : public Executable, public Broadcastable
 
     bool CheckState(Action action);
     void Init();
+    void Prepare(bool runInitializeGenesisBlocks);
 
 #ifndef IS_LOOKUP_NODE
     // internal calls from ProcessStartPoW1

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -319,6 +319,9 @@ public:
         ERROR
     };
 
+    // This process is newly invoked by shell from late node join script
+    bool m_runFromLate = false;
+
     std::condition_variable m_cvAllMicroBlocksRecvd;
     std::mutex m_mutexAllMicroBlocksRecvd;
     bool m_allMicroBlocksRecvd = true;

--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -159,10 +159,8 @@ bool Node::ProcessSharding(const vector<unsigned char>& message,
     {
         m_mediator.m_isConnectedToNetwork = true;
         AccountStore::GetInstance().MoveUpdatesToDisk();
-        if (m_isNewNode)
-        {
-            m_isNewNode = false;
-        }
+        m_isNewNode = false;
+        m_runFromLate = false;
     }
 
     // if (m_state != TX_SUBMISSION)

--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -154,12 +154,15 @@ bool Node::ProcessSharding(const vector<unsigned char>& message,
 
     POW::GetInstance().StopMining();
 
-    m_mediator.m_isConnectedToNetwork = true;
-
-    /// if it is a new node joining after finishing pow2, commit the state into db
-    if (m_isNewNode)
+    /// if it is a node joining after finishing pow2, commit the state into db
+    if (!m_mediator.m_isConnectedToNetwork)
     {
+        m_mediator.m_isConnectedToNetwork = true;
         AccountStore::GetInstance().MoveUpdatesToDisk();
+        if (m_isNewNode)
+        {
+            m_isNewNode = false;
+        }
     }
 
     // if (m_state != TX_SUBMISSION)

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -94,6 +94,10 @@ void Retriever::RetrieveTxBlocks(bool& result)
         return;
     }
 
+    blocks.sort([](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
+        return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
+    });
+
     // truncate the extra final blocks at last
     int totalSize = blocks.size();
     int extra_txblocks = totalSize % NUM_FINAL_BLOCK_PER_POW;
@@ -102,10 +106,6 @@ void Retriever::RetrieveTxBlocks(bool& result)
         BlockStorage::GetBlockStorage().DeleteTxBlock(totalSize - i);
         blocks.pop_back();
     }
-
-    blocks.sort([](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
-        return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
-    });
 
     for (const auto& block : blocks)
         m_mediator.m_txBlockChain.AddBlock(*block);

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -202,6 +202,7 @@ bool Retriever::ValidateStates()
         == AccountStore::GetInstance().GetStateRootHash())
     {
         LOG_MESSAGE("ValidateStates passed.");
+        AccountStore::GetInstance().RepopulateStateTrie();
         return true;
     }
     else

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -90,6 +90,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 
     if (toSyncWithNetwork && !toRetrieveHistory)
     {
+        m_n.m_runFromLate = true;
         m_n.StartSynchronization();
     }
 #else // else for IS_LOOKUP_NODE

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -90,7 +90,6 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 
     if (toSyncWithNetwork && !toRetrieveHistory)
     {
-        m_n.m_isNewNode = true;
         m_n.StartSynchronization();
     }
 #else // else for IS_LOOKUP_NODE

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -90,6 +90,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 
     if (toSyncWithNetwork && !toRetrieveHistory)
     {
+        m_n.m_isNewNode = true;
         m_n.StartSynchronization();
     }
 #else // else for IS_LOOKUP_NODE


### PR DESCRIPTION
It's found that after persistence recovery, for new node joining it always failed the state root check before initializing mining. After carefully investigation, the reason is after retrieving the state trie from db, when updating the state afterward, the state root will be different from the state trie obtained from init. This is because the order of insertion counts when populating the trie. 