### PR TITLE
Fix heap-use-after-free issue in AccountStore

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -48,9 +48,11 @@
         <FULL_DATASET_MINE>false</FULL_DATASET_MINE>
     </options>
     <smart_contract>
-        <SCILLA_PATH></SCILLA_PATH>
+        <SCILLA_ROOT></SCILLA_ROOT>
+        <SCILLA_BINARY>bin/scilla-runner</SCILLA_BINARY>>
         <SCILLA_FILES>scilla_files</SCILLA_FILES>
         <SCILLA_LOG>_build</SCILLA_LOG>
+        <SCILLA_LIB>src/stdlib</SCILLA_LIB>
         <INIT_JSON>init.json</INIT_JSON>
         <INPUT_STATE_JSON>input_state.json</INPUT_STATE_JSON>
         <INPUT_BLOCKCHAIN_JSON>input_blockchain.json</INPUT_BLOCKCHAIN_JSON>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -61,7 +61,7 @@
         <INPUT_CODE>input.scilla</INPUT_CODE>
     </smart_contract>
     <accounts>
-		<account>
+        <account>
             <wallet_address>cc02a3c906612cc5bdb087a30e6093c9f0aa04fc</wallet_address>
         </account>
     </accounts>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -61,6 +61,9 @@
         <INPUT_CODE>input.scilla</INPUT_CODE>
     </smart_contract>
     <accounts>
+		<account>
+            <wallet_address>cc02a3c906612cc5bdb087a30e6093c9f0aa04fc</wallet_address>
+        </account>
     </accounts>
     <lookups>
         <peer>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -48,9 +48,11 @@
         <FULL_DATASET_MINE>false</FULL_DATASET_MINE>
     </options>
     <smart_contract>
-        <SCILLA_PATH></SCILLA_PATH>
+        <SCILLA_ROOT></SCILLA_ROOT>
+        <SCILLA_BINARY>bin/scilla-runner</SCILLA_BINARY>
         <SCILLA_FILES>scilla_files</SCILLA_FILES>
         <SCILLA_LOG>_build</SCILLA_LOG>
+        <SCILLA_LIB>src/stdlib</SCILLA_LIB>
         <INIT_JSON>init.json</INIT_JSON>
         <INPUT_STATE_JSON>input_state.json</INPUT_STATE_JSON>
         <INPUT_BLOCKCHAIN_JSON>input_blockchain.json</INPUT_BLOCKCHAIN_JSON>
@@ -59,9 +61,6 @@
         <INPUT_CODE>input.scilla</INPUT_CODE>
     </smart_contract>
     <accounts>
-        <account>
-            <wallet_address>cc02a3c906612cc5bdb087a30e6093c9f0aa04fc</wallet_address>
-        </account>
     </accounts>
     <lookups>
         <peer>

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -145,9 +145,13 @@ const std::vector<std::string> GENESIS_WALLETS{
     ReadAccountsFromConstantsFile("wallet_address")};
 const std::vector<std::string> GENESIS_KEYS{
     ReadAccountsFromConstantsFile("private_key")};
-const std::string SCILLA_PATH{ReadSmartContractConstants("SCILLA_PATH")};
+const std::string SCILLA_ROOT{ReadSmartContractConstants("SCILLA_ROOT")};
+const std::string SCILLA_BINARY{SCILLA_ROOT + '/'
+                                + ReadSmartContractConstants("SCILLA_BINARY")};
 const std::string SCILLA_FILES{ReadSmartContractConstants("SCILLA_FILES")};
 const std::string SCILLA_LOG{ReadSmartContractConstants("SCILLA_LOG")};
+const std::string SCILLA_LIB{SCILLA_ROOT + '/'
+                             + ReadSmartContractConstants("SCILLA_LIB")};
 const std::string INIT_JSON{SCILLA_FILES + '/'
                             + ReadSmartContractConstants("INIT_JSON")};
 const std::string INPUT_STATE_JSON{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -97,9 +97,11 @@ const std::string DS_KICKOUT_MSG = "KICKED OUT FROM DS";
 const std::string DS_LEADER_MSG = "DS LEADER NOW";
 const std::string DS_BACKUP_MSG = "DS BACKUP NOW";
 
-extern const std::string SCILLA_PATH;
+extern const std::string SCILLA_ROOT;
+extern const std::string SCILLA_BINARY;
 extern const std::string SCILLA_FILES;
 extern const std::string SCILLA_LOG;
+extern const std::string SCILLA_LIB;
 extern const std::string INIT_JSON;
 extern const std::string INPUT_STATE_JSON;
 extern const std::string INPUT_BLOCKCHAIN_JSON;

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -85,6 +85,16 @@ void Account::InitContract()
         return;
     }
     m_initValJson = root;
+
+    // Append createBlockNum
+    {
+        Json::Value createBlockNumObj;
+        createBlockNumObj["vname"] = "_creation_block";
+        createBlockNumObj["type"] = "BNum";
+        createBlockNumObj["value"] = to_string(GetCreateBlockNum());
+        m_initValJson.append(createBlockNumObj);
+    }
+
     for (auto& v : root)
     {
         if (!v.isMember("vname") || !v.isMember("type") || !v.isMember("value"))

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -48,8 +48,7 @@ void AccountStore::InitSoft()
 
     AccountStoreTrie<OverlayDB, unordered_map<Address, Account>>::Init();
 
-    std::lock_guard<mutex> lock(m_mutexDelta);
-    m_accountStoreTemp->Init();
+    InitTemp();
 }
 
 AccountStore& AccountStore::GetInstance()
@@ -149,6 +148,7 @@ void AccountStore::SerializeDelta()
 unsigned int AccountStore::GetSerializedDelta(vector<unsigned char>& dst)
 {
     // LOG_MARKER();
+    lock_guard<mutex> g(m_mutexDelta);
 
     copy(m_stateDeltaSerialized.begin(), m_stateDeltaSerialized.end(),
          back_inserter(dst));
@@ -365,4 +365,13 @@ void AccountStore::CommitTemp()
 
     // LOG_GENERAL(INFO, "After CommitTemp");
     InitTemp();
+}
+
+void AccountStore::InitTemp()
+{
+    LOG_MARKER();
+
+    lock_guard<mutex> g(m_mutexDelta);
+
+    m_accountStoreTemp->Init();
 }

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -112,7 +112,7 @@ public:
 
     void CommitTemp();
 
-    void InitTemp() { m_accountStoreTemp->Init(); }
+    void InitTemp();
 };
 
 #endif // __ACCOUNTSTORE_H__

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -56,8 +56,7 @@ template<class MAP> class AccountStoreSC : public AccountStoreBase<MAP>
     bool ParseCreateContractJsonOutput(const Json::Value& _json);
     bool ParseCallContractOutput();
     bool ParseCallContractJsonOutput(const Json::Value& _json);
-    Json::Value GetBlockStateJson(const uint64_t& BlockNum,
-                                  const uint64_t& CreateBlockNum = 0) const;
+    Json::Value GetBlockStateJson(const uint64_t& BlockNum) const;
     string GetCreateContractCmdStr();
     string GetCallContractCmdStr();
 

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -28,8 +28,14 @@ template<class MAP> AccountStoreSC<MAP>::AccountStoreSC()
 
 template<class MAP> void AccountStoreSC<MAP>::Init()
 {
+    lock_guard<mutex> g(m_mutexUpdateAccounts);
     AccountStoreBase<MAP>::Init();
     m_curContractAddr.clear();
+    m_curSenderAddr.clear();
+    m_curAmount = 0;
+    m_curGasCum = 0;
+    m_curGasLimit = 0;
+    m_curGasPrice = 0;
 }
 
 template<class MAP>

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -287,8 +287,7 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
 
 template<class MAP>
 Json::Value
-AccountStoreSC<MAP>::GetBlockStateJson(const uint64_t& BlockNum,
-                                       const uint64_t& CreateBlockNum) const
+AccountStoreSC<MAP>::GetBlockStateJson(const uint64_t& BlockNum) const
 {
     Json::Value root;
     Json::Value blockItem;
@@ -296,9 +295,6 @@ AccountStoreSC<MAP>::GetBlockStateJson(const uint64_t& BlockNum,
     blockItem["type"] = "BNum";
     blockItem["value"] = to_string(BlockNum);
     root.append(blockItem);
-    // LOG_GENERAL(INFO, "BNum: " << BlockNum);
-
-    (void)CreateBlockNum;
 
     return root;
 }
@@ -326,9 +322,8 @@ void AccountStoreSC<MAP>::ExportCreateContractFiles(const Account& contract)
     JSONUtils::writeJsontoFile(INIT_JSON, contract.GetInitJson());
 
     // Block Json
-    JSONUtils::writeJsontoFile(
-        INPUT_BLOCKCHAIN_JSON,
-        GetBlockStateJson(m_curBlockNum /*, contract.GetCreateBlockNum()*/));
+    JSONUtils::writeJsontoFile(INPUT_BLOCKCHAIN_JSON,
+                               GetBlockStateJson(m_curBlockNum));
 }
 
 template<class MAP>
@@ -357,9 +352,8 @@ void AccountStoreSC<MAP>::ExportContractFiles(const Account& contract)
     JSONUtils::writeJsontoFile(INPUT_STATE_JSON, contract.GetStorageJson());
 
     // Block Json
-    JSONUtils::writeJsontoFile(
-        INPUT_BLOCKCHAIN_JSON,
-        GetBlockStateJson(m_curBlockNum /*, contract.GetCreateBlockNum()*/));
+    JSONUtils::writeJsontoFile(INPUT_BLOCKCHAIN_JSON,
+                               GetBlockStateJson(m_curBlockNum));
 }
 
 template<class MAP>
@@ -400,19 +394,20 @@ void AccountStoreSC<MAP>::ExportCallContractFiles(
 
 template<class MAP> string AccountStoreSC<MAP>::GetCreateContractCmdStr()
 {
-    string ret = SCILLA_PATH + " -init " + INIT_JSON + " -iblockchain "
-        + INPUT_BLOCKCHAIN_JSON + " -o " + OUTPUT_JSON + " -i " + INPUT_CODE;
-    // LOG_GENERAL(INFO, ret);
+    string ret = SCILLA_BINARY + " -init " + INIT_JSON + " -iblockchain "
+        + INPUT_BLOCKCHAIN_JSON + " -o " + OUTPUT_JSON + " -i " + INPUT_CODE
+        + " -libdir " + SCILLA_LIB;
+    LOG_GENERAL(INFO, ret);
     return ret;
 }
 
 template<class MAP> string AccountStoreSC<MAP>::GetCallContractCmdStr()
 {
-    string ret = SCILLA_PATH + " -init " + INIT_JSON + " -istate "
+    string ret = SCILLA_BINARY + " -init " + INIT_JSON + " -istate "
         + INPUT_STATE_JSON + " -iblockchain " + INPUT_BLOCKCHAIN_JSON
         + " -imessage " + INPUT_MESSAGE_JSON + " -o " + OUTPUT_JSON + " -i "
-        + INPUT_CODE;
-    // LOG_GENERAL(INFO, ret);
+        + INPUT_CODE + " -libdir " + SCILLA_LIB;
+    LOG_GENERAL(INFO, ret);
     return ret;
 }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -922,25 +922,19 @@ void Node::SubmitTransactions()
 
         if (findOneFromCreated(t))
         {
-            if (!m_mediator.m_validator->CheckCreatedTransaction(t))
+            if (m_mediator.m_validator->CheckCreatedTransaction(t)
+                || (t.GetCode().empty() && t.GetData().empty()))
             {
-                if (t.GetCode().empty() && t.GetData().empty())
-                {
-                    continue;
-                }
+                appendOne(t);
             }
-            appendOne(t);
         }
         else if (findOneFromPrefilled(t))
         {
-            if (!m_mediator.m_validator->CheckCreatedTransaction(t))
+            if (m_mediator.m_validator->CheckCreatedTransaction(t)
+                || (t.GetCode().empty() && t.GetData().empty()))
             {
-                if (t.GetCode().empty() && t.GetData().empty())
-                {
-                    continue;
-                }
+                appendOne(t);
             }
-            appendOne(t);
         }
         else
         {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -898,7 +898,7 @@ void Node::SubmitTransactions()
         if (findOneFromCreated(t))
         {
             if (m_mediator.m_validator->CheckCreatedTransaction(t)
-                || (t.GetCode().empty() && t.GetData().empty()))
+                || !t.GetCode().empty() || !t.GetData().empty())
             {
                 appendOne(t);
             }
@@ -906,7 +906,7 @@ void Node::SubmitTransactions()
         else if (findOneFromPrefilled(t))
         {
             if (m_mediator.m_validator->CheckCreatedTransaction(t)
-                || (t.GetCode().empty() && t.GetData().empty()))
+                || !t.GetCode().empty() || !t.GetData().empty())
             {
                 appendOne(t);
             }


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
During test we found that some node crashed due to heap-use-after-free issue in `AccountStoreTemp`, which is actually because of the Inititialization function in `AccountStoreTemp` is not protected by mutex, which lead to usage after the element being deleted in the later invocation in `SubmitTransaction`.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] implement ...
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [ ] local machine test
- [ ] small-scale cloud test
