### PR TITLE
Don't wait for CommitTemp if my shard microblock not in finalblock

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -326,8 +326,8 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
         m_mediator.m_ds->m_consensusID
             = m_mediator.m_currentEpochNum == 1 ? 1 : 0;
         m_mediator.m_ds->SetState(DirectoryService::DirState::POW2_SUBMISSION);
-        m_mediator.m_ds->NotifyPOW2Submission();
         m_mediator.m_ds->m_mode = DirectoryService::Mode::PRIMARY_DS;
+        m_mediator.m_ds->NotifyPOW2Submission();
         LOG_EPOCHINFO(to_string(m_mediator.m_currentEpochNum).c_str(),
                       DS_LEADER_MSG);
         LOG_STATE("[IDENT][" << std::setw(15) << std::left

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -327,6 +327,7 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
             = m_mediator.m_currentEpochNum == 1 ? 1 : 0;
         m_mediator.m_ds->SetState(DirectoryService::DirState::POW2_SUBMISSION);
         m_mediator.m_ds->m_mode = DirectoryService::Mode::PRIMARY_DS;
+        m_mediator.m_node->CleanCreatedTransaction();
         m_mediator.m_ds->NotifyPOW2Submission();
         LOG_EPOCHINFO(to_string(m_mediator.m_currentEpochNum).c_str(),
                       DS_LEADER_MSG);

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -790,7 +790,6 @@ bool Node::IsMyShardsMicroBlockInFinalBlock(const uint256_t& blocknum)
         return false;
     }
 
-    lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
     auto it = m_unavailableMicroBlocks.find(blocknum);
     if (it == m_unavailableMicroBlocks.end())
     {

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -212,6 +212,7 @@ void Node::LoadUnavailableMicroBlockHashes(
             lock_guard<mutex> g2(m_mutexAllMicroBlocksRecvd);
             m_allMicroBlocksRecvd = false;
         }
+        if (IsMyShardsMicroBlockInFinalBlock(blocknum))
         {
             lock_guard<mutex> g3(m_mutexTempCommitted);
             m_tempStateDeltaCommitted = false;
@@ -780,6 +781,37 @@ bool Node::IsMyShardsMicroBlockStateDeltaHashInFinalBlock(
                m_microblock->GetHeader().GetStateDeltaHash(),
                m_microblock->GetHeader().GetTxRootHash(), blocknum,
                isEveryMicroBlockAvailable);
+}
+
+bool Node::IsMyShardsMicroBlockInFinalBlock(const uint256_t& blocknum)
+{
+    if (m_microblock == nullptr)
+    {
+        return false;
+    }
+
+    lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
+    auto it = m_unavailableMicroBlocks.find(blocknum);
+    if (it == m_unavailableMicroBlocks.end())
+    {
+        return false;
+    }
+
+    for (auto it2 = m_unavailableMicroBlocks[blocknum].begin();
+         it2 != m_unavailableMicroBlocks[blocknum].end(); it2++)
+    {
+        if (it2->first.m_stateDeltaHash
+                == m_microblock->GetHeader().GetStateDeltaHash()
+            && it2->first.m_txRootHash
+                == m_microblock->GetHeader().GetTxRootHash())
+        {
+            LOG_GENERAL(INFO, "Found my shards microblock in finalblock");
+            return true;
+        }
+    }
+
+    LOG_GENERAL(WARNING, "Didn't find my shards microblock in finalblock");
+    return false;
 }
 
 bool Node::ActOnFinalBlock(uint8_t tx_sharing_mode, const vector<Peer>& nodes)

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -982,6 +982,12 @@ bool Node::CleanVariables()
 
     return true;
 }
+
+void Node::CleanCreatedTransaction()
+{
+    std::lock_guard<mutex> lock(m_mutexCreatedTransactions);
+    m_createdTransactions.clear();
+}
 #endif // IS_LOOKUP_NODE
 
 bool Node::ToBlockMessage(unsigned char ins_byte)

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -243,6 +243,8 @@ class Node : public Executable, public Broadcastable
     bool IsMyShardsMicroBlockStateDeltaHashInFinalBlock(
         const boost::multiprecision::uint256_t& blocknum,
         bool& isEveryMicroBlockAvailable);
+    bool IsMyShardsMicroBlockInFinalBlock(
+        const boost::multiprecision::uint256_t& blocknum);
     bool
     ReadAuxilliaryInfoFromFinalBlockMsg(const vector<unsigned char>& message,
                                         unsigned int& cur_offset,
@@ -475,6 +477,9 @@ public:
     bool StartPoW2(const boost::multiprecision::uint256_t block_num,
                    uint8_t difficulty, array<unsigned char, 32> rand1,
                    array<unsigned char, 32> rand2);
+
+    /// Call when the normal node be promoted to DS
+    void CleanCreatedTransaction();
 #endif // IS_LOOKUP_NODE
 };
 


### PR DESCRIPTION
1. To fix the bug that the shard without microblock in finalblock will be waiting for m_tempStateDeltaCommitted becomes true until forever if there are any microblock from other shard.
2. Also add a clean up for m_createdTransactions if a shard node becomes a DS Leader.