### PR TITLE
Refactor cmake and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ install:
       docker exec -t ci /bin/sh -c "
         apt-get -qq update;
         apt-get install -y cmake build-essential pkg-config libssl-dev;
-        apt-get install -y libboost-all-dev libleveldb-dev libsnappy-dev;
+        apt-get install -y libboost-system-dev libboost-filesystem-dev;
+        apt-get install -y libboost-test-dev libleveldb-dev libsnappy-dev;
         apt-get install -y libjsoncpp-dev libmicrohttpd-dev libjsonrpccpp-dev;
         apt-get install -y ccache;
         apt-get install -y clang-format-5.0 clang-tidy-5.0 clang-5.0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ os:
 
 # multiplied by BUILD_COMMAND
 env:
-  global:
-    - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
     - BUILD_COMMAND="./scripts/ci_build.sh"
     - BUILD_COMMAND="./scripts/ci_build.sh lookup"
@@ -25,18 +23,9 @@ before_install:
 install:
   # note: use option '-t' for 'docker exec' to enable colored output
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker exec -t ci /bin/sh -c "
-        apt-get -qq update;
-        apt-get install -y cmake build-essential pkg-config libssl-dev;
-        apt-get install -y libboost-system-dev libboost-filesystem-dev;
-        apt-get install -y libboost-test-dev libleveldb-dev libsnappy-dev;
-        apt-get install -y libjsoncpp-dev libmicrohttpd-dev libjsonrpccpp-dev;
-        apt-get install -y ccache;
-        apt-get install -y clang-format-5.0 clang-tidy-5.0 clang-5.0;
-      ";
+      docker exec -e CI="true" -t ci /bin/sh -c "./scripts/ci_install_deps.sh";
     else
-      brew install pkg-config jsoncpp leveldb libjson-rpc-cpp ccache;
-      brew install llvm@5;
+      ./scripts/ci_install_deps.sh;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
   global:
     - HOMEBREW_NO_AUTO_UPDATE=1
   matrix:
-    - BUILD_COMMAND=./build.sh
-    - BUILD_COMMAND=./build_lookup.sh
+    - BUILD_COMMAND="./scripts/ci_build.sh"
+    - BUILD_COMMAND="./scripts/ci_build.sh lookup"
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -39,21 +39,8 @@ install:
     fi
 
 script:
-  # build
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       docker exec -t ci /bin/sh -c "$BUILD_COMMAND";
     else
       $BUILD_COMMAND;
-    fi
-  # check format
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker exec -t ci /bin/sh -c "make clang-format";
-    else
-      make clang-format;
-    fi
-  # run tests
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker exec -t ci /bin/sh -c "ctest --output-on-failure";
-    else
-      ctest --output-on-failure;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(Zilliqa)
 # detect operating system
 message(STATUS "We are on a ${CMAKE_SYSTEM_NAME} system")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 #
 # check dependencies
 #
@@ -33,6 +34,11 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
+
+find_package(LevelDB REQUIRED)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 # export compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -63,4 +69,4 @@ if(TESTS)
 endif()
 
 # add clang-format and clang-tidy targets lastly
-include(cmake/LLVMExtraTools.cmake)
+include(LLVMExtraTools)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5.1)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -7,110 +7,100 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(Zilliqa)
+
 # detect operating system
 message(STATUS "We are on a ${CMAKE_SYSTEM_NAME} system")
-enable_testing()
+
+#
+# check dependencies
+#
+find_package(PkgConfig REQUIRED)
 
 find_package(Boost COMPONENTS filesystem system unit_test_framework)
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(JSONCPP jsoncpp)
-link_libraries(${JSONCPP_LIBRARIES})
-include_directories(${JSONCPP_INCLUDE_DIRS})
-link_libraries(${SNAPPY_LIBRARIES})
+
+# pkg_check_modules(JSONCPP jsoncpp)
+# link_libraries(${JSONCPP_LIBRARIES})
+# include_directories(${JSONCPP_INCLUDE_DIRS})
+# link_libraries(${SNAPPY_LIBRARIES})
+
+find_program(HOMEBREW NAMES brew PATH /usr/local/bin)
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND HOMEBREW)
+    execute_process(
+        COMMAND ${HOMEBREW} --prefix openssl
+        OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+
+find_package(OpenSSL REQUIRED)
+include_directories(${OPENSSL_INCLUDE_DIR})
+
+# message(STATUS "checking for module 'jsoncpp'")
+
+# # Look for the header file.
+# find_path(JSONCPP_INCLUDE NAMES json/json.h
+                          # PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
+                          # DOC "Path in which the file json/json.h is located." )
+
+# # Look for the library.
+# find_library(JSONCPP_LIBRARY NAMES libjsoncpp.a libjsoncpp.dylib
+                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
+                             # DOC "Path to jsoncpp library." )
+
+# if(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
+  # set(JSONCPP_FOUND TRUE)
+# endif(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
+
+# if(JSONCPP_FOUND)
+    # message(STATUS "Found jsoncpp (include: ${JSONCPP_INCLUDE}, library: ${JSONCPP_LIBRARY})")
+    # set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE})
+    # set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY})
+# else()
+    # message(STATUS "  package 'jsoncpp' not found")
+# endif()
 
 ###################
 
-message(STATUS "checking for module 'openssl'")
+# message(STATUS "checking for module 'LevelDB'")
 
-find_path(OPENSSL_INCLUDE_DIR
-    NAMES openssl/opensslv.h
-    PATHS /usr/local/opt/openssl/include /opt/local/include /usr/local/include /usr/include
-    DOC "Path in which openssl headers are located."
-)
+# # Look for the header file.
+# find_path(LevelDB_INCLUDE NAMES leveldb/db.h
+                          # PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
+                          # DOC "Path in which the file leveldb/db.h is located." )
 
-find_path(OPENSSL_LIBRARY_DIR
-    NAMES libssl.a libssl.dylib
-    PATHS /usr/local/opt/openssl/lib /usr/lib /usr/local/lib
-    DOC "Path in which openssl library is located."
-)
+# # Look for the library.
+# find_library(LevelDB_LIBRARY NAMES libleveldb.a libleveldb.dylib
+                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
+                             # DOC "Path to leveldb library." )
 
-if(OPENSSL_INCLUDE_DIR AND OPENSSL_LIBRARY_DIR)
-  set(OPENSSL_FOUND TRUE)
-endif()
+# if(LevelDB_INCLUDE AND LevelDB_LIBRARY)
+  # set(LEVELDB_FOUND TRUE)
+# endif(LevelDB_INCLUDE AND LevelDB_LIBRARY)
 
-if(OPENSSL_FOUND)
-    message(STATUS "Found openssl (include: ${OPENSSL_INCLUDE_DIR}, library: ${OPENSSL_LIBRARY_DIR})")
-else()
-    message(STATUS "  package 'openssl' not found")
-endif()
+# if(LEVELDB_FOUND)
+    # message(STATUS "Found LevelDB (include: ${LevelDB_INCLUDE}, library: ${LevelDB_LIBRARY})")
+    # set(LevelDB_INCLUDES ${LevelDB_INCLUDE})
+    # set(LevelDB_LIBRARIES ${LevelDB_LIBRARY})
+# else()
+    # message(STATUS "  package 'LevelDB' not found")
+# endif()
 
-###################
+# # Look for the library.
+# find_library(SNAPPY_LIBRARY NAMES libsnappy.a
+                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
+                             # DOC "Path to snappy library." )
 
-message(STATUS "checking for module 'jsoncpp'")
+# if(SNAPPY_LIBRARY)
+    # set(SNAPPY_FOUND TRUE)
+# endif(SNAPPY_LIBRARY)
 
-# Look for the header file.
-find_path(JSONCPP_INCLUDE NAMES json/json.h
-                          PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
-                          DOC "Path in which the file json/json.h is located." )
-
-# Look for the library.
-find_library(JSONCPP_LIBRARY NAMES libjsoncpp.a libjsoncpp.dylib
-                             PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             DOC "Path to jsoncpp library." )
-
-if(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
-  set(JSONCPP_FOUND TRUE)
-endif(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
-
-if(JSONCPP_FOUND)
-    message(STATUS "Found jsoncpp (include: ${JSONCPP_INCLUDE}, library: ${JSONCPP_LIBRARY})")
-    set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE})
-    set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY})
-else()
-    message(STATUS "  package 'jsoncpp' not found")
-endif()
-
-###################
-
-message(STATUS "checking for module 'LevelDB'")
-
-# Look for the header file.
-find_path(LevelDB_INCLUDE NAMES leveldb/db.h
-                          PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
-                          DOC "Path in which the file leveldb/db.h is located." )
-
-# Look for the library.
-find_library(LevelDB_LIBRARY NAMES libleveldb.a libleveldb.dylib
-                             PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             DOC "Path to leveldb library." )
-
-if(LevelDB_INCLUDE AND LevelDB_LIBRARY)
-  set(LEVELDB_FOUND TRUE)
-endif(LevelDB_INCLUDE AND LevelDB_LIBRARY)
-
-if(LEVELDB_FOUND)
-    message(STATUS "Found LevelDB (include: ${LevelDB_INCLUDE}, library: ${LevelDB_LIBRARY})")
-    set(LevelDB_INCLUDES ${LevelDB_INCLUDE})
-    set(LevelDB_LIBRARIES ${LevelDB_LIBRARY})
-else()
-    message(STATUS "  package 'LevelDB' not found")
-endif()
-
-# Look for the library.
-find_library(SNAPPY_LIBRARY NAMES libsnappy.a
-                             PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             DOC "Path to snappy library." )
-
-if(SNAPPY_LIBRARY)
-    set(SNAPPY_FOUND TRUE)
-endif(SNAPPY_LIBRARY)
-
-if(SNAPPY_FOUND)
-    message(STATUS "Found SNAPPY (library: ${SNAPPY_LIBRARY})")
-    set(SNAPPY_LIBRARIES ${SNAPPY_LIBRARY})
-else()
-    message(STATUS "  package 'SNAPPY' not found")
-endif()
+# if(SNAPPY_FOUND)
+    # message(STATUS "Found SNAPPY (library: ${SNAPPY_LIBRARY})")
+    # set(SNAPPY_LIBRARIES ${SNAPPY_LIBRARY})
+# else()
+    # message(STATUS "  package 'SNAPPY' not found")
+# endif()
 
 # export compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -118,46 +108,55 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # customize the flags for RELWITHDEBINFO
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -ggdb -DNDEBUG")
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# compiler and linker options
 add_definitions(-DSTAT_TEST)
 
 if(IS_LOOKUP_NODE)
     add_definitions(-DIS_LOOKUP_NODE)
 endif(IS_LOOKUP_NODE)
 
-add_compile_options(-Wall -Werror) #TODO: -Wextra
+add_compile_options(-Wall)
+add_compile_options(-Werror)
+# add_compile_options(-Wextra) #TODO: enable it
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -std=c++14 -ggdb")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-server -lboost_system -lboost_filesystem -std=c++14")
-endif()
-#XXX Assume clang is used on OSX platform, so -pthread is dropped
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    set(CMAKE_CXX_FLAGS
-        "${CMAKE_CXX_FLAGS} \
-        ${GCC_COVERAGE_COMPILE_FLAGS} \
-        -stdlib=libc++ \
-        -std=c++14 \
-        -ggdb \
-        -I${OPENSSL_INCLUDE_DIR} \
-        -I/usr/local/Cellar/boost/include \
-        -I/usr/local/include" )
-    set(CMAKE_EXE_LINKER_FLAGS
-        "-L/usr/local/opt/boost/lib \
-        ${CMAKE_EXE_LINKER_FLAGS} \
-        ${GCC_COVERAGE_LINK_FLAGS} \
-        ${jsoncpp_LIBRARIES} \
-        -ljsonrpccpp-common \
-        -ljsonrpccpp-server \
-        -lboost_system \
-        -lboost_filesystem \
-        -std=c++14 \
-        -L${OPENSSL_LIBRARY_DIR}")
-endif()
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    # To-do
-endif()
+# if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -std=c++14 -ggdb")
+    # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-server -lboost_system -lboost_filesystem -std=c++14")
+# endif()
+# #XXX Assume clang is used on OSX platform, so -pthread is dropped
+# if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    # set(CMAKE_CXX_FLAGS
+        # "${CMAKE_CXX_FLAGS} \
+        # ${GCC_COVERAGE_COMPILE_FLAGS} \
+        # -stdlib=libc++ \
+        # -std=c++14 \
+        # -ggdb \
+        # -I${OPENSSL_INCLUDE_DIR} \
+        # -I/usr/local/Cellar/boost/include \
+        # -I/usr/local/include" )
+    # set(CMAKE_EXE_LINKER_FLAGS
+        # "-L/usr/local/opt/boost/lib \
+        # ${CMAKE_EXE_LINKER_FLAGS} \
+        # ${GCC_COVERAGE_LINK_FLAGS} \
+        # ${jsoncpp_LIBRARIES} \
+        # -ljsonrpccpp-common \
+        # -ljsonrpccpp-server \
+        # -lboost_system \
+        # -lboost_filesystem \
+        # -std=c++14 \
+        # ")
+# endif()
 
 add_subdirectory (src)
-add_subdirectory (tests)
 
+if(TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# add clang-format and clang-tidy targets lastly
 include(cmake/LLVMExtraTools.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,8 @@ find_package(PkgConfig REQUIRED)
 
 find_package(Boost COMPONENTS filesystem system unit_test_framework)
 
-# pkg_check_modules(JSONCPP jsoncpp)
-# link_libraries(${JSONCPP_LIBRARIES})
-# include_directories(${JSONCPP_INCLUDE_DIRS})
-# link_libraries(${SNAPPY_LIBRARIES})
+pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+include_directories(${JSONCPP_INCLUDE_DIRS})
 
 find_program(HOMEBREW NAMES brew PATH /usr/local/bin)
 
@@ -35,72 +33,6 @@ endif()
 
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
-
-# message(STATUS "checking for module 'jsoncpp'")
-
-# # Look for the header file.
-# find_path(JSONCPP_INCLUDE NAMES json/json.h
-                          # PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
-                          # DOC "Path in which the file json/json.h is located." )
-
-# # Look for the library.
-# find_library(JSONCPP_LIBRARY NAMES libjsoncpp.a libjsoncpp.dylib
-                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             # DOC "Path to jsoncpp library." )
-
-# if(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
-  # set(JSONCPP_FOUND TRUE)
-# endif(JSONCPP_INCLUDE AND JSONCPP_LIBRARY)
-
-# if(JSONCPP_FOUND)
-    # message(STATUS "Found jsoncpp (include: ${JSONCPP_INCLUDE}, library: ${JSONCPP_LIBRARY})")
-    # set(JSONCPP_INCLUDE_DIRS ${JSONCPP_INCLUDE})
-    # set(JSONCPP_LIBRARIES ${JSONCPP_LIBRARY})
-# else()
-    # message(STATUS "  package 'jsoncpp' not found")
-# endif()
-
-###################
-
-# message(STATUS "checking for module 'LevelDB'")
-
-# # Look for the header file.
-# find_path(LevelDB_INCLUDE NAMES leveldb/db.h
-                          # PATHS $ENV{LEVELDB_ROOT}/include /opt/local/include /usr/local/include /usr/include
-                          # DOC "Path in which the file leveldb/db.h is located." )
-
-# # Look for the library.
-# find_library(LevelDB_LIBRARY NAMES libleveldb.a libleveldb.dylib
-                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             # DOC "Path to leveldb library." )
-
-# if(LevelDB_INCLUDE AND LevelDB_LIBRARY)
-  # set(LEVELDB_FOUND TRUE)
-# endif(LevelDB_INCLUDE AND LevelDB_LIBRARY)
-
-# if(LEVELDB_FOUND)
-    # message(STATUS "Found LevelDB (include: ${LevelDB_INCLUDE}, library: ${LevelDB_LIBRARY})")
-    # set(LevelDB_INCLUDES ${LevelDB_INCLUDE})
-    # set(LevelDB_LIBRARIES ${LevelDB_LIBRARY})
-# else()
-    # message(STATUS "  package 'LevelDB' not found")
-# endif()
-
-# # Look for the library.
-# find_library(SNAPPY_LIBRARY NAMES libsnappy.a
-                             # PATHS /usr/lib /usr/local/lib $ENV{LEVELDB_ROOT}/lib
-                             # DOC "Path to snappy library." )
-
-# if(SNAPPY_LIBRARY)
-    # set(SNAPPY_FOUND TRUE)
-# endif(SNAPPY_LIBRARY)
-
-# if(SNAPPY_FOUND)
-    # message(STATUS "Found SNAPPY (library: ${SNAPPY_LIBRARY})")
-    # set(SNAPPY_LIBRARIES ${SNAPPY_LIBRARY})
-# else()
-    # message(STATUS "  package 'SNAPPY' not found")
-# endif()
 
 # export compile commands
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -122,34 +54,6 @@ endif(IS_LOOKUP_NODE)
 add_compile_options(-Wall)
 add_compile_options(-Werror)
 # add_compile_options(-Wextra) #TODO: enable it
-
-# if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -pthread -std=c++14 -ggdb")
-    # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -pthread -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-server -lboost_system -lboost_filesystem -std=c++14")
-# endif()
-# #XXX Assume clang is used on OSX platform, so -pthread is dropped
-# if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-    # set(CMAKE_CXX_FLAGS
-        # "${CMAKE_CXX_FLAGS} \
-        # ${GCC_COVERAGE_COMPILE_FLAGS} \
-        # -stdlib=libc++ \
-        # -std=c++14 \
-        # -ggdb \
-        # -I${OPENSSL_INCLUDE_DIR} \
-        # -I/usr/local/Cellar/boost/include \
-        # -I/usr/local/include" )
-    # set(CMAKE_EXE_LINKER_FLAGS
-        # "-L/usr/local/opt/boost/lib \
-        # ${CMAKE_EXE_LINKER_FLAGS} \
-        # ${GCC_COVERAGE_LINK_FLAGS} \
-        # ${jsoncpp_LIBRARIES} \
-        # -ljsonrpccpp-common \
-        # -ljsonrpccpp-server \
-        # -lboost_system \
-        # -lboost_filesystem \
-        # -std=c++14 \
-        # ")
-# endif()
 
 add_subdirectory (src)
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ brew install pkg-config jsoncpp leveldb libjson-rpc-cpp
 1. Build Zilliqa from the source.  
 ` ./build.sh`
 
-2. Run the local testnet script  
-`./tests/Node/test_node_simple.sh`  
+2. Run the local testnet script in `build` directory
+`cd build && ./tests/Node/test_node_simple.sh`  
 
 3. Logs of each node can be found at `./local_run`
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ To compile and run the Zilliqa codebase, you will need the following dependencie
 * `pkg-config` 
 * `json-rpc-cpp`
 
-For Ubuntu 16.04, you can use the following command to install the dependencies:  
+For Ubuntu 16.04, you can use the following command (or refer to `./scripts/ci_install_deps.sh`) to install the dependencies:  
 
 ```bash
 sudo apt-get update
 ```
 
 ```bash
-sudo apt-get install libboost-all-dev libssl-dev libleveldb-dev libjsoncpp-dev libsnappy-dev cmake libmicrohttpd-dev libjsonrpccpp-dev build-essential pkg-config
+sudo apt-get install libboost-system-dev libboost-filesystem-dev libboost-test-dev libssl-dev libleveldb-dev libjsoncpp-dev libsnappy-dev cmake libmicrohttpd-dev libjsonrpccpp-dev build-essential pkg-config
 ```
 
 For Mac OS X (experimental), you can use the following command to install the dependencies:  

--- a/build.sh
+++ b/build.sh
@@ -13,15 +13,8 @@
 # GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 # and which include a reference to GPLv3 in their program files.
 
-rm -rf ./blocks
-rm -rf ./blocks.db
-rm -rf ./dsblocks.db
-rm -rf ./txblocks.db
-rm -rf ./test.db
-rm -rf ./txbodies.db
-
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j4
 make clang-format-fix
 make clang-format

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,8 @@ rm -rf ./txblocks.db
 rm -rf ./test.db
 rm -rf ./txbodies.db
 
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j4
 make clang-format-fix
 make clang-format

--- a/build_lookup.sh
+++ b/build_lookup.sh
@@ -13,15 +13,8 @@
 # GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 # and which include a reference to GPLv3 in their program files.
 
-rm -rf ./blocks
-rm -rf ./blocks.db
-rm -rf ./dsblocks.db
-rm -rf ./txblocks.db
-rm -rf ./test.db
-rm -rf ./txbodies.db
-
-mkdir build && cd build
-cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+mkdir build_lookup && cd build_lookup
+cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j4
 make clang-format-fix
 make clang-format

--- a/build_lookup.sh
+++ b/build_lookup.sh
@@ -20,11 +20,8 @@ rm -rf ./txblocks.db
 rm -rf ./test.db
 rm -rf ./txbodies.db
 
-#find . -name *.cmake | xargs rm -rf
-#find . -name CMakeCache.txt | xargs rm -rf
-#find . -name CMakeFiles | xargs rm -rf
-
-cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+mkdir build && cd build
+cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
 make -j4
 make clang-format-fix
 make clang-format

--- a/cmake/FindLevelDB.cmake
+++ b/cmake/FindLevelDB.cmake
@@ -1,0 +1,27 @@
+# Find LevelDB
+
+find_path(
+	LEVELDB_INCLUDE_DIR
+	NAMES leveldb/db.h
+    DOC "LevelDB include directory"
+)
+
+find_library(
+	LEVELDB_LIBRARY
+	NAMES leveldb
+    DOC "LevelDB library"
+)
+
+set(LEVELDB_INCLUDE_DIRS ${LEVELDB_INCLUDE_DIR})
+set(LEVELDB_LIBRARIES ${LEVELDB_LIBRARY})
+
+if (NOT BUILD_SHARED_LIBS AND APPLE)
+	find_path(SNAPPY_INCLUDE_DIR snappy.h PATH_SUFFIXES snappy)
+	find_library(SNAPPY_LIBRARY snappy)
+	set(LEVELDB_INCLUDE_DIRS ${LEVELDB_INCLUDE_DIR} ${SNAPPY_INCLUDE_DIR})
+	set(LEVELDB_LIBRARIES ${LEVELDB_LIBRARY} ${SNAPPY_LIBRARY})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(leveldb DEFAULT_MSG
+	LEVELDB_LIBRARY LEVELDB_INCLUDE_DIR)

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # The script is supposed to be run in project root directory
 
 if [ "$1" = "lookup" ]
@@ -8,7 +10,7 @@ then
 fi
 
 mkdir build && cd build
-cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j$(nproc)
 make clang-format
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
+#
+# This script is dedicated for CI use
+#
 
 set -e
-
-# The script is supposed to be run in project root directory
 
 if [ "$1" = "lookup" ]
 then
     CMAKE_EXTRA_OPTIONS="-DIS_LOOKUP_NODE=1"
 fi
 
+# assume that it is run from project root directory
 mkdir build && cd build
 cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j$(nproc)
 make clang-format
+ctest --output-on-failure
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The script is supposed to be run in project root directory
+
+if [ "$1" = "lookup" ]
+then
+    CMAKE_EXTRA_OPTIONS="-DIS_LOOKUP_NODE=1"
+fi
+
+mkdir build && cd build
+cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+make -j$(nproc)
+make clang-format
+

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -10,10 +10,24 @@ then
     CMAKE_EXTRA_OPTIONS="-DIS_LOOKUP_NODE=1"
 fi
 
+# set n_parallel to fully utilize the resources
+os=$(uname)
+case $os in
+    'Linux')
+        n_parallel=$(nproc)
+        ;;
+    'Darwin')
+        n_parallel=$(sysctl -n hw.ncpu)
+        ;;
+    *)
+        n_parallel=2
+        ;;
+esac
+
 # assume that it is run from project root directory
 mkdir build && cd build
 cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
-make -j$(nproc)
+make -j${n_parallel}
 make clang-format
 ctest --output-on-failure
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -29,5 +29,5 @@ mkdir build && cd build
 cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j${n_parallel}
 make clang-format
-ctest --output-on-failure -j${n_parallel}
+ctest --output-on-failure
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -29,5 +29,5 @@ mkdir build && cd build
 cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j${n_parallel}
 make clang-format
-ctest --output-on-failure
+ctest --output-on-failure -j${n_parallel}
 

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# The script is dedicated for CI use
+#
+
+set -e
+
+# presently a docker version ubuntu 16.04 is used
+function on_sudoless_ubuntu() {
+
+apt-get -qq update
+
+# install build dependencies
+apt-get install -y \
+    cmake \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libboost-test-dev \
+    libleveldb-dev \
+    libsnappy-dev \
+    libjsoncpp-dev \
+    libmicrohttpd-dev \
+    libjsonrpccpp-dev
+
+# install development dependencies
+apt-get install -y \
+    ccache \
+    clang-format-5.0 \
+    clang-tidy-5.0 \
+    clang-5.0
+}
+
+function on_osx() {
+
+# travis will keep brew updated
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+# install build deps
+brew install \
+    pkg-config \
+    jsoncpp \
+    leveldb \
+    libjson-rpc-cpp \
+
+# install developement deps
+brew install \
+    ccache \
+    llvm@5
+}
+
+if [ "${TRAVIS}" != "true" -o "${CI}" != "true" ]
+then
+    echo "No CI environment detected, continue [y/N]?:"
+    read force
+    case $force in
+        'y')
+            ;;
+        *)
+            echo "Dependency installation stopped"
+            exit 1
+            ;;
+    esac
+fi
+
+os=$(uname)
+
+# only need to distinguish linux and osx
+case $os in
+    'Linux')
+        echo "Installing dependencies on Linux ..."
+        on_sudoless_ubuntu || echo "Hint: Try re-run with sudo right, if failed"
+        ;;
+    'Darwin')
+        echo "Installing dependencies on OSX ..."
+        on_osx
+        ;;
+    *)
+        echo "Error: Unknown OS, no dependencies installed"
+        ;;
+esac
+

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -51,7 +51,7 @@ brew install \
     llvm@5
 }
 
-if [ "${TRAVIS}" != "true" -o "${CI}" != "true" ]
+if [ "${TRAVIS}" != "true" -a "${CI}" != "true" ]
 then
     echo "No CI environment detected, continue [y/N]?:"
     read force

--- a/src/depends/libDatabase/CMakeLists.txt
+++ b/src/depends/libDatabase/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library (Database LevelDB.cpp MemoryDB.cpp OverlayDB.cpp)
 target_include_directories (Database PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries (Database PUBLIC Common ${LevelDB_LIBRARIES} ${SNAPPY_LIBRARIES} Utils)
+target_link_libraries (Database PUBLIC Common ${LEVELDB_LIBRARIES} Utils Threads::Threads)

--- a/src/libUtils/CMakeLists.txt
+++ b/src/libUtils/CMakeLists.txt
@@ -1,3 +1,3 @@
-include_directories(${Boost_INCLUDE_DIRS}) 
-add_library (Utils DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp TimeUtils.cpp TxnRootComputationLight.cpp)
-target_include_directories (Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Crypto)
+add_library(Utils DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp TimeUtils.cpp TxnRootComputationLight.cpp)
+target_include_directories(Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Crypto Boost)
+target_link_libraries(Utils INTERFACE Threads::Threads)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,12 @@ add_subdirectory (depends)
 add_subdirectory (Lookup)
 add_subdirectory (Network)
 add_subdirectory (Persistence)
-#add_subdirectory (POW) 
+#add_subdirectory (POW)
 add_subdirectory (Utils)
 add_subdirectory (Zilliqa)
+
+file(COPY ${CMAKE_SOURCE_DIR}/constants_local.xml DESTINATION ${CMAKE_BINARY_DIR})
+#FIXME: constants.xml is not used for local_run, thus shouldn't be copied
+# presently, it's a workaround to silence the error thrown by tests_zilliqa_local.py
+file(COPY ${CMAKE_SOURCE_DIR}/constants.xml DESTINATION ${CMAKE_BINARY_DIR})
+file(COPY Node DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/Zilliqa/CMakeLists.txt
+++ b/tests/Zilliqa/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries (sendtxn PUBLIC Network Utils)
 add_executable (genkeypair genkeypair.cpp)
 target_include_directories (genkeypair PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (genkeypair PUBLIC Crypto)
+
+file(GLOB TEST_ZILLIQA_PYTHON_FILES *.py)
+file(COPY ${TEST_ZILLIQA_PYTHON_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The most important change is enabling out-of-tree build, see `build.sh` and `build_lookup.sh` for details. 

Now developers can stay in one source tree directory and have two independent build folder (`build` and `build_lookup`). The impact to the local run testing is only the running directory change - previously `./tests/Node/test_node_simple.sh` is run in root directory, but now it's in individual build directories, for example:

- running normal nodes: `cd build && ./tests/Node/test_node_simple.sh`
- running lookup nodes: `cd build_lookup && ./tests/Node/test_node_lookup.sh`

Other changes
- Refactor top-level `CMakeLists.txt`
  - remove the libraries linking commands to sub-directories
  - use `find_package` and `pkg_search_modules` for dependency check
  - use  `brew --prefix openssl` to set `OPENSSL_ROOT_DIR`
- Refactor travis
  - dedicated dependency installation script `script/ci_install_deps.sh`
  - dedicated build script `scripts/ci_build.sh`
- Optimize dependency installation
  - Stop installing all the boost libraries and only install the required ones (system, filesystem, unit_test_framework)