### PR TITLE
Improve the gitter badge quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Zilliqa (codename _Durian_)
 
-[![Build Status](https://travis-ci.org/Zilliqa/Zilliqa.svg?branch=master)](https://travis-ci.org/Zilliqa/Zilliqa) [![codecov](https://codecov.io/gh/Zilliqa/Zilliqa/branch/master/graph/badge.svg)](https://codecov.io/gh/Zilliqa/Zilliqa) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/Zilliqa/)
+[![Build Status](https://travis-ci.org/Zilliqa/Zilliqa.svg?branch=master)](https://travis-ci.org/Zilliqa/Zilliqa)
+[![codecov](https://codecov.io/gh/Zilliqa/Zilliqa/branch/master/graph/badge.svg)](https://codecov.io/gh/Zilliqa/Zilliqa)
+[![Gitter chat](http://img.shields.io/badge/chat-on%20gitter-077a8f.svg)](https://gitter.im/Zilliqa/)
 
 ## Overview
 Zilliqa is a new blockchain platform capable of processing thousands of transactions per second with sharding built into it. With sharding, Zilliqa has the potential to match throughput benchmarks set by traditional payment methods (such as _VISA_ and _MasterCard_). More importantly, Zilliqa’s transaction throughput increases (roughly) linearly with its network size.


### PR DESCRIPTION
The color (#077a8f) is the darkest color from Zilliqa logo.

![image](https://user-images.githubusercontent.com/3510144/42357582-324031c2-810b-11e8-8140-65acc6be091a.png)

links:
- https://shields.io/