### PR TITLE
Set consensus state to error if there backup has missing txns (at microblock announcement)

### DIFF
--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -374,7 +374,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
             {
                 // Update internal state
                 // =====================
-                m_state = INITIAL; // TODO: replace it by a more specific state
+                m_state = ERROR;
 
                 // Unicast to the leader
                 // =====================


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
When a shard backup received microblock announcement, a shard backup may not have all the transactions proposed in the announcement. In this case, a shard backup will request it from the shard leader. The backup will also set it `m_state` to `initial` and return true from the consensusbackup.  

However, the previous implementation in #426, the backup will only reprocess announcement if `state == ConsensusCommon::State::ERROR`, which is not true in this case. 

In this PR, `m_state` is set to `ERROR` if there is missing txn. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status
To test out in local test and medium-scale cloud test. 

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] medium-scale cloud test
