### PR TITLE
Consensus message ordering for ds block, sharding structure, final block and view change block

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -434,6 +434,24 @@ bool DirectoryService::ProcessDSBlockConsensus(
     // If COLLECTIVESIG also comes in, it's then possible COLLECTIVESIG will be processed before ANNOUNCE!
     // So, ANNOUNCE should acquire a lock here
 
+    std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
+    if (cv_processConsensusMessage.wait_for(
+            cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
+            [this, message, offset]() -> bool {
+                return m_consensusObject->CanProcessMessage(message, offset);
+            }))
+    {
+        // Correct order preserved
+    }
+    else
+    {
+        LOG_GENERAL(
+            WARNING,
+            "Timeout while waiting for correct order of DS Block consensus "
+            "messages");
+        return false;
+    }
+
     lock_guard<mutex> g(m_mutexConsensus);
 
     // Wait until ProcessDSBlock in the case that primary sent announcement pretty early
@@ -494,6 +512,7 @@ bool DirectoryService::ProcessDSBlockConsensus(
     {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Consensus state = " << state);
+        cv_processConsensusMessage.notify_all();
     }
 
     return result;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -164,7 +164,8 @@ class DirectoryService : public Executable, public Broadcastable
     std::mutex m_MutexCVPOW1Submission;
     std::condition_variable cv_POW2Submission;
     std::mutex m_MutexCVPOW2Submission;
-
+    std::mutex m_mutexProcessConsensusMessage;
+    std::condition_variable cv_processConsensusMessage;
     // TO Remove
     Mediator& m_mediator;
 

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -415,6 +415,24 @@ bool DirectoryService::ProcessFinalBlockConsensus(
     // If COLLECTIVESIG also comes in, it's then possible COLLECTIVESIG will be processed before ANNOUNCE!
     // So, ANNOUNCE should acquire a lock here
 
+    std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
+    if (cv_processConsensusMessage.wait_for(
+            cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
+            [this, message, offset]() -> bool {
+                return m_consensusObject->CanProcessMessage(message, offset);
+            }))
+    {
+        // Correct order preserved
+    }
+    else
+    {
+        LOG_GENERAL(
+            WARNING,
+            "Timeout while waiting for correct order of Final Block consensus "
+            "messages");
+        return false;
+    }
+
     lock_guard<mutex> g(m_mutexConsensus);
 
     // Wait until in the case that primary sent announcement pretty early
@@ -472,6 +490,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(
     {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Consensus state = " << state);
+        cv_processConsensusMessage.notify_all();
     }
 
     return result;

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -356,6 +356,25 @@ bool DirectoryService::ProcessViewChangeConsensus(
     // If COLLECTIVESIG also comes in, it's then possible COLLECTIVESIG will be processed before ANNOUNCE!
     // So, ANNOUNCE should acquire a lock here
 
+    std::unique_lock<mutex> cv_lk_con_msg(m_mutexProcessConsensusMessage);
+    if (cv_processConsensusMessage.wait_for(
+            cv_lk_con_msg,
+            std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
+            [this, message, offset]() -> bool {
+                return m_consensusObject->CanProcessMessage(message, offset);
+            }))
+    {
+        // Correct order preserved
+    }
+    else
+    {
+        LOG_GENERAL(WARNING,
+                    "Timeout while waiting for correct order of View Change "
+                    "Block consensus "
+                    "messages");
+        return false;
+    }
+
     lock_guard<mutex> g(m_mutexConsensus);
 
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeConsensusObj);
@@ -407,6 +426,13 @@ bool DirectoryService::ProcessViewChangeConsensus(
         // throw exception();
         // TODO: no consensus reached
         return false;
+    }
+    else
+    {
+        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Consensus state = " << state);
+
+        cv_processConsensusMessage.notify_all();
     }
 
     return result;


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This is a follow PR to PR #419. Recall that in PR #419 , we removed the hotfix (of sleeping after consensus commit) and implemented ordering of consensus message. In that particular PR, we implemented it only for microblock consensus. This PR follows up on the outstanding issue from PR #419  

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Reviewer should refer back to PR #419  and #423 if he/she need context of this PR. 

<!-- How can the reviewers verify the pull request is working as expected -->

## Status
Ready for review 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] implement consensus message ordering for DS block 
- [x] implement consensus message ordering for Sharding structure 
- [x] implement consensus message ordering for Final block 
- [x] implement consensus message ordering for Viewchange block 
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] medium-scale cloud test
