### PR TITLE
[PoW Merge] Add winner IP to DSBlock to avoid REQUESTALLPOWCONN

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -174,15 +174,15 @@ bool DirectoryService::DSBlockValidator(
     m_pendingDSBlock.reset(new DSBlock(dsblock, 0));
 
     // PoW winner IP
-    Peer deserializedWinnerPeer(dsblock, m_pendingDSBlock->GetSerializedSize());
+    Peer winnerPeer(dsblock, m_pendingDSBlock->GetSerializedSize());
 
-    auto expectedWinnerPeer
+    auto storedMember
         = m_allPoWConns.find(m_pendingDSBlock->GetHeader().GetMinerPubKey());
 
     // I know the winner but the winner IP given by the leader is different!
-    if (expectedWinnerPeer != m_allPoWConns.end())
+    if (storedMember != m_allPoWConns.end())
     {
-        if (expectedWinnerPeer->second != deserializedWinnerPeer)
+        if (storedMember->second != winnerPeer)
         {
             LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "WARNING: Why is the IP of the winner different from "
@@ -194,7 +194,7 @@ bool DirectoryService::DSBlockValidator(
     else
     {
         m_allPoWConns.emplace(m_pendingDSBlock->GetHeader().GetMinerPubKey(),
-                              deserializedWinnerPeer);
+                              winnerPeer);
     }
 
     return true;

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -134,6 +134,17 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary()
     {
         lock_guard<mutex> g(m_mutexPendingDSBlock);
         m_pendingDSBlock->Serialize(m, 0);
+
+        // Add the IP info of the PoW winner so the backups don't need to query this anymore
+        auto winnerPeer = m_allPoWConns.find(
+            m_pendingDSBlock->GetHeader().GetMinerPubKey());
+        if (winnerPeer == m_allPoWConns.end())
+        {
+            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "WARNING: Why don't I know the IP of the winner???");
+            return false;
+        }
+        winnerPeer->second.Serialize(m, m.size());
     }
 
     LOG_STATE("[DSCON][" << std::setw(15) << std::left
@@ -152,29 +163,40 @@ bool DirectoryService::DSBlockValidator(
 {
     LOG_MARKER();
 
+    // Message = [DS block] [PoW winner IP]
+
     // To-do: Put in the logic here for checking the proposed DS block
     lock(m_mutexPendingDSBlock, m_mutexAllPoWConns);
     lock_guard<mutex> g(m_mutexPendingDSBlock, adopt_lock);
     lock_guard<mutex> g2(m_mutexAllPoWConns, adopt_lock);
 
+    // DS block
     m_pendingDSBlock.reset(new DSBlock(dsblock, 0));
 
-    if (m_allPoWConns.find(m_pendingDSBlock->GetHeader().GetMinerPubKey())
-        == m_allPoWConns.end())
+    // PoW winner IP
+    Peer deserializedWinnerPeer(dsblock, m_pendingDSBlock->GetSerializedSize());
+
+    auto expectedWinnerPeer
+        = m_allPoWConns.find(m_pendingDSBlock->GetHeader().GetMinerPubKey());
+
+    // I know the winner but the winner IP given by the leader is different!
+    if (expectedWinnerPeer != m_allPoWConns.end())
     {
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  "Winning node of PoW not inside m_allPoWConns! Getting "
-                  "from ds leader");
-
-        m_hasAllPoWconns = false;
-        std::unique_lock<std::mutex> lk(m_MutexCVAllPowConn);
-
-        RequestAllPoWConn();
-        while (!m_hasAllPoWconns)
+        if (expectedWinnerPeer->second != deserializedWinnerPeer)
         {
-            cv_allPowConns.wait(lk);
+            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+                      "WARNING: Why is the IP of the winner different from "
+                      "what I have in m_allPoWConns???");
+            return false;
         }
     }
+    // I don't know the winner -> store the IP given by the leader
+    else
+    {
+        m_allPoWConns.emplace(m_pendingDSBlock->GetHeader().GetMinerPubKey(),
+                              deserializedWinnerPeer);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another PR in the PoW merging work.

The final plan is to move sharding structure into the DSBLOCK message. The structure will include all the IP info of the nodes, thereby removing the need for REQUESTALLPOWCONN.

But that will come later. Meanwhile, another place where REQUESTALLPOWCONN is used is in DSBLOCK consensus if the DS backup doesn't know the winner's IP.  So, why not just add the winner's IP to the DSBLOCK consensus message?  This PR addresses that.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
