### PR TITLE
Adds libevent-dev dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get install -y libjsoncpp-dev
 RUN apt-get install -y libsnappy-dev
 RUN apt-get install -y libmicrohttpd-dev
 RUN apt-get install -y libjsonrpccpp-dev
+RUN apt-get install -y libevent-dev
 
 #--------------------------------------------------------------------
 # GET SOURCES


### PR DESCRIPTION
Adds libevent-dev dependency. Fixes compilation error:

```
P2PComm.cpp:19:19: fatal error: event.h: No such file or directory
compilation terminated.
```