### PR TITLE
Fix View change cornercase where candidate leader is faulty before vc consensus

### DIFF
--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -85,8 +85,11 @@ void DirectoryService::RunConsensusOnViewChange()
     {
         LOG_GENERAL(INFO, m_mediator.m_DSCommittee.at(i).second);
     }
-    unsigned int newCandidateLeader
-        = 1; // TODO: To be change to a random node using VRF
+    // The intention of adding the counter is to ensure that in the event of a new view change,
+    // where current view change failed, the new candidate leader will faulty candidate leader
+    unsigned int newCandidateLeader = (1 + m_viewChangeCounter)
+        % m_mediator.m_DSCommittee
+              .size(); // TODO: To be change to a random node using VRF
 
     // TODO
     // We compare with empty peer is due to the fact that DSCommittee for yourself is 0.0.0.0 with port 0.

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -85,8 +85,8 @@ void DirectoryService::RunConsensusOnViewChange()
     {
         LOG_GENERAL(INFO, m_mediator.m_DSCommittee.at(i).second);
     }
-    // The intention of adding the counter is to ensure that in the event of a new view change,
-    // where current view change failed, the new candidate leader will faulty candidate leader
+    // The intention of adding the m_viewChangeCounter is to ensure that in the event of a new view change,
+    // where the current view change failed, the new candidate leader will not be the old faulty candidate leader
     unsigned int newCandidateLeader = (1 + m_viewChangeCounter)
         % m_mediator.m_DSCommittee
               .size(); // TODO: To be change to a random node using VRF


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`m_viewChangeCounter` in view change is not being used. This should be used to ensure the candidate leader will be different in the event a view change failed. 

A concretely example will be 
epoch n: leader become faulty
epoch n-x: candidate leader become faulty

At epoch n, leader become faulty. DS committee elect candidate leader (whom failed at epoch n-x) as the new leader. Candidate leader failed to transit the `announcement` as it is faulty. DS committee elect a new candidate leader but this is the same candidate leader. 

Solution: Use `m_viewChangeCounter` to sequentially elect the leader. 
Long time solution: Elect a random candidate leader using a secure random source

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status
Need more testing 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] implement ...
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [ ] local machine test
- [ ] small-scale cloud test
