### PR TITLE
Reordered block number checking in EthashConfigureLightClient

### DIFF
--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -140,12 +140,6 @@ void POW::EthashLightDelete(ethash_light_t light)
 bool POW::EthashConfigureLightClient(uint64_t block_number)
 {
     std::lock_guard<std::mutex> g(m_mutexLightClientConfigure);
-    if (block_number != currentBlockNum)
-    {
-        ethash_light_client
-            = EthashLightReuse(ethash_light_client, block_number);
-        currentBlockNum = block_number;
-    }
 
     if (block_number < currentBlockNum)
     {
@@ -153,6 +147,13 @@ bool POW::EthashConfigureLightClient(uint64_t block_number)
                     "WARNING: How come the latest block number is smaller than "
                     "current block number.  block_number: "
                         << " currentBlockNum: " << currentBlockNum);
+    }
+
+    if (block_number != currentBlockNum)
+    {
+        ethash_light_client
+            = EthashLightReuse(ethash_light_client, block_number);
+        currentBlockNum = block_number;
     }
 
     return true;


### PR DESCRIPTION
For the case `block_number < currentBlockNum`, the warning message would have never appeared because `currentBlockNum` would have already been set to `block_number` in the earlier code block for `block_number != currentBlockNum`.