### PR TITLE
Add fix to clear broadcast hashes for lookup nodes

### DIFF
--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -60,6 +60,9 @@ class P2PComm
                              const std::vector<unsigned char>& message,
                              const std::vector<unsigned char>& message_hash);
 
+    void
+    ClearBroadcastHashAsync(const std::vector<unsigned char>& message_hash);
+
     template<typename Container>
     void SendBroadcastMessageHelper(const Container& peers,
                                     const std::vector<unsigned char>& message);


### PR DESCRIPTION
This is a fix for #362 