### PR TITLE
Fix cornercase when prechecking consensus message

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -413,7 +413,43 @@ bool DirectoryService::ProcessFinalBlockConsensus(
     // In that case, ANNOUNCE will sleep for a second below
     // If COLLECTIVESIG also comes in, it's then possible COLLECTIVESIG will be processed before ANNOUNCE!
     // So, ANNOUNCE should acquire a lock here
+    {
+        lock_guard<mutex> g(m_mutexConsensus);
 
+        // Wait until in the case that primary sent announcement pretty early
+        if ((m_state == MICROBLOCK_SUBMISSION)
+            || (m_state == FINALBLOCK_CONSENSUS_PREP))
+        {
+            std::unique_lock<std::mutex> cv_lkObject(
+                m_MutexCVFinalBlockConsensusObject);
+
+            if (cv_finalBlockConsensusObject.wait_for(
+                    cv_lkObject,
+                    std::chrono::seconds(FINALBLOCK_CONSENSUS_OBJECT_TIMEOUT))
+                == std::cv_status::timeout)
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Time out while waiting for state transition and "
+                          "consensus object creation ");
+            }
+
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "State transition is completed and consensus object "
+                      "creation. (check for timeout)");
+        }
+
+        if (!CheckState(PROCESS_FINALBLOCKCONSENSUS))
+        {
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "Ignoring consensus message. I am at state " << m_state);
+            return false;
+        }
+    }
+
+    // Consensus messages must be processed in correct sequence as they come in
+    // It is possible for ANNOUNCE to arrive before correct DS state
+    // In that case, state transition will occurs and ANNOUNCE will be processed.
     std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
@@ -451,35 +487,6 @@ bool DirectoryService::ProcessFinalBlockConsensus(
 
     lock_guard<mutex> g(m_mutexConsensus);
 
-    // Wait until in the case that primary sent announcement pretty early
-    if ((m_state == MICROBLOCK_SUBMISSION)
-        || (m_state == FINALBLOCK_CONSENSUS_PREP))
-    {
-        std::unique_lock<std::mutex> cv_lkObject(
-            m_MutexCVFinalBlockConsensusObject);
-
-        if (cv_finalBlockConsensusObject.wait_for(
-                cv_lkObject,
-                std::chrono::seconds(FINALBLOCK_CONSENSUS_OBJECT_TIMEOUT))
-            == std::cv_status::timeout)
-        {
-            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Time out while waiting for state transition and "
-                      "consensus object creation ");
-        }
-
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "State transition is completed and consensus object "
-                  "creation. (check for timeout)");
-    }
-
-    if (!CheckState(PROCESS_FINALBLOCKCONSENSUS))
-    {
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Ignoring consensus message. I am at state " << m_state);
-        return false;
-    }
-
     bool result = m_consensusObject->ProcessMessage(message, offset, from);
 
     ConsensusCommon::State state = m_consensusObject->GetState();
@@ -493,13 +500,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(
     else if (state == ConsensusCommon::State::ERROR)
     {
         LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Oops, no consensus reached - what to do now???");
-        // throw exception();
-        // TODO: no consensus reached
-        // if (m_mode != PRIMARY_DS)
-        // {
-        //     RejoinAsDS();
-        // }
+                  "No consensus reached. Wait for view change. ");
         return false;
     }
     else

--- a/src/libDirectoryService/ShardingPostProcessing.cpp
+++ b/src/libDirectoryService/ShardingPostProcessing.cpp
@@ -238,7 +238,44 @@ bool DirectoryService::ProcessShardingConsensus(
     // In that case, ANNOUNCE will sleep for a second below
     // If COLLECTIVESIG also comes in, it's then possible COLLECTIVESIG will be processed before ANNOUNCE!
     // So, ANNOUNCE should acquire a lock here
+    {
+        lock_guard<mutex> g(m_mutexConsensus);
+        // Wait until in the case that primary sent announcement pretty early
+        if ((m_state == POW2_SUBMISSION)
+            || (m_state == SHARDING_CONSENSUS_PREP))
+        {
+            cv_shardingConsensus.notify_all();
 
+            std::unique_lock<std::mutex> cv_lk(
+                m_MutexCVShardingConsensusObject);
+
+            if (cv_shardingConsensusObject.wait_for(
+                    cv_lk, std::chrono::seconds(CONSENSUS_OBJECT_TIMEOUT))
+                == std::cv_status::timeout)
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Time out while waiting for state transition and "
+                          "consensus object creation ");
+            }
+
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "State transition is completed and consensus object "
+                      "creation. (check for timeout)");
+        }
+
+        // if (m_state != SHARDING_CONSENSUS)
+        if (!CheckState(PROCESS_SHARDINGCONSENSUS))
+        {
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "Ignoring consensus message");
+            return false;
+        }
+    }
+
+    // Consensus messages must be processed in correct sequence as they come in
+    // It is possible for ANNOUNCE to arrive before correct DS state
+    // In that case, state transition will occurs and ANNOUNCE will be processed.
     std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
@@ -410,13 +447,7 @@ bool DirectoryService::ProcessShardingConsensus(
                           m_mediator.m_DSCommittee[i].first));
         }
         LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Oops, no consensus reached - what to do now???");
-        // throw exception();
-        // TODO: no consensus reached
-        // if (m_mode != PRIMARY_DS)
-        // {
-        //     RejoinAsDS();
-        // }
+                  "No consensus reached. Wait for view change");
         return false;
     }
     else

--- a/src/libNode/MicroBlockProcessing.cpp
+++ b/src/libNode/MicroBlockProcessing.cpp
@@ -94,6 +94,52 @@ bool Node::ProcessMicroblockConsensus(const vector<unsigned char>& message,
 #ifndef IS_LOOKUP_NODE
     LOG_MARKER();
 
+    {
+        lock_guard<mutex> g(m_mutexConsensus);
+
+        // Consensus messages must be processed in correct sequence as they come in
+        // It is possible for ANNOUNCE to arrive before correct DS state
+        // In that case, state transition will occurs and ANNOUNCE will be processed.
+
+        if ((m_state == TX_SUBMISSION) || (m_state == TX_SUBMISSION_BUFFER)
+            || (m_state == MICROBLOCK_CONSENSUS_PREP))
+        {
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "Received microblock announcement from shard leader. I "
+                      "will move on to consensus");
+            cv_microblockConsensus.notify_all();
+
+            std::unique_lock<std::mutex> cv_lk(
+                m_MutexCVMicroblockConsensusObject);
+
+            if (cv_microblockConsensusObject.wait_for(
+                    cv_lk, std::chrono::seconds(CONSENSUS_OBJECT_TIMEOUT),
+                    [this] { return (m_state == MICROBLOCK_CONSENSUS); }))
+            {
+                // condition passed without timeout
+            }
+            else
+            {
+                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Time out while waiting for state transition and "
+                          "consensus object creation ");
+            }
+
+            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "State transition is completed and consensus object "
+                      "creation.");
+        }
+    }
+
+    if (!CheckState(PROCESS_MICROBLOCKCONSENSUS))
+    {
+        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Not in MICROBLOCK_CONSENSUS state");
+        return false;
+    }
+
+    // Consensus message must be processed in order. The following will block till it is the right order.
+
     std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
     if (cv_processConsensusMessage.wait_for(
             cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
@@ -107,11 +153,12 @@ bool Node::ProcessMicroblockConsensus(const vector<unsigned char>& message,
                                 "consensus msg.")
                     return false;
                 }
+
                 if (m_consensusObject == nullptr)
                 {
                     LOG_GENERAL(WARNING,
-                                "m_consensusObject is a nullptr. It has not "
-                                "been initialized.")
+                                "m_consensusObject should have been created "
+                                "but it is not")
                     return false;
                 }
                 return m_consensusObject->CanProcessMessage(message, offset);
@@ -128,45 +175,6 @@ bool Node::ProcessMicroblockConsensus(const vector<unsigned char>& message,
     }
 
     lock_guard<mutex> g(m_mutexConsensus);
-
-    // Consensus messages must be processed in correct sequence as they come in
-    // It is possible for ANNOUNCE to arrive before correct DS state
-    // In that case, state transition will occurs and ANNOUNCE will be processed.
-
-    if ((m_state == TX_SUBMISSION) || (m_state == TX_SUBMISSION_BUFFER)
-        || (m_state == MICROBLOCK_CONSENSUS_PREP))
-    {
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Received microblock announcement from shard leader. I "
-                  "will move on to consensus");
-        cv_microblockConsensus.notify_all();
-
-        std::unique_lock<std::mutex> cv_lk(m_MutexCVMicroblockConsensusObject);
-
-        if (cv_microblockConsensusObject.wait_for(
-                cv_lk, std::chrono::seconds(CONSENSUS_OBJECT_TIMEOUT),
-                [this] { return (m_state == MICROBLOCK_CONSENSUS); }))
-        {
-            // condition passed without timeout
-        }
-        else
-        {
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Time out while waiting for state transition and "
-                      "consensus object creation ");
-        }
-
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "State transition is completed and consensus object "
-                  "creation.");
-    }
-
-    if (!CheckState(PROCESS_MICROBLOCKCONSENSUS))
-    {
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Not in MICROBLOCK_CONSENSUS state");
-        return false;
-    }
 
     bool result = m_consensusObject->ProcessMessage(message, offset, from);
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Recall in PR #433, a check for `m_consensusObject == nullptr` was added to the check function before m_consensusObject->canProcessMessage. If it is `nullptr`, the lambda function will return false and it will not enter canProcessMessage. 

However, a corner case may arise when the first announcement came and `m_consensusObject` is not initialized. This will enter the lambda function and return false, resulting in a blocking state enforced by the conditional variable. In normal out of order consensus message, the message will be processed in order and the previous correct ordered message will notify the conditional variable to signal the next ordered message to process.

However, since this is the first message (announcement), there is no notify to unblock the conditional variable, result it to block till timeout. As a result, the node failed to complete the consensus round. In the case of a shard node, it will process final block without processing microblock consensus, resulting the shard node to rejoin the near future (which the same issue may re-occur again)

There can be corner case where `m_consensusObject` is `nullptr`, namely
1. First epoch
2. Shard node rejoining the network

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status
Ready 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] Fix the corner case mentioned above
- [x] Refactor some logging message
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] medium-scale cloud test
