### PR TITLE
Enlarge log function name to avoid confusion

### DIFF
--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -58,7 +58,7 @@ public:
     static const size_t MAX_BYTES_TO_DISPLAY = 100;
 
     /// Limits the number of characters of the current function to display.
-    static const size_t MAX_FUNCNAME_LEN = 20;
+    static const size_t MAX_FUNCNAME_LEN = 30;
 
     /// Limits the number of digits of the current thread ID to display.
     static const size_t TID_LEN = 5;


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Recently we have more and more function with long name.
In our log, we only log the name with size=20 and truncate the reminder.
It's easy to confuse because we have many function with same prefix.

Ex.
ProcessFinalBlockConsensus
ProcessFinalBlockConsensusWhenDone
Both above 2 function will be truncated to "ProcessFinalBlockCon" and make confuse.

In this PR, we enlarge the function name size to 30.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
