### PR TITLE
[PoW Merge] Use the IPs in the SHARDING consensus announcement

### DIFF
--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -460,12 +460,12 @@ bool DirectoryService::ShardingValidator(
 
     // [4-byte num of committees]
     // [4-byte committee size]
-    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
-    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
     //   ...
     // [4-byte committee size]
-    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
-    //   [33-byte public key] [16-byte ip] [4-byte port] <- IP and port ignored in this version
+    //   [33-byte public key] [16-byte ip] [4-byte port]
+    //   [33-byte public key] [16-byte ip] [4-byte port]
     //   ...
     // ...
     lock_guard<mutex> g(m_mutexAllPoWConns);
@@ -499,48 +499,39 @@ bool DirectoryService::ShardingValidator(
             PubKey memberPubkey(sharding_structure, curr_offset);
             curr_offset += PUB_KEY_SIZE;
 
-            curr_offset
-                += IP_SIZE + PORT_SIZE; // IP and port ignored in this version
+            Peer memberPeer(sharding_structure, curr_offset);
+            curr_offset += IP_SIZE + PORT_SIZE;
 
-            auto memberPeer = m_allPoWConns.find(memberPubkey);
-            if (memberPeer == m_allPoWConns.end())
+            auto storedMember = m_allPoWConns.find(memberPubkey);
+
+            // I know the member but the member IP given by the leader is different!
+            if (storedMember != m_allPoWConns.end())
             {
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          "Shard node not inside m_allPoWConns. "
-                              << memberPeer->second.GetPrintableIPAddress()
-                              << " Port: "
-                              << memberPeer->second.m_listenPortHost);
-
-                m_hasAllPoWconns = false;
-                std::unique_lock<std::mutex> lk(m_MutexCVAllPowConn);
-
-                RequestAllPoWConn();
-                while (!m_hasAllPoWconns)
+                if (storedMember->second != memberPeer)
                 {
-                    cv_allPowConns.wait(lk);
-                }
-                memberPeer = m_allPoWConns.find(memberPubkey);
-
-                if (memberPeer == m_allPoWConns.end())
-                {
-                    LOG_EPOCH(INFO,
-                              to_string(m_mediator.m_currentEpochNum).c_str(),
-                              "Sharding validator error");
-                    // throw exception();
+                    LOG_EPOCH(
+                        WARNING,
+                        to_string(m_mediator.m_currentEpochNum).c_str(),
+                        "WARNING: Why is the IP of the member different from "
+                        "what I have in m_allPoWConns???");
                     return false;
                 }
             }
+            // I don't know the member -> store the IP given by the leader
+            else
+            {
+                m_allPoWConns.emplace(memberPubkey, memberPeer);
+            }
 
             // To-do: Should we check for a public key that's been assigned to more than 1 shard?
-            m_shards.back().emplace(memberPubkey, memberPeer->second);
+            m_shards.back().emplace(memberPubkey, memberPeer);
             m_publicKeyToShardIdMap.emplace(memberPubkey, i);
 
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       " PubKey = "
                           << DataConversion::SerializableToHexStr(memberPubkey)
-                          << " at "
-                          << memberPeer->second.GetPrintableIPAddress()
-                          << " Port: " << memberPeer->second.m_listenPortHost);
+                          << " at " << memberPeer.GetPrintableIPAddress()
+                          << " Port: " << memberPeer.m_listenPortHost);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another PR in the PoW merging work.

In #464 the SHARDING announcement message was updated to contain the IP info, but the IP info was ignored by the DS backup validator to maintain the current behavior.

This PR will change the DS backup validator behavior to start using the IP info. This means we don't need to call REQUESTALLPOWCONN anymore.
 
After this PR, REQUESTALLPOWCONN will be completely unused in the code base. I will submit another PR to finally remove the code related to REQUESTALLPOWCONN.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
The change is quite similar to #465 so you can review the same way.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
