### PR TITLE
[PoW Merge] Move txn sharing assignments serialization code

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -69,6 +69,9 @@ class DirectoryService : public Executable, public Broadcastable
 
     // Transaction sharing assignments
     std::vector<unsigned char> m_txnSharingMessage;
+    std::vector<Peer> m_DSReceivers;
+    std::vector<std::vector<Peer>> m_shardReceivers;
+    std::vector<std::vector<Peer>> m_shardSenders;
 
     std::mutex m_MutexScheduleFinalBlockConsensus;
     std::condition_variable cv_scheduleFinalBlockConsensus;
@@ -190,6 +193,7 @@ class DirectoryService : public Executable, public Broadcastable
     // PoW2 (sharding) consensus functions
     void RunConsensusOnSharding();
     void ComputeSharding();
+    void ComputeTxnSharingAssignments();
 
     // internal calls from RunConsensusOnDSBlock
     bool RunConsensusOnDSBlockWhenDSPrimary();
@@ -231,8 +235,6 @@ class DirectoryService : public Executable, public Broadcastable
     vector<unsigned char> ComposeFinalBlockMessage();
     bool ParseMessageAndVerifyPOW(const vector<unsigned char>& message,
                                   unsigned int offset, const Peer& from);
-    void AppendSharingSetupToShardingStructure(
-        vector<unsigned char>& finalBlockMessage, unsigned int curr_offset);
     bool CheckWhetherDSBlockIsFresh(const uint64_t dsblock_num);
     bool CheckWhetherMaxSubmissionsReceived(Peer peer, PubKey key);
     bool VerifyPoWSubmission(const vector<unsigned char>& message,

--- a/src/libDirectoryService/ShardingPreProcessing.cpp
+++ b/src/libDirectoryService/ShardingPreProcessing.cpp
@@ -141,7 +141,7 @@ void DirectoryService::ComputeTxnSharingAssignments()
 
         // PART 2
 
-        m_shardReceivers.emplace_back(vector<Peer>());
+        m_shardReceivers.emplace_back();
 
         uint32_t nodes_recv_lo = 0;
         uint32_t nodes_recv_hi = nodes_recv_lo + TX_SHARING_CLUSTER_SIZE - 1;
@@ -153,7 +153,7 @@ void DirectoryService::ComputeTxnSharingAssignments()
 
         unsigned int num_nodes = nodes_recv_hi - nodes_recv_lo + 1;
 
-        map<PubKey, Peer>::const_iterator node_peer = shard.begin();
+        auto node_peer = shard.begin();
         for (unsigned int j = 0; j < num_nodes; j++)
         {
             m_shardReceivers.back().emplace_back(node_peer->second);
@@ -162,7 +162,7 @@ void DirectoryService::ComputeTxnSharingAssignments()
 
         // PART 3
 
-        m_shardSenders.emplace_back(vector<Peer>());
+        m_shardSenders.emplace_back();
 
         uint32_t nodes_send_lo = 0;
         uint32_t nodes_send_hi = 0;


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another PR in the PoW merging work.

This is a similar effort to #464 where sharding info serialization was moved to DSBlockMessage.h.
This time, serialization of txn sharing assignments has been moved to that same file.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
What I basically did was split `AppendSharingSetupToShardingStructure()` into two functions:
- `DirectoryService::ComputeTxnSharingAssignments()` handles the computation part
- `TxnSharingAssignments::Serialize()` handles the serialization part

The assignment algorithm remains the same, except now we have to store the result of the computation part so that we can pass it to the serialization part.  Hence, 3 new member variables `m_DSReceivers`, `m_shardReceivers`, and `m_shardSenders`.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
