### PR TITLE
Remove unused LASTDSBLOCKREQUEST and LASTDSBLOCKRESPONSE

### DIFF
--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -51,9 +51,7 @@ enum DSInstructionType : unsigned char
     FINALBLOCKCONSENSUS = 0x06,
     AllPoWConnRequest = 0x07,
     AllPoWConnResponse = 0x08,
-    LastDSBlockRequest = 0x09,
-    LastDSBlockResponse = 0x0A,
-    VIEWCHANGECONSENSUS = 0X0B
+    VIEWCHANGECONSENSUS = 0X09
 };
 
 enum NodeInstructionType : unsigned char

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -60,9 +60,6 @@ class DirectoryService : public Executable, public Broadcastable
         PROCESS_VIEWCHANGECONSENSUS
     };
 
-    std::atomic<bool> m_requesting_last_ds_block;
-    unsigned int BUFFER_TIME_BEFORE_DS_BLOCK_REQUEST = 5;
-
     std::mutex m_mutexConsensus;
 
     bool m_hasAllPoWconns = true;


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In earlier development for RedPrawn (see https://github.com/Zilliqa/Zilliqa/commit/2f76d41e88a1b81b6959a5fb39bb2a965e1d41c7) we added these two messages for use in ProcessPoW2Submission, but have since stopped using them. Removing them now in preparation for PoW merging work. Also removing related variables BUFFER_TIME_BEFORE_DS_BLOCK_REQUEST and m_requesting_last_ds_block.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
