### PR TITLE
Fix/vc ds leader transition

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -259,19 +259,17 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
 
     SetState(DSBLOCK_CONSENSUS);
 
-    if (m_mode != PRIMARY_DS)
+    // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return 
+    // without triggering view change. 
+    std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);
+    if (cv_viewChangeDSBlock.wait_for(cv_lk,
+                                      std::chrono::seconds(VIEWCHANGE_TIME))
+        == std::cv_status::timeout)
     {
-        std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);
-        if (cv_viewChangeDSBlock.wait_for(cv_lk,
-                                          std::chrono::seconds(VIEWCHANGE_TIME))
-            == std::cv_status::timeout)
-        {
-            //View change.
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Initiated DS block view change. ");
-            auto func = [this]() -> void { RunConsensusOnViewChange(); };
-            DetachedFunction(1, func);
-        }
+        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Initiated DS block view change. ");
+        auto func = [this]() -> void { RunConsensusOnViewChange(); };
+        DetachedFunction(1, func);
     }
 }
 

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -259,8 +259,8 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
 
     SetState(DSBLOCK_CONSENSUS);
 
-    // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return 
-    // without triggering view change. 
+    // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
+    // without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);
     if (cv_viewChangeDSBlock.wait_for(cv_lk,
                                       std::chrono::seconds(VIEWCHANGE_TIME))

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -859,6 +859,8 @@ void DirectoryService::RunConsensusOnFinalBlock()
     SetState(FINALBLOCK_CONSENSUS);
     cv_finalBlockConsensusObject.notify_all();
 
+    // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
+    // without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeFinalBlock);
     if (cv_viewChangeFinalBlock.wait_for(cv_lk,
                                          std::chrono::seconds(VIEWCHANGE_TIME))

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -696,8 +696,9 @@ void DirectoryService::RunConsensusOnSharding()
 
     SetState(SHARDING_CONSENSUS);
 
+    // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
+    // without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeSharding);
-
     if (cv_viewChangeSharding.wait_for(cv_lk,
                                        std::chrono::seconds(VIEWCHANGE_TIME))
         == std::cv_status::timeout)


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
View change is triggered via timeout. In DS consensus, if consensus failed and there is a timeout, the existing ds leader does not transit to view change state. This PR fixes this issue. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Reviewer should be familiar with out view change process.  Refer to our bi-weekly blog post https://blog.zilliqa.com/zilliqa-project-update-10-technology-adoption-application-building-865b43ce7fbe and PR https://github.com/Zilliqa/Zilliqa/pull/297

## Status
Ready 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] Removal of `if (m_mode != PRIMARY_DS)` for view change at ds block consensus
- [x] Added comments to describe the view change process
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
