### PR TITLE
Move sharding serialization code into one place

### DIFF
--- a/src/libDirectoryService/DSBlockMessage.h
+++ b/src/libDirectoryService/DSBlockMessage.h
@@ -1,0 +1,93 @@
+/**
+* Copyright (c) 2018 Zilliqa 
+* This source code is being disclosed to you solely for the purpose of your participation in 
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
+* the protocols and algorithms that are programmed into, and intended by, the code. You may 
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
+* including modifying or publishing the code (or any part of it), and developing or forming 
+* another public or private blockchain network. This source code is provided ‘as is’ and no 
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* and which include a reference to GPLv3 in their program files.
+**/
+
+#ifndef __DSBLOCKMESSAGE_H__
+#define __DSBLOCKMESSAGE_H__
+
+#include "libCrypto/Schnorr.h"
+#include "libNetwork/Peer.h"
+#include "libUtils/SanityChecks.h"
+#include <deque>
+#include <map>
+#include <utility>
+#include <vector>
+
+class ShardingStructure
+{
+    // Sharding structure message format:
+    // [4-byte num of committees]
+    // [4-byte committee size]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   ...
+    // [4-byte committee size]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   ...
+
+public:
+    static unsigned int
+    Serialize(const std::vector<std::map<PubKey, Peer>>& shards,
+              std::vector<unsigned char>& output, unsigned int cur_offset)
+    {
+        LOG_MARKER();
+
+        uint32_t numOfComms = shards.size();
+
+        // 4-byte num of committees
+        Serializable::SetNumber<uint32_t>(output, cur_offset, numOfComms,
+                                          sizeof(uint32_t));
+        cur_offset += sizeof(uint32_t);
+
+        LOG_GENERAL(INFO, "Number of committees = " << numOfComms);
+
+        for (unsigned int i = 0; i < numOfComms; i++)
+        {
+            const std::map<PubKey, Peer>& shard = shards.at(i);
+
+            // 4-byte committee size
+            Serializable::SetNumber<uint32_t>(output, cur_offset, shard.size(),
+                                              sizeof(uint32_t));
+            cur_offset += sizeof(uint32_t);
+
+            LOG_GENERAL(INFO,
+                        "Committee size = " << shard.size() << "\n"
+                                            << "Members:");
+
+            for (auto& kv : shard)
+            {
+                // 33-byte public key
+                kv.first.Serialize(output, cur_offset);
+                cur_offset += PUB_KEY_SIZE;
+
+                // 16-byte ip + 4-byte port
+                kv.second.Serialize(output, cur_offset);
+                cur_offset += IP_SIZE + PORT_SIZE;
+
+                LOG_GENERAL(
+                    INFO,
+                    " PubKey = "
+                        << DataConversion::SerializableToHexStr(kv.first)
+                        << " at " << kv.second.GetPrintableIPAddress()
+                        << " Port: " << kv.second.m_listenPortHost);
+            }
+        }
+
+        return cur_offset;
+    }
+};
+
+#endif // __DSBLOCKMESSAGE_H__

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -28,6 +28,7 @@
 #include <shared_mutex>
 #include <vector>
 
+#include "DSBlockMessage.h"
 #include "common/Broadcastable.h"
 #include "common/Executable.h"
 #include "libConsensus/Consensus.h"
@@ -188,15 +189,10 @@ class DirectoryService : public Executable, public Broadcastable
     void ComposeDSBlock();
 
     // internal calls from RunConsensusOnSharding
-    void
-    SerializeShardingStructure(vector<unsigned char>& sharding_structure) const;
     bool RunConsensusOnShardingWhenDSPrimary();
     bool RunConsensusOnShardingWhenDSBackup();
 
     // internal calls from ProcessShardingConsensus
-    unsigned int
-    SerializeEntireShardingStructure(vector<unsigned char>& sharding_message,
-                                     unsigned int curr_offset);
     bool SendEntireShardingStructureToLookupNodes();
 
     // PoW2 (sharding) consensus functions

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -460,12 +460,12 @@ bool DirectoryService::ShardingValidator(
 
     // [4-byte num of committees]
     // [4-byte committee size]
-    //   [33-byte public key]
-    //   [33-byte public key]
+    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
+    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
     //   ...
     // [4-byte committee size]
-    //   [33-byte public key]
-    //   [33-byte public key]
+    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
+    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
     //   ...
     // ...
     lock_guard<mutex> g(m_mutexAllPoWConns);
@@ -498,6 +498,9 @@ bool DirectoryService::ShardingValidator(
         {
             PubKey memberPubkey(sharding_structure, curr_offset);
             curr_offset += PUB_KEY_SIZE;
+
+            curr_offset
+                += IP_SIZE + PORT_SIZE; // IP and port ignored in this version
 
             auto memberPeer = m_allPoWConns.find(memberPubkey);
             if (memberPeer == m_allPoWConns.end())

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -88,64 +88,6 @@ void DirectoryService::ComputeSharding()
     }
 }
 
-void DirectoryService::SerializeShardingStructure(
-    vector<unsigned char>& sharding_structure) const
-{
-    // Sharding structure message format:
-    // [4-byte num of committees]
-    // [4-byte committee size]
-    //   [33-byte public key]
-    //   [33-byte public key]
-    //   ...
-    // [4-byte committee size]
-    //   [33-byte public key]
-    //   [33-byte public key]
-    //   ...
-
-    uint32_t numOfComms = m_shards.size();
-
-    unsigned int curr_offset = 0;
-
-    Serializable::SetNumber<unsigned int>(sharding_structure, curr_offset,
-                                          m_viewChangeCounter,
-                                          sizeof(unsigned int));
-    curr_offset += sizeof(unsigned int);
-
-    // 4-byte num of committees
-    Serializable::SetNumber<uint32_t>(sharding_structure, curr_offset,
-                                      numOfComms, sizeof(uint32_t));
-    curr_offset += sizeof(uint32_t);
-
-    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Number of committees = " << numOfComms);
-
-    for (unsigned int i = 0; i < numOfComms; i++)
-    {
-        const map<PubKey, Peer>& shard = m_shards.at(i);
-
-        // 4-byte committee size
-        Serializable::SetNumber<uint32_t>(sharding_structure, curr_offset,
-                                          shard.size(), sizeof(uint32_t));
-        curr_offset += sizeof(uint32_t);
-
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Committee size = " << shard.size() << "\n"
-                                      << "Members:");
-
-        for (auto& kv : shard)
-        {
-            kv.first.Serialize(sharding_structure, curr_offset);
-            curr_offset += PUB_KEY_SIZE;
-
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      " PubKey = "
-                          << DataConversion::SerializableToHexStr(kv.first)
-                          << " at " << kv.second.GetPrintableIPAddress()
-                          << " Port: " << kv.second.m_listenPortHost);
-        }
-    }
-}
-
 void DirectoryService::AppendSharingSetupToShardingStructure(
     vector<unsigned char>& sharding_structure, unsigned int curr_offset)
 {
@@ -345,9 +287,9 @@ bool DirectoryService::RunConsensusOnShardingWhenDSPrimary()
     vector<unsigned char> sharding_structure;
 
     ComputeSharding();
-    SerializeShardingStructure(sharding_structure);
 
-    unsigned int txn_sharing_offset = sharding_structure.size();
+    unsigned int txn_sharing_offset
+        = ShardingStructure::Serialize(m_shards, sharding_structure, 0);
     AppendSharingSetupToShardingStructure(sharding_structure,
                                           txn_sharing_offset);
 
@@ -529,8 +471,6 @@ bool DirectoryService::ShardingValidator(
     lock_guard<mutex> g(m_mutexAllPoWConns);
 
     unsigned int curr_offset = 0;
-    // unsigned int viewChangecounter = Serializable::GetNumber<uint32_t>(sharding_structure, curr_offset, sizeof(unsigned int));
-    curr_offset += sizeof(unsigned int);
 
     // 4-byte num of committees
     uint32_t numOfComms = Serializable::GetNumber<uint32_t>(


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another small update to prepare for PoW merging.  This time, I have moved the sharding structure serialization code into one new file called DSBlockMessage.h.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Before this change, we used sharding structure serialization in two places:

- DirectoryService::SendEntireShardingStructureToLookupNodes
- DirectoryService::SerializeShardingStructure

The only difference between the two is that the first one has the IP info for all nodes, while the second one does not.

I have now made just one function now called ShardingStructure::Serialize that has the IP info.  The part of the code that does not need the IP info (DirectoryService::ShardingValidator) can just skip over it for now, to maintain the current behavior.

Regarding the file name DSBlockMessage.h:
When PoW merging is completed, the DS Block message will actually contain three things:
- DS Block
- Sharding structure
- Txn sharing assignments
So, the naming is in preparation for the merging.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
