### PR TITLE
Use option SO_REUSEADDR to avoid socket binding failures

### DIFF
--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -569,6 +569,16 @@ void P2PComm::StartMessagePump(
         return;
     }
 
+    int enable = 1;
+    if (setsockopt(serv_sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int))
+        < 0)
+    {
+        LOG_GENERAL(WARNING,
+                    "Socket set option SO_REUSEADDR failed. Code = "
+                        << errno << " Desc: " << std::strerror(errno));
+        return;
+    }
+
     struct sockaddr_in serv_addr;
     memset(&serv_addr, 0, sizeof(struct sockaddr_in));
     serv_addr.sin_family = AF_INET;


### PR DESCRIPTION
When the node needs to be restarted right away, for example after a crash or a config change, socket binding may fail due to the previous bound TCP connection still being in TIME_WAIT state, preventing the node from starting. This issue can be avoided by setting the SO_REUSEADDR option on the socket.
Note that only this corner case is covered by the fix: an active TCP connection would still gracefully prevent the binding.