### PR TITLE
Move SetState for POW_SUBMISSION to new epoch

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -323,11 +323,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
 
     m_allPoWConns.clear();
 
-    // Assumption for now: New round of PoW done after every final block
-    // Reset state to be ready to accept new PoW submissions
-    SetState(POW_SUBMISSION);
-    cv_POWSubmission.notify_all();
-
     auto func = [this]() mutable -> void {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "START OF a new EPOCH");
@@ -335,6 +330,9 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
         {
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "[PoW needed]");
+
+            SetState(POW_SUBMISSION);
+            cv_POWSubmission.notify_all();
 
             POW::GetInstance().EthashConfigureLightClient(
                 (uint64_t)m_mediator.m_dsBlockChain


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull -->
Fix issue:
https://github.com/Zilliqa/Issues/issues/126

Simply let the DS call `SetState(POW_SUBMISSION)` only when a new DS epoch is about to begin.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
