### PR TITLE
Fix race condition when using m_consensusObject->CanProcessMessage(message, offset) and add atomic to m_state in consensusCommon

### DIFF
--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -97,7 +97,7 @@ protected:
     };
 
     /// State of the active consensus session.
-    State m_state;
+    std::atomic<State> m_state;
 
     /// State of the active consensus session.
     ConsensusErrorCode m_consensusErrorCode;

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -438,6 +438,7 @@ bool DirectoryService::ProcessDSBlockConsensus(
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
+                lock_guard<mutex> g(m_mutexConsensus);
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -447,6 +447,14 @@ bool DirectoryService::ProcessDSBlockConsensus(
                                 "consensus msg.")
                     return false;
                 }
+
+                if (m_consensusObject == nullptr)
+                {
+                    LOG_GENERAL(WARNING,
+                                "m_consensusObject is a nullptr. It has not "
+                                "been initialized.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -439,6 +439,14 @@ bool DirectoryService::ProcessDSBlockConsensus(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
                 lock_guard<mutex> g(m_mutexConsensus);
+                if (m_mediator.m_lookup->m_syncType != SyncType::NO_SYNC)
+                {
+                    LOG_GENERAL(WARNING,
+                                "The node started the process of rejoining, "
+                                "Ignore rest of "
+                                "consensus msg.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -274,7 +274,8 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
             //View change.
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "Initiated DS block view change. ");
-            RunConsensusOnViewChange();
+            auto func = [this]() -> void { RunConsensusOnViewChange(); };
+            DetachedFunction(1, func);
         }
     }
 }

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -238,26 +238,27 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
         }
     }
 
-    if (m_mode == PRIMARY_DS)
     {
-        if (!RunConsensusOnDSBlockWhenDSPrimary())
+        lock_guard<mutex> lock(m_mutexConsensus);
+        if (m_mode == PRIMARY_DS)
         {
-            LOG_GENERAL(
-                WARNING,
-                "Throwing exception after RunConsensusOnDSBlockWhenDSPrimary");
-            // throw exception();
-            return;
+            if (!RunConsensusOnDSBlockWhenDSPrimary())
+            {
+                LOG_GENERAL(WARNING,
+                            "Error after RunConsensusOnDSBlockWhenDSPrimary");
+                // throw exception();
+                return;
+            }
         }
-    }
-    else
-    {
-        if (!RunConsensusOnDSBlockWhenDSBackup())
+        else
         {
-            LOG_GENERAL(
-                WARNING,
-                "Throwing exception after RunConsensusOnDSBlockWhenDSBackup");
-            // throw exception();
-            return;
+            if (!RunConsensusOnDSBlockWhenDSBackup())
+            {
+                LOG_GENERAL(WARNING,
+                            "Error after RunConsensusOnDSBlockWhenDSBackup");
+                // throw exception();
+                return;
+            }
         }
     }
 
@@ -271,7 +272,6 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
             == std::cv_status::timeout)
         {
             //View change.
-            //TODO: This is a simplified version and will be review again.
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "Initiated DS block view change. ");
             RunConsensusOnViewChange();

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -238,27 +238,24 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
         }
     }
 
+    if (m_mode == PRIMARY_DS)
     {
-        lock_guard<mutex> lock(m_mutexConsensus);
-        if (m_mode == PRIMARY_DS)
+        if (!RunConsensusOnDSBlockWhenDSPrimary())
         {
-            if (!RunConsensusOnDSBlockWhenDSPrimary())
-            {
-                LOG_GENERAL(WARNING,
-                            "Error after RunConsensusOnDSBlockWhenDSPrimary");
-                // throw exception();
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Error after RunConsensusOnDSBlockWhenDSPrimary");
+            // throw exception();
+            return;
         }
-        else
+    }
+    else
+    {
+        if (!RunConsensusOnDSBlockWhenDSBackup())
         {
-            if (!RunConsensusOnDSBlockWhenDSBackup())
-            {
-                LOG_GENERAL(WARNING,
-                            "Error after RunConsensusOnDSBlockWhenDSBackup");
-                // throw exception();
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Error after RunConsensusOnDSBlockWhenDSBackup");
+            // throw exception();
+            return;
         }
     }
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1261,7 +1261,12 @@ bool DirectoryService::CleanVariables()
     m_shards.clear();
     m_publicKeyToShardIdMap.clear();
     m_allPoWConns.clear();
-    m_consensusObject.reset();
+
+    {
+        std::lock_guard<mutex> lock(m_mutexConsensus);
+        m_consensusObject.reset();
+    }
+
     m_consensusBlockHash.clear();
     {
         std::lock_guard<mutex> lock(m_mutexPendingDSBlock);

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -420,6 +420,14 @@ bool DirectoryService::ProcessFinalBlockConsensus(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
                 lock_guard<mutex> g(m_mutexConsensus);
+                if (m_mediator.m_lookup->m_syncType != SyncType::NO_SYNC)
+                {
+                    LOG_GENERAL(WARNING,
+                                "The node started the process of rejoining, "
+                                "Ignore rest of "
+                                "consensus msg.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -419,6 +419,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
+                lock_guard<mutex> g(m_mutexConsensus);
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -428,6 +428,14 @@ bool DirectoryService::ProcessFinalBlockConsensus(
                                 "consensus msg.")
                     return false;
                 }
+
+                if (m_consensusObject == nullptr)
+                {
+                    LOG_GENERAL(WARNING,
+                                "m_consensusObject is a nullptr. It has not "
+                                "been initialized.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -871,7 +871,8 @@ void DirectoryService::RunConsensusOnFinalBlock()
     {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Initiated final block view change. ");
-        RunConsensusOnViewChange();
+        auto func = [this]() -> void { RunConsensusOnViewChange(); };
+        DetachedFunction(1, func);
     }
 }
 #endif // IS_LOOKUP_NODE

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -835,29 +835,26 @@ void DirectoryService::RunConsensusOnFinalBlock()
 
     SetState(FINALBLOCK_CONSENSUS_PREP);
 
+    if (m_mode == PRIMARY_DS)
     {
-        lock_guard<mutex> lock(m_mutexConsensus);
-        if (m_mode == PRIMARY_DS)
+        if (!RunConsensusOnFinalBlockWhenDSPrimary())
         {
-            if (!RunConsensusOnFinalBlockWhenDSPrimary())
-            {
-                LOG_GENERAL(WARNING,
-                            "Consensus failed at "
-                            "RunConsensusOnFinalBlockWhenDSPrimary");
-                // throw exception();
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Consensus failed at "
+                        "RunConsensusOnFinalBlockWhenDSPrimary");
+            // throw exception();
+            return;
         }
-        else
+    }
+    else
+    {
+        if (!RunConsensusOnFinalBlockWhenDSBackup())
         {
-            if (!RunConsensusOnFinalBlockWhenDSBackup())
-            {
-                LOG_GENERAL(WARNING,
-                            "Consensus failed at "
-                            "RunConsensusOnFinalBlockWhenDSBackup");
-                // throw exception();
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Consensus failed at "
+                        "RunConsensusOnFinalBlockWhenDSBackup");
+            // throw exception();
+            return;
         }
     }
 

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -835,26 +835,29 @@ void DirectoryService::RunConsensusOnFinalBlock()
 
     SetState(FINALBLOCK_CONSENSUS_PREP);
 
-    if (m_mode == PRIMARY_DS)
     {
-        if (!RunConsensusOnFinalBlockWhenDSPrimary())
+        lock_guard<mutex> lock(m_mutexConsensus);
+        if (m_mode == PRIMARY_DS)
         {
-            LOG_GENERAL(WARNING,
-                        "Consensus failed at "
-                        "RunConsensusOnFinalBlockWhenDSPrimary");
-            // throw exception();
-            return;
+            if (!RunConsensusOnFinalBlockWhenDSPrimary())
+            {
+                LOG_GENERAL(WARNING,
+                            "Consensus failed at "
+                            "RunConsensusOnFinalBlockWhenDSPrimary");
+                // throw exception();
+                return;
+            }
         }
-    }
-    else
-    {
-        if (!RunConsensusOnFinalBlockWhenDSBackup())
+        else
         {
-            LOG_GENERAL(WARNING,
-                        "Consensus failed at "
-                        "RunConsensusOnFinalBlockWhenDSBackup");
-            // throw exception();
-            return;
+            if (!RunConsensusOnFinalBlockWhenDSBackup())
+            {
+                LOG_GENERAL(WARNING,
+                            "Consensus failed at "
+                            "RunConsensusOnFinalBlockWhenDSBackup");
+                // throw exception();
+                return;
+            }
         }
     }
 

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -244,6 +244,7 @@ bool DirectoryService::ProcessShardingConsensus(
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
+                lock_guard<mutex> g(m_mutexConsensus);
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -253,6 +253,14 @@ bool DirectoryService::ProcessShardingConsensus(
                                 "consensus msg.")
                     return false;
                 }
+
+                if (m_consensusObject == nullptr)
+                {
+                    LOG_GENERAL(WARNING,
+                                "m_consensusObject is a nullptr. It has not "
+                                "been initialized.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -245,6 +245,14 @@ bool DirectoryService::ProcessShardingConsensus(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
                 lock_guard<mutex> g(m_mutexConsensus);
+                if (m_mediator.m_lookup->m_syncType != SyncType::NO_SYNC)
+                {
+                    LOG_GENERAL(WARNING,
+                                "The node started the process of rejoining, "
+                                "Ignore rest of "
+                                "consensus msg.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -674,30 +674,26 @@ void DirectoryService::RunConsensusOnSharding()
         return;
     }
 
+    if (m_mode == PRIMARY_DS)
     {
-        lock_guard<mutex> lock(m_mutexConsensus);
-        if (m_mode == PRIMARY_DS)
+        if (!RunConsensusOnShardingWhenDSPrimary())
         {
-            if (!RunConsensusOnShardingWhenDSPrimary())
-            {
-                LOG_EPOCH(WARNING,
-                          to_string(m_mediator.m_currentEpochNum).c_str(),
-                          "Error encountered with running sharding consensus "
-                          "as ds leader");
-                // throw exception();
-                return;
-            }
+            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "Error encountered with running sharding consensus "
+                      "as ds leader");
+            // throw exception();
+            return;
         }
-        else
+    }
+    else
+    {
+        if (!RunConsensusOnShardingWhenDSBackup())
         {
-            if (!RunConsensusOnShardingWhenDSBackup())
-            {
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          "Error encountered with running sharding consensus "
-                          "as ds backup")
-                // throw exception();
-                return;
-            }
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "Error encountered with running sharding consensus "
+                      "as ds backup")
+            // throw exception();
+            return;
         }
     }
 

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -674,26 +674,30 @@ void DirectoryService::RunConsensusOnSharding()
         return;
     }
 
-    if (m_mode == PRIMARY_DS)
     {
-        if (!RunConsensusOnShardingWhenDSPrimary())
+        lock_guard<mutex> lock(m_mutexConsensus);
+        if (m_mode == PRIMARY_DS)
         {
-            LOG_EPOCH(
-                WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                "Exception encountered with running sharding on ds leader");
-            // throw exception();
-            return;
+            if (!RunConsensusOnShardingWhenDSPrimary())
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Error encountered with running sharding consensus "
+                          "as ds leader");
+                // throw exception();
+                return;
+            }
         }
-    }
-    else
-    {
-        if (!RunConsensusOnShardingWhenDSBackup())
+        else
         {
-            LOG_EPOCH(
-                INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                "Exception encountered with running sharding on ds backup")
-            // throw exception();
-            return;
+            if (!RunConsensusOnShardingWhenDSBackup())
+            {
+                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Error encountered with running sharding consensus "
+                          "as ds backup")
+                // throw exception();
+                return;
+            }
         }
     }
 

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -711,7 +711,8 @@ void DirectoryService::RunConsensusOnSharding()
     {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Initiated sharding structure consensus view change. ");
-        RunConsensusOnViewChange();
+        auto func = [this]() -> void { RunConsensusOnViewChange(); };
+        DetachedFunction(1, func);
     }
 }
 #endif // IS_LOOKUP_NODE

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -362,6 +362,14 @@ bool DirectoryService::ProcessViewChangeConsensus(
             std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
                 lock_guard<mutex> g(m_mutexConsensus);
+                if (m_mediator.m_lookup->m_syncType != SyncType::NO_SYNC)
+                {
+                    LOG_GENERAL(WARNING,
+                                "The node started the process of rejoining, "
+                                "Ignore rest of "
+                                "consensus msg.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -361,6 +361,7 @@ bool DirectoryService::ProcessViewChangeConsensus(
             cv_lk_con_msg,
             std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
+                lock_guard<mutex> g(m_mutexConsensus);
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -370,6 +370,14 @@ bool DirectoryService::ProcessViewChangeConsensus(
                                 "consensus msg.")
                     return false;
                 }
+
+                if (m_consensusObject == nullptr)
+                {
+                    LOG_GENERAL(WARNING,
+                                "m_consensusObject is a nullptr. It has not "
+                                "been initialized.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -92,27 +92,24 @@ void DirectoryService::RunConsensusOnViewChange()
 
     // TODO
     // We compare with empty peer is due to the fact that DSCommittee for yourself is 0.0.0.0 with port 0.
+
+    if (m_mediator.m_DSCommitteeNetworkInfo.at(newCandidateLeader) == Peer())
     {
-        lock_guard<mutex> lock(m_mutexConsensus);
-        if (m_mediator.m_DSCommitteeNetworkInfo.at(newCandidateLeader)
-            == Peer())
+        if (!RunConsensusOnViewChangeWhenCandidateLeader())
         {
-            if (!RunConsensusOnViewChangeWhenCandidateLeader())
-            {
-                LOG_GENERAL(WARNING,
-                            "Error after RunConsensusOnDSBlockWhenDSPrimary");
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Error after RunConsensusOnDSBlockWhenDSPrimary");
+            return;
         }
-        else
+    }
+    else
+    {
+        if (!RunConsensusOnViewChangeWhenNotCandidateLeader())
         {
-            if (!RunConsensusOnViewChangeWhenNotCandidateLeader())
-            {
-                LOG_GENERAL(WARNING,
-                            "Error after "
-                            "RunConsensusOnViewChangeWhenNotCandidateLeader");
-                return;
-            }
+            LOG_GENERAL(WARNING,
+                        "Error after "
+                        "RunConsensusOnViewChangeWhenNotCandidateLeader");
+            return;
         }
     }
 

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -92,24 +92,27 @@ void DirectoryService::RunConsensusOnViewChange()
 
     // TODO
     // We compare with empty peer is due to the fact that DSCommittee for yourself is 0.0.0.0 with port 0.
-    if (m_mediator.m_DSCommitteeNetworkInfo.at(newCandidateLeader) == Peer())
     {
-        if (!RunConsensusOnViewChangeWhenCandidateLeader())
+        lock_guard<mutex> lock(m_mutexConsensus);
+        if (m_mediator.m_DSCommitteeNetworkInfo.at(newCandidateLeader)
+            == Peer())
         {
-            LOG_GENERAL(
-                WARNING,
-                "Throwing exception after RunConsensusOnDSBlockWhenDSPrimary");
-            return;
+            if (!RunConsensusOnViewChangeWhenCandidateLeader())
+            {
+                LOG_GENERAL(WARNING,
+                            "Error after RunConsensusOnDSBlockWhenDSPrimary");
+                return;
+            }
         }
-    }
-    else
-    {
-        if (!RunConsensusOnViewChangeWhenNotCandidateLeader())
+        else
         {
-            LOG_GENERAL(WARNING,
-                        "Throwing exception after "
-                        "RunConsensusOnViewChangeWhenNotCandidateLeader");
-            return;
+            if (!RunConsensusOnViewChangeWhenNotCandidateLeader())
+            {
+                LOG_GENERAL(WARNING,
+                            "Error after "
+                            "RunConsensusOnViewChangeWhenNotCandidateLeader");
+                return;
+            }
         }
     }
 

--- a/src/libNode/MicroBlockProcessing.cpp
+++ b/src/libNode/MicroBlockProcessing.cpp
@@ -581,25 +581,29 @@ bool Node::RunConsensusOnMicroBlock()
         lock_guard<mutex> g2(m_mutexNewRoundStarted);
         m_newRoundStarted = false;
     }
-
-    if (m_isPrimary == true)
     {
-        if (!RunConsensusOnMicroBlockWhenShardLeader())
+        lock_guard<mutex> lock(m_mutexConsensus);
+        if (m_isPrimary == true)
         {
-            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Error at RunConsensusOnMicroBlockWhenShardLeader");
-            // throw exception();
-            return false;
+            if (!RunConsensusOnMicroBlockWhenShardLeader())
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Error at RunConsensusOnMicroBlockWhenShardLeader");
+                // throw exception();
+                return false;
+            }
         }
-    }
-    else
-    {
-        if (!RunConsensusOnMicroBlockWhenShardBackup())
+        else
         {
-            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Error at RunConsensusOnMicroBlockWhenShardBackup");
-            // throw exception();
-            return false;
+            if (!RunConsensusOnMicroBlockWhenShardBackup())
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Error at RunConsensusOnMicroBlockWhenShardBackup");
+                // throw exception();
+                return false;
+            }
         }
     }
 

--- a/src/libNode/MicroBlockProcessing.cpp
+++ b/src/libNode/MicroBlockProcessing.cpp
@@ -93,6 +93,15 @@ bool Node::ProcessMicroblockConsensus(const vector<unsigned char>& message,
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
             [this, message, offset]() -> bool {
+                lock_guard<mutex> g(m_mutexConsensus);
+                if (m_mediator.m_lookup->m_syncType != SyncType::NO_SYNC)
+                {
+                    LOG_GENERAL(WARNING,
+                                "The node started the process of rejoining, "
+                                "Ignore rest of "
+                                "consensus msg.")
+                    return false;
+                }
                 return m_consensusObject->CanProcessMessage(message, offset);
             }))
     {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -975,7 +975,11 @@ bool Node::CleanVariables()
     m_tempStateDeltaCommitted = true;
     m_myShardID = 0;
 
-    m_consensusObject.reset();
+    {
+        std::lock_guard<mutex> lock(m_mutexConsensus);
+        m_consensusObject.reset();
+    }
+
     m_consensusBlockHash.clear();
     {
         std::lock_guard<mutex> lock(m_mutexMicroBlock);


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In PR #419 and #428, `m_consensusObject->CanProcessMessage(message, offset)` was added before each consensus message to check whether the ordering of the consensus message is correct or wrong. However, race condition (when using `m_consensusObject`) may occurs. 

One example will be for `libNode`. When the conditional variable `cv_processConsensusMessage` timeout, depending on the situation, a node may rejoin as a new node. During this period of time, `m_consensusObject` will be reset. However, there may be more threads (in the threadpool) that will use `m_consensusObject` in the near future. There is currently no such issue for `libDirectoryService`.

This PR fixes the race condition by introducing a mutex to protect `m_consensusObject`. In addtion, for `libNode`, an additional check was added to check whether is the node in the process of rejoining. If true, it will ignore the rest of the consensus message. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
This PR does not catered for the case when m_consensusObject is reset to prepare for the next round of consensus. 

## Status
Ready for review 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] use atomic for m_state in consensusCommon
- [x] Fix race condition when using m_consensusObject
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] medium-scale cloud test
