### PR TITLE
Add log level switch in constant file

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -35,6 +35,7 @@
         <COINBASE_REWARD>100</COINBASE_REWARD>
         <TXN_SUBMISSION>5</TXN_SUBMISSION>
         <TXN_BROADCAST>10</TXN_BROADCAST>
+        <DEBUG_LEVEL>3</DEBUG_LEVEL>
     </constants>
     <options>
         <TEST_NET_MODE>false</TEST_NET_MODE>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -35,6 +35,7 @@
         <COINBASE_REWARD>100</COINBASE_REWARD>
         <TXN_SUBMISSION>5</TXN_SUBMISSION>
         <TXN_BROADCAST>10</TXN_BROADCAST>
+        <DEBUG_LEVEL>3</DEBUG_LEVEL>
     </constants>
     <options>
         <TEST_NET_MODE>false</TEST_NET_MODE>

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -128,6 +128,7 @@ const unsigned int NORMAL_TRAN_GAS{ReadFromConstantsFile("NORMAL_TRAN_GAS")};
 const unsigned int COINBASE_REWARD{ReadFromConstantsFile("COINBASE_REWARD")};
 const unsigned int TXN_SUBMISSION{ReadFromConstantsFile("TXN_SUBMISSION")};
 const unsigned int TXN_BROADCAST{ReadFromConstantsFile("TXN_BROADCAST")};
+const unsigned int DEBUG_LEVEL{ReadFromConstantsFile("DEBUG_LEVEL")};
 const std::vector<std::string> GENESIS_WALLETS{
     ReadAccountsFromConstantsFile("wallet_address")};
 const std::vector<std::string> GENESIS_KEYS{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -142,6 +142,7 @@ extern const unsigned int WAITING_STATE_FORWARD_IN_SECONDS;
 extern const unsigned int COINBASE_REWARD;
 extern const unsigned int TXN_SUBMISSION;
 extern const unsigned int TXN_BROADCAST;
+extern const unsigned int DEBUG_LEVEL;
 extern const std::vector<std::string> GENESIS_WALLETS;
 extern const std::vector<std::string> GENESIS_KEYS;
 #endif // __CONSTANTS_H__

--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -182,6 +182,7 @@ PeerManager::PeerManager(const std::pair<PrivKey, PubKey>& key,
     , m_selfPeer(peer)
 {
     LOG_MARKER();
+    SetupLogLevel();
 
     if (loadConfig)
     {
@@ -271,4 +272,28 @@ vector<Peer> PeerManager::GetBroadcastList(unsigned char ins_type,
 {
     LOG_MARKER();
     return Broadcastable::GetBroadcastList(ins_type, broadcast_originator);
+}
+
+void PeerManager::SetupLogLevel()
+{
+    LOG_MARKER();
+    switch (DEBUG_LEVEL)
+    {
+    case 1:
+    {
+        LOG_DISPLAY_LEVEL_ABOVE(FATAL);
+        break;
+    }
+    case 2:
+    {
+        LOG_DISPLAY_LEVEL_ABOVE(WARNING);
+        break;
+    }
+    case 3:
+    default:
+    {
+        LOG_DISPLAY_LEVEL_ABOVE(INFO);
+        break;
+    }
+    }
 }

--- a/src/libNetwork/PeerManager.h
+++ b/src/libNetwork/PeerManager.h
@@ -41,6 +41,8 @@ class PeerManager : public Executable, public Broadcastable
     bool ProcessBroadcast(const std::vector<unsigned char>& message,
                           unsigned int offset, const Peer& from);
 
+    void SetupLogLevel();
+
 public:
     enum InstructionType : unsigned char
     {


### PR DESCRIPTION
User can switch log level by specifying log level inside constant_local.xml & constant.xml.

<DEBUG_LEVEL>3</DEBUG_LEVEL>
-> Default, show INFO/WARNING/FATAL log

<DEBUG_LEVEL>2</DEBUG_LEVEL>
-> Show WARNING/FATAL log

<DEBUG_LEVEL>1</DEBUG_LEVEL>
-> Show FATAL log
