### PR TITLE
Fix build.sh & build_lookup.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,8 @@
 # GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 # and which include a reference to GPLv3 in their program files.
 
-mkdir build && cd build
+mkdir build
+cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j4
 make clang-format-fix

--- a/build_lookup.sh
+++ b/build_lookup.sh
@@ -13,7 +13,8 @@
 # GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 # and which include a reference to GPLv3 in their program files.
 
-mkdir build_lookup && cd build_lookup
+mkdir build_lookup
+cd build_lookup
 cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON ..
 make -j4
 make clang-format-fix


### PR DESCRIPTION
Allow `build.sh` and `build_lookup.sh` to be run repeatedly after `build` and `build_lookup` is created the first time.