### PR TITLE
remove the rest of STAT_TEST completely

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # compiler and linker options
-add_definitions(-DSTAT_TEST)
 
 if(IS_LOOKUP_NODE)
     add_definitions(-DIS_LOOKUP_NODE)

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -187,7 +187,6 @@ void DirectoryService::SendDSBlockToCluster(
                   << my_pow1nodes_cluster_lo << " to "
                   << my_pow1nodes_cluster_hi);
 
-#ifdef STAT_TEST
     SHA2<HASH_TYPE::HASH_VARIANT_256> sha256;
     sha256.Update(dsblock_message);
     vector<unsigned char> this_msg_hash = sha256.Finalize();
@@ -201,7 +200,6 @@ void DirectoryService::SendDSBlockToCluster(
         << "]["
         << m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum()
         << "] DSBLOCKGEN");
-#endif // STAT_TEST
 
     // Sleep to give sufficient time to other ds node to receive the ds block
     this_thread::sleep_for(chrono::seconds(5));
@@ -305,7 +303,6 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "DS block consensus is DONE!!!");
 
-#ifdef STAT_TEST
     if (m_mode == PRIMARY_DS)
     {
         LOG_STATE("[DSCON]["
@@ -313,7 +310,6 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
                   << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                   << m_mediator.m_txBlockChain.GetBlockCount() << "] DONE");
     }
-#endif // STAT_TEST
 
     {
         lock_guard<mutex> g(m_mutexPendingDSBlock);

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -764,7 +764,6 @@ bool DirectoryService::ProcessSetPrimary(const vector<unsigned char>& message,
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "START OF EPOCH " << m_mediator.m_dsBlockChain.GetBlockCount());
 
-#ifdef STAT_TEST
     if (primary == m_mediator.m_selfPeer)
     {
         LOG_STATE("[IDENT][" << std::setw(15) << std::left
@@ -778,7 +777,6 @@ bool DirectoryService::ProcessSetPrimary(const vector<unsigned char>& message,
                              << "][" << std::setw(6) << std::left
                              << m_consensusMyID << "] DSBK");
     }
-#endif // STAT_TEST
 
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Waiting " << POW1_WINDOW_IN_SECONDS

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -44,9 +44,7 @@ class Mediator;
 /// Implements Directory Service functionality including PoW verification, DS, Tx Block Consensus and sharding management.
 class DirectoryService : public Executable, public Broadcastable
 {
-#ifdef STAT_TEST
     std::chrono::system_clock::time_point m_timespec;
-#endif // STAT_TEST
 
     enum Action
     {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -198,7 +198,6 @@ void DirectoryService::SendFinalBlockToShardNodes(
             Serializable::SetNumber<uint8_t>(finalblock_message, curr_offset,
                                              (uint8_t)i, sizeof(uint8_t));
 
-#ifdef STAT_TEST
             SHA2<HASH_TYPE::HASH_VARIANT_256> sha256;
             sha256.Update(finalblock_message);
             vector<unsigned char> this_msg_hash = sha256.Finalize();
@@ -212,7 +211,6 @@ void DirectoryService::SendFinalBlockToShardNodes(
                        .substr(0, 6)
                 << "][" << m_mediator.m_txBlockChain.GetBlockCount()
                 << "] FBBLKGEN");
-#endif // STAT_TEST
 
             P2PComm::GetInstance().SendBroadcastMessage(shard_peers,
                                                         finalblock_message);
@@ -249,7 +247,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Final block consensus is DONE!!!");
 
-#ifdef STAT_TEST
     if (m_mode == PRIMARY_DS)
     {
         LOG_STATE("[FBCON]["
@@ -257,7 +254,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
                   << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                   << m_mediator.m_txBlockChain.GetBlockCount() << "] DONE");
     }
-#endif // STAT_TEST
 
     // Update the final block with the co-signatures from the consensus
     m_finalBlock->SetCoSignatures(*m_consensusObject);

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -482,7 +482,7 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary()
 
     ConsensusLeader* cl
         = dynamic_cast<ConsensusLeader*>(m_consensusObject.get());
-#ifdef STAT_TEST
+
     if (m_mode == PRIMARY_DS)
     {
         LOG_STATE("[FBCON]["
@@ -490,7 +490,6 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary()
                   << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                   << m_mediator.m_txBlockChain.GetBlockCount() << "] BGIN");
     }
-#endif // STAT_TEST
 
     cl->StartConsensus(finalBlockMessage, TxBlockHeader::SIZE);
 

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -200,7 +200,6 @@ bool DirectoryService::ProcessMicroblockSubmission(
 
     if (m_microBlocks.size() == m_shards.size())
     {
-#ifdef STAT_TEST
         if (m_mode == PRIMARY_DS)
         {
             LOG_STATE("[MICRO]["
@@ -208,7 +207,6 @@ bool DirectoryService::ProcessMicroblockSubmission(
                       << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                       << m_mediator.m_txBlockChain.GetBlockCount() << "] LAST");
         }
-#endif // STAT_TEST
         for (auto& microBlock : m_microBlocks)
         {
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -218,7 +216,6 @@ bool DirectoryService::ProcessMicroblockSubmission(
         cv_scheduleFinalBlockConsensus.notify_all();
         RunConsensusOnFinalBlock();
     }
-#ifdef STAT_TEST
     else if ((m_microBlocks.size() == 1) && (m_mode == PRIMARY_DS))
     {
         LOG_STATE("[MICRO]["
@@ -226,7 +223,6 @@ bool DirectoryService::ProcessMicroblockSubmission(
                   << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                   << m_mediator.m_txBlockChain.GetBlockCount() << "] FRST");
     }
-#endif // STAT_TEST
 
         // TODO: Re-request from shard leader if microblock is not received after a certain time.
 #endif // IS_LOOKUP_NODE

--- a/src/libDirectoryService/PoW1Processing.cpp
+++ b/src/libDirectoryService/PoW1Processing.cpp
@@ -96,9 +96,7 @@ bool DirectoryService::VerifyPoW1Submission(
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "dsblock_num            = " << block_num);
 
-#ifdef STAT_TEST
     m_timespec = r_timer_start();
-#endif // STAT_TEST
 
     bool result = POW::GetInstance().PoWVerify(
         block_num, difficulty, rand1, rand2, from.m_ipAddress, key, false,

--- a/src/libDirectoryService/PoW2Processing.cpp
+++ b/src/libDirectoryService/PoW2Processing.cpp
@@ -120,9 +120,7 @@ bool DirectoryService::VerifyPOW2(const vector<unsigned char>& message,
     // Verify nonce
     uint256_t block_num = m_mediator.m_txBlockChain.GetBlockCount();
 
-#ifdef STAT_TEST
     m_timespec = r_timer_start();
-#endif // STAT_TEST
 
     lock(m_mutexAllPOW2, m_mutexAllPoWConns);
     lock_guard<mutex> g(m_mutexAllPOW2, adopt_lock);

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -219,7 +219,6 @@ void DirectoryService::SendingShardingStructureToShard(
                               << " Port: " << kv.second.m_listenPortHost);
     }
 
-#ifdef STAT_TEST
     SHA2<HASH_TYPE::HASH_VARIANT_256> sha256;
     sha256.Update(sharding_message);
     vector<unsigned char> this_msg_hash = sha256.Finalize();
@@ -232,7 +231,6 @@ void DirectoryService::SendingShardingStructureToShard(
         << DataConversion::charArrToHexStr(m_mediator.m_dsBlockRand)
                .substr(0, 6)
         << "][" << m_mediator.m_txBlockChain.GetBlockCount() << "] SHMSG");
-#endif // STAT_TEST
 
     P2PComm::GetInstance().SendBroadcastMessage(shard_peers, sharding_message);
     p++;
@@ -291,7 +289,6 @@ bool DirectoryService::ProcessShardingConsensus(
                   "Sharding consensus is DONE!!!");
         cv_viewChangeSharding.notify_all();
 
-#ifdef STAT_TEST
         if (m_mode == PRIMARY_DS)
         {
             LOG_STATE("[SHCON]["
@@ -299,7 +296,6 @@ bool DirectoryService::ProcessShardingConsensus(
                       << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["
                       << m_mediator.m_txBlockChain.GetBlockCount() << "] DONE");
         }
-#endif // STAT_TEST
 
         // TODO: Refine this
         unsigned int nodeToSendToLookUpLo = COMM_SIZE / 4;

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -460,7 +460,6 @@ void P2PComm::HandleAcceptedConnection(
                     broadcast_list, message, this_msg_hash);
             }
 
-#ifdef STAT_TEST
             vector<unsigned char> this_msg_hash(hash_buf, hash_buf + HASH_LEN);
             LOG_STATE(
                 "[BROAD]["
@@ -468,7 +467,6 @@ void P2PComm::HandleAcceptedConnection(
                 << P2PComm::GetInstance().m_selfPeer << "]["
                 << DataConversion::Uint8VecToHexStr(this_msg_hash).substr(0, 6)
                 << "] RECV");
-#endif // STAT_TEST
 
             // Dispatch message normally
             dispatcher(message, from);
@@ -717,6 +715,4 @@ void P2PComm::SendBroadcastMessage(const deque<Peer>& peers,
     SendBroadcastMessageHelper(peers, message);
 }
 
-#ifdef STAT_TEST
 void P2PComm::SetSelfPeer(const Peer& self) { m_selfPeer = self; }
-#endif // STAT_TEST

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -76,9 +76,7 @@ class P2PComm
     P2PComm(P2PComm const&) = delete;
     void operator=(P2PComm const&) = delete;
 
-#ifdef STAT_TEST
     Peer m_selfPeer;
-#endif // STAT_TEST
 
     ThreadPool m_SendPool{MAXMESSAGE, "SendPool"};
     ThreadPool m_RecvPool{MAXMESSAGE, "RecvPool"};
@@ -124,9 +122,7 @@ public:
     void SendBroadcastMessage(const std::deque<Peer>& peers,
                               const std::vector<unsigned char>& message);
 
-#ifdef STAT_TEST
     void SetSelfPeer(const Peer& self);
-#endif // STAT_TEST
 };
 
 #endif // __P2PCOMM_H__

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -330,11 +330,9 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
         m_mediator.m_ds->m_mode = DirectoryService::Mode::PRIMARY_DS;
         LOG_EPOCHINFO(to_string(m_mediator.m_currentEpochNum).c_str(),
                       DS_LEADER_MSG);
-#ifdef STAT_TEST
         LOG_STATE("[IDENT][" << std::setw(15) << std::left
                              << m_mediator.m_selfPeer.GetPrintableIPAddress()
                              << "][0     ] DSLD");
-#endif // STAT_TEST
         m_mediator.m_ds->ScheduleShardingConsensus(
             LEADER_POW2_WINDOW_IN_SECONDS);
     }

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -82,9 +82,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 
     LogSelfNodeInfo(key, peer);
 
-#ifdef STAT_TEST
     P2PComm::GetInstance().SetSelfPeer(peer);
-#endif // STAT_TEST
 
     switch (syncType)
     {


### PR DESCRIPTION
After taking a closer look, I'm thinking about removing `STAT_TEST` completely. I understand why we have it at first - clearly identifying the code segments that later can be disabled for less verbose logs.   However, the current use of `STAT_TEST` is not cautious becuase the other code path (without `STAT_TEST`) actually has compile errors (about the use of `m_selfPeer`).

So why don't we just remove it completely. Later, if we want any of those parts disabled, we can just find it from the commit history. 