### PR TITLE
no re-alloc on POW - issue #310

### DIFF
--- a/src/depends/libethash/ethash.h
+++ b/src/depends/libethash/ethash.h
@@ -75,6 +75,17 @@ typedef struct ethash_return_value {
  *                       ERRNOMEM or invalid parameters used for @ref ethash_compute_cache_nodes()
  */
 ethash_light_t ethash_light_new(uint64_t block_number);
+
+/**
+ * Allocate and initialize a new ethash_light handler
+ *
+ * @param block_number   The block number for which to create the handler
+ * @param old_client     Old value for the client. Might be freed. If still fit, memory gets reused.
+ * @return               Newly allocated ethash_light handler or NULL in case of
+ *                       ERRNOMEM or invalid parameters used for @ref ethash_compute_cache_nodes()
+ */
+ethash_light_t ethash_light_renew(uint64_t block_number, ethash_light_t old_client);
+
 /**
  * Frees a previously allocated ethash_light handler
  * @param light        The light handler to free

--- a/src/depends/libethash/internal.c
+++ b/src/depends/libethash/internal.c
@@ -367,6 +367,28 @@ ethash_light_t ethash_light_new(uint64_t block_number)
 	return ret;
 }
 
+
+ethash_light_t ethash_light_renew(uint64_t block_number, ethash_light_t old_client)
+{
+	if (old_client) {
+        const uint64_t cache_size = ethash_get_cachesize(block_number);
+		if (cache_size == old_client->cache_size) {
+			node* nodes = (node*)old_client->cache;
+            const ethash_h256_t seedhash = ethash_get_seedhash(block_number);
+			if (!ethash_compute_cache_nodes(nodes, cache_size, &seedhash)) {
+				ethash_light_delete(old_client);
+				return NULL;
+			}
+            old_client->block_number = block_number;
+			return old_client;
+		}
+		else {
+			ethash_light_delete(old_client);
+		}
+	}
+	return ethash_light_new(block_number);
+}
+
 void ethash_light_delete(ethash_light_t light)
 {
 	if (light->cache) {

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -125,6 +125,12 @@ ethash_light_t POW::EthashLightNew(uint64_t block_number)
     return ethash_light_new(block_number);
 }
 
+ethash_light_t POW::EthashLightReuse(ethash_light_t ethashLight,
+                                     uint64_t block_number)
+{
+    return ethash_light_renew(block_number, ethashLight);
+}
+
 void POW::EthashLightDelete(ethash_light_t light)
 {
     ethash_light_delete(light);
@@ -135,8 +141,8 @@ bool POW::EthashConfigureLightClient(uint64_t block_number)
     std::lock_guard<std::mutex> g(m_mutexLightClientConfigure);
     if (block_number != currentBlockNum)
     {
-        EthashLightDelete(ethash_light_client);
-        ethash_light_client = EthashLightNew(block_number);
+        ethash_light_client
+            = EthashLightReuse(ethash_light_client, block_number);
         currentBlockNum = block_number;
     }
 

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -93,6 +93,8 @@ private:
     bool shouldMine;
 
     ethash_light_t EthashLightNew(uint64_t block_number);
+    ethash_light_t EthashLightReuse(ethash_light_t ethashLight,
+                                    uint64_t block_number);
     void EthashLightDelete(ethash_light_t light);
     ethash_return_value_t EthashLightCompute(ethash_light_t& light,
                                              ethash_h256_t const& header_hash,


### PR DESCRIPTION
Reuses memory when the size of nodes remains the same. Doesn't hit `malloc` from multiple threads (apart from 1:30k POWs when the size changes). Treats issue #310, kudos to @ansnunez @ckyang @jiayaoqijia @bb111189 @digiront and everybody else for the excellent investigation!