### PR TITLE
libNetwork: Various fixes

### DIFF
--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -1,16 +1,16 @@
 /**
-* Copyright (c) 2018 Zilliqa 
-* This source code is being disclosed to you solely for the purpose of your participation in 
-* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
-* the protocols and algorithms that are programmed into, and intended by, the code. You may 
-* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
-* including modifying or publishing the code (or any part of it), and developing or forming 
-* another public or private blockchain network. This source code is provided ‘as is’ and no 
-* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
-* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
-* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
-* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
-* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* Copyright (c) 2018 Zilliqa
+* This source code is being disclosed to you solely for the purpose of your participation in
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to
+* the protocols and algorithms that are programmed into, and intended by, the code. You may
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd.,
+* including modifying or publishing the code (or any part of it), and developing or forming
+* another public or private blockchain network. This source code is provided ‘as is’ and no
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 * and which include a reference to GPLv3 in their program files.
 **/
 
@@ -71,6 +71,10 @@ class P2PComm
 
     P2PComm();
     ~P2PComm();
+
+    // Singleton should not implement these
+    P2PComm(P2PComm const&) = delete;
+    void operator=(P2PComm const&) = delete;
 
 #ifdef STAT_TEST
     Peer m_selfPeer;

--- a/src/libNetwork/PeerStore.cpp
+++ b/src/libNetwork/PeerStore.cpp
@@ -53,6 +53,7 @@ vector<Peer> PeerStore::GetAllPeers() const
 {
     vector<Peer> result;
 
+    lock_guard<mutex> g(m_mutexStore);
     for (auto it = m_store.begin(); it != m_store.end(); it++)
     {
         result.push_back(it->second);
@@ -65,6 +66,7 @@ vector<PubKey> PeerStore::GetAllKeys() const
 {
     vector<PubKey> result;
 
+    lock_guard<mutex> g(m_mutexStore);
     for (auto it = m_store.begin(); it != m_store.end(); it++)
     {
         result.push_back(it->first);

--- a/src/libNetwork/PeerStore.h
+++ b/src/libNetwork/PeerStore.h
@@ -1,16 +1,16 @@
 /**
-* Copyright (c) 2018 Zilliqa 
-* This source code is being disclosed to you solely for the purpose of your participation in 
-* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
-* the protocols and algorithms that are programmed into, and intended by, the code. You may 
-* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
-* including modifying or publishing the code (or any part of it), and developing or forming 
-* another public or private blockchain network. This source code is provided ‘as is’ and no 
-* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
-* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
-* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
-* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
-* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* Copyright (c) 2018 Zilliqa
+* This source code is being disclosed to you solely for the purpose of your participation in
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to
+* the protocols and algorithms that are programmed into, and intended by, the code. You may
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd.,
+* including modifying or publishing the code (or any part of it), and developing or forming
+* another public or private blockchain network. This source code is provided ‘as is’ and no
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
 * and which include a reference to GPLv3 in their program files.
 **/
 
@@ -29,7 +29,7 @@
 /// Maintains the Peer-PubKey lookup table.
 class PeerStore
 {
-    std::mutex m_mutexStore;
+    mutable std::mutex m_mutexStore;
     std::map<PubKey, Peer> m_store;
     PeerStore();
     ~PeerStore();


### PR DESCRIPTION
Summary:
- Fixed race condition in `PeerStore`
- Deleted copy ctor and assignment operator for `P2PComm` singleton