### PR TITLE
Add scripts/make_image.sh for local image build and push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ jobs:
     env: BUILD_COMMAND="./scripts/ci_make_image.sh"
     before_install: # left blank
     install: # left blank
+    - pip install --user awscli
+    - export PATH=$PATH:$HOME/.local/bin
     cache: # left blank
     script:
     - $BUILD_COMMAND

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,27 +28,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #--------------------------------------------------------------------
 # BUILDING
 #--------------------------------------------------------------------
-ARG BRANCH=master
 # don't do check-out if COMMIT is empty
 ARG COMMIT=
 ARG REPO=https://github.com/Zilliqa/Zilliqa.git
 ARG SOURCE_DIR=/zilliqa
 ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
+ARG BUILD_TYPE=RelWithDebInfo
 
 # FIXME: see issue https://github.com/Zilliqa/Zilliqa/issues/240
-RUN git clone --recursive -b ${BRANCH} --depth=10 ${REPO} ${SOURCE_DIR}; \
-    git -C ${SOURCE_DIR} checkout ${COMMIT}; \
-    mkdir $BUILD_DIR && cd $BUILD_DIR; \
-    cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ${SOURCE_DIR}; \
-    make -j2 && make install; \
-    cd .. && rm -rf ${BUILD_DIR}; \
-    mv ${INSTALL_DIR}/bin/zilliqa ${INSTALL_DIR}/bin/zilliqa_lookup; \
-    mkdir $BUILD_DIR && cd $BUILD_DIR; \
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ${SOURCE_DIR}; \
-    make -j2 && make install; \
+RUN git clone --recursive ${REPO} ${SOURCE_DIR} && \
+    git -C ${SOURCE_DIR} checkout ${COMMIT} && \
+    mkdir $BUILD_DIR && cd $BUILD_DIR && \
+    cmake -DIS_LOOKUP_NODE=1 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ${SOURCE_DIR} && \
+    make -j2 && make install && \
+    cd .. && rm -rf ${BUILD_DIR} && \
+    mv ${INSTALL_DIR}/bin/zilliqa ${INSTALL_DIR}/bin/zilliqa_lookup && \
+    mkdir $BUILD_DIR && cd $BUILD_DIR && \
+    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ${SOURCE_DIR} && \
+    make -j2 && make install && \
     cd ${INSTALL_DIR} && rm -rf ${BUILD_DIR}
 
 ENV LD_LIBRARY_PATH=${INSTALL_DIR}/lib

--- a/scripts/ci_make_image.sh
+++ b/scripts/ci_make_image.sh
@@ -6,18 +6,15 @@
 set -e
 
 docker --version
-pip install --user awscli
-export PATH=$PATH:$HOME/.local/bin
+aws --version
 
-branch=${TRAVIS_BRANCH}
 commit=$(git rev-parse --short ${TRAVIS_COMMIT})
 account_id=$(aws sts get-caller-identity --output text --query 'Account')
 region_id=us-east-1
 registry_url=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit}
 
 eval $(aws ecr get-login --no-include-email --region ${region_id})
-docker build --build-arg BRANCH=${branch} --build-arg COMMIT=${commit} \
-    -t zilliqa:${commit} docker
+docker build --build-arg COMMIT=${commit} -t zilliqa:${commit} docker
 docker build -t ${registry_url} -<<EOF
 FROM zilliqa:${commit}
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -32,4 +29,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 EOF
 
 docker push ${registry_url}
-

--- a/scripts/make_image.sh
+++ b/scripts/make_image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script is used for making image locally and pushing to private registry
+
+# Usage:
+#     ./scripts/make_image.sh         # using current HEAD
+#     ./scripts/make_image.sh COMMIT  # using a specific commit
+
+if [ ! -d .git ]
+then
+    echo "$0 should be run from project root directory"
+    echo "Hint: run it like 'scripts/$(basename $0)'"
+    exit 1
+fi
+
+commit=$1
+
+if [ -z "$commit" ]
+then
+    commit=$(git rev-parse HEAD)
+fi
+
+echo "Making images using commit $commit"
+
+github_commit=https://github.com/Zilliqa/Zilliqa/commit/$commit
+
+curl -sf $github_commit > /dev/null
+
+if [ $? != 0 ]
+then
+    echo "Checking '$github_commit' failed. Have you pushed the commit '$commit'?"
+    exit 1
+fi
+
+TRAVIS_COMMIT=$commit ./scripts/ci_make_image.sh

--- a/scripts/make_image.sh
+++ b/scripts/make_image.sh
@@ -12,6 +12,15 @@ then
     exit 1
 fi
 
+if [ "$EUID" -eq 0 ]
+then
+    echo "Please do not run as root"
+    echo
+    echo "If you see docker permission error previously, check if you have sudo-less docker."
+    echo "See https://docs.docker.com/install/linux/linux-postinstall"
+    exit 1
+fi
+
 commit=$1
 
 if [ -z "$commit" ]
@@ -25,10 +34,16 @@ github_commit=https://github.com/Zilliqa/Zilliqa/commit/$commit
 
 curl -sf $github_commit > /dev/null
 
-if [ $? != 0 ]
+if [ "$?" -ne 0 ]
 then
     echo "Checking '$github_commit' failed. Have you pushed the commit '$commit'?"
     exit 1
 fi
 
 TRAVIS_COMMIT=$commit ./scripts/ci_make_image.sh
+
+if [ "$?" -ne 0 ]
+then
+    echo "Making image failed"
+    exit 1
+fi


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The goal of this PR is to directly create and push the image to private docker registry without waiting for Travis. The main change is in `scripts/make_image.sh` and other modifications are to support it.

The intended usage of this script is

```
# from the project root
./scripts/make_image.sh
# or
./scripts/make_image.sh COMMIT
``` 

The docker image it creates has the same tag as the travis-built one, so the image being pushed will eventually be overwritten by the Travis. This is safe as `scripts/make_image.sh` is actually calling `scripts/ci_make_image.sh` (which is used on travis) to make the same image.

Other minor changes include
- moving `awscli` installation from `scripts/ci_make_image.sh` to `.travis.yaml`
- removing the dockerfile ARG `BRANCH` to reduce the complexity with the price of having to clone the entire repository instead of the last 10 commits on the specified branch
- fixing the issue of the chained commands in dockerfile `RUN` where it didn't' catch the error during the build when using `;` to connect commands

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Go to `scripts/make_image.sh` first and see the rest of the changes in other files.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] implement `scripts/make_image.sh`
- [x] remind user that sudo-less docker is needed
- [x] **ready for review**

### Travis Test
- [x] Passed?

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] small-scale cloud test
