### PR TITLE
Fix consensus object not created in certain cases

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -293,7 +293,6 @@ void DirectoryService::ScheduleShardingConsensus(const unsigned int wait_window)
         }
 
         RunConsensusOnSharding();
-        cv_shardingConsensusObject.notify_all();
     };
 
     DetachedFunction(1, func);

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -258,8 +258,8 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
     }
 
     SetState(DSBLOCK_CONSENSUS);
-    cv_DSBlockConsensusObject.notify_all(); 
-    
+    cv_DSBlockConsensusObject.notify_all();
+
     // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
     // without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -258,7 +258,8 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin)
     }
 
     SetState(DSBLOCK_CONSENSUS);
-
+    cv_DSBlockConsensusObject.notify_all(); 
+    
     // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
     // without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -373,7 +373,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
                 }
 
                 RunConsensusOnDSBlock();
-                cv_DSBlockConsensusObject.notify_all();
             }
         }
         else

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -695,6 +695,7 @@ void DirectoryService::RunConsensusOnSharding()
     }
 
     SetState(SHARDING_CONSENSUS);
+    cv_shardingConsensusObject.notify_all();
 
     // View change will wait for timeout. If conditional variable is notified before timeout, the thread will return
     // without triggering view change.


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Upon creation of consensus object, the corresponding conditional variable should be notify. However, there may be corner cases in the case for ds block consensus where notify is not called. For instance, view change or rejoining calling `RunConsensusOnDSBlock` will not trigger the notify. 

This PR moved the `notify_all` to immediately after creation of consensus object and state transition to avoid any corner case. 

Concretely, in ds block consensus, notify will happen in `RunConsensusOnDSBlock` after `    SetState(DSBLOCK_CONSENSUS)`

In sharding consensus, notify will happen in `RunConsensusOnSharding` after `    SetState(SHARDING_CONSENSUS);`

There is no issue with microblock and view change consensus. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status
Testing

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] As describe above
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
