### PR TITLE
Add mutex to protect AccountStoreTemp Init

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -48,8 +48,7 @@ void AccountStore::InitSoft()
 
     AccountStoreTrie<OverlayDB, unordered_map<Address, Account>>::Init();
 
-    std::lock_guard<mutex> lock(m_mutexDelta);
-    m_accountStoreTemp->Init();
+    InitTemp();
 }
 
 AccountStore& AccountStore::GetInstance()
@@ -149,6 +148,7 @@ void AccountStore::SerializeDelta()
 unsigned int AccountStore::GetSerializedDelta(vector<unsigned char>& dst)
 {
     // LOG_MARKER();
+    lock_guard<mutex> g(m_mutexDelta);
 
     copy(m_stateDeltaSerialized.begin(), m_stateDeltaSerialized.end(),
          back_inserter(dst));
@@ -365,4 +365,13 @@ void AccountStore::CommitTemp()
 
     // LOG_GENERAL(INFO, "After CommitTemp");
     InitTemp();
+}
+
+void AccountStore::InitTemp()
+{
+    LOG_MARKER();
+
+    lock_guard<mutex> g(m_mutexDelta);
+
+    m_accountStoreTemp->Init();
 }

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -112,7 +112,7 @@ public:
 
     void CommitTemp();
 
-    void InitTemp() { m_accountStoreTemp->Init(); }
+    void InitTemp();
 };
 
 #endif // __ACCOUNTSTORE_H__

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -28,8 +28,14 @@ template<class MAP> AccountStoreSC<MAP>::AccountStoreSC()
 
 template<class MAP> void AccountStoreSC<MAP>::Init()
 {
+    lock_guard<mutex> g(m_mutexUpdateAccounts);
     AccountStoreBase<MAP>::Init();
     m_curContractAddr.clear();
+    m_curSenderAddr.clear();
+    m_curAmount = 0;
+    m_curGasCum = 0;
+    m_curGasLimit = 0;
+    m_curGasPrice = 0;
 }
 
 template<class MAP>


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
During test we found that some node crashed due to heap-use-after-free issue in AccountStoreTemp, which is actually because of the Inititialization function in AccountStoreTemp is not protected by mutex, which lead to usage after the element being deleted in the later invocation in SubmitTransaction.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] implement ...
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
