### PR TITLE
Adjust log mutex range to avoid potential race-condition from gmtime

### DIFF
--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -21,7 +21,6 @@
 #include <pthread.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-
 using namespace std;
 using namespace g3;
 
@@ -153,8 +152,11 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
 {
     if (IsG3Log())
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         LOG(level) << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                   << put_time(GetCurTime(), "%H:%M:%S") << "]["
+                   << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                   << PAD(get_ms(cur), 3) << "]["
                    << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg;
         return;
     }
@@ -164,16 +166,22 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                  << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
+                  << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
                   << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-             << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
+             << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "] " << msg << endl
              << flush;
     }
 }
@@ -186,17 +194,23 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                  << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
+                  << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
                   << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
                   << "[Epoch " << epoch << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-             << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+             << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "]"
              << "[Epoch " << epoch << "] " << msg << endl
              << flush;
     }
@@ -214,32 +228,40 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
         {
             m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                      << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN)
-                      << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] "
-                      << msg << " (Len=" << payload.size()
+                      << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                      << PAD(get_ms(cur), 3) << "]["
+                      << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                      << " (Len=" << payload.size()
                       << "): " << payload_string.get() << "..." << endl
                       << flush;
         }
         else
         {
             m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                      << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN)
-                      << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] "
-                      << msg << " (Len=" << payload.size()
+                      << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                      << PAD(get_ms(cur), 3) << "]["
+                      << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                      << " (Len=" << payload.size()
                       << "): " << payload_string.get() << endl
                       << flush;
         }
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
+
         if (payload.size() > max_bytes_to_display)
         {
             cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                 << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
+                 << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                 << PAD(get_ms(cur), 3) << "]["
                  << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                  << " (Len=" << payload.size() << "): " << payload_string.get()
                  << "..." << endl
@@ -248,7 +270,8 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
         else
         {
             cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                 << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
+                 << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                 << PAD(get_ms(cur), 3) << "]["
                  << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                  << " (Len=" << payload.size() << "): " << payload_string.get()
                  << endl
@@ -266,17 +289,23 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(tid, TID_LEN) << "]["
-                  << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
+                  << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
                   << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
                   << "[Epoch " << epoch << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(tid, TID_LEN) << "]["
-             << PAD(put_time(GetCurTime(), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+             << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "]"
              << "[Epoch " << epoch << "] " << msg << endl
              << flush;
     }

--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -152,7 +152,7 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
 {
     if (IsG3Log())
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         LOG(level) << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                    << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -166,7 +166,7 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                   << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -176,7 +176,7 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
              << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -194,7 +194,7 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                   << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -205,7 +205,7 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
              << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -228,7 +228,7 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
@@ -254,7 +254,7 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
@@ -289,7 +289,7 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(tid, TID_LEN) << "]["
                   << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")
@@ -300,7 +300,7 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(tid, TID_LEN) << "]["
              << put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:")

--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -25,6 +25,8 @@
 using namespace std;
 using namespace g3;
 
+mutex Logger::m_logMutex;
+
 string MyCustomFormatting(const LogMessage& msg)
 {
     string res = string("[") + msg.level();
@@ -136,7 +138,7 @@ Logger& Logger::GetEpochInfoLogger(const char* fname_prefix, bool log_to_file,
 
 void Logger::LogState(const char* msg, const char*)
 {
-    lock_guard<mutex> guard(m);
+    lock_guard<mutex> guard(m_logMutex);
 
     if (m_logToFile)
     {
@@ -154,6 +156,8 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     std::time_t curTime = std::chrono::system_clock::to_time_t(
         std::chrono::system_clock::now());
 
+    lock_guard<mutex> guard(m_logMutex);
+
     if (IsG3Log())
     {
         LOG(level) << "[TID " << PAD(GetPid(), TID_LEN) << "]["
@@ -161,8 +165,6 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
                    << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg;
         return;
     }
-
-    lock_guard<mutex> guard(m);
 
     if (m_logToFile)
     {
@@ -188,7 +190,7 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     std::time_t curTime = std::chrono::system_clock::to_time_t(
         std::chrono::system_clock::now());
 
-    lock_guard<mutex> guard(m);
+    lock_guard<mutex> guard(m_logMutex);
 
     if (m_logToFile)
     {
@@ -218,7 +220,7 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     std::time_t curTime = std::chrono::system_clock::to_time_t(
         std::chrono::system_clock::now());
 
-    lock_guard<mutex> guard(m);
+    lock_guard<mutex> guard(m_logMutex);
 
     if (m_logToFile)
     {
@@ -274,7 +276,7 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     std::time_t curTime = std::chrono::system_clock::to_time_t(
         std::chrono::system_clock::now());
 
-    lock_guard<mutex> guard(m);
+    lock_guard<mutex> guard(m_logMutex);
 
     if (m_logToFile)
     {

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -38,6 +38,8 @@
 class Logger
 {
 private:
+    std::mutex m_nonG3LogMutex;
+    static std::mutex m_timeMutex;
     bool m_logToFile;
     std::streampos m_maxFileSize;
     std::unique_ptr<g3::LogWorker> logworker;
@@ -129,7 +131,14 @@ public:
                             size_t max_bytes_to_display,
                             std::unique_ptr<char[]>& res);
 
-    static std::mutex m_logMutex;
+    /// Get current time with mutex protection (thread-safe)
+    static struct std::tm* GetCurTime()
+    {
+        std::lock_guard<std::mutex> guard(Logger::m_timeMutex);
+        std::time_t curTime = std::chrono::system_clock::to_time_t(
+            std::chrono::system_clock::now());
+        return gmtime(&curTime);
+    }
 };
 
 /// Utility class for automatically logging function or code block exit.
@@ -163,11 +172,9 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
-            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
-                       << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
+                       << "]["                                                 \
+                       << std::put_time(Logger::GetCurTime(), "%H:%M:%S")      \
                        << "]["                                                 \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)        \
                        << "] " << msg;                                         \
@@ -184,11 +191,9 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
-            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
-                       << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
+                       << "]["                                                 \
+                       << std::put_time(Logger::GetCurTime(), "%H:%M:%S")      \
                        << "]["                                                 \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN) << "]" \
                        << "[Epoch " << epoch << "] " << msg;                   \
@@ -205,17 +210,14 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
-            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&curTime), "%H:%M:%S")      \
+                           << std::put_time(Logger::GetCurTime(), "%H:%M:%S")  \
                            << "]["                                             \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
@@ -225,7 +227,7 @@ public:
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&curTime), "%H:%M:%S")      \
+                           << std::put_time(Logger::GetCurTime(), "%H:%M:%S")  \
                            << "]["                                             \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -38,7 +38,6 @@
 class Logger
 {
 private:
-    std::mutex m;
     bool m_logToFile;
     std::streampos m_maxFileSize;
     std::unique_ptr<g3::LogWorker> logworker;
@@ -129,6 +128,8 @@ public:
     static void GetPayloadS(const std::vector<unsigned char>& payload,
                             size_t max_bytes_to_display,
                             std::unique_ptr<char[]>& res);
+
+    static std::mutex m_logMutex;
 };
 
 /// Utility class for automatically logging function or code block exit.
@@ -164,6 +165,7 @@ public:
         {                                                                      \
             std::time_t curTime = std::chrono::system_clock::to_time_t(        \
                 std::chrono::system_clock::now());                             \
+            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
                        << "]["                                                 \
@@ -184,6 +186,7 @@ public:
         {                                                                      \
             std::time_t curTime = std::chrono::system_clock::to_time_t(        \
                 std::chrono::system_clock::now());                             \
+            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
                        << "]["                                                 \
@@ -207,6 +210,7 @@ public:
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
+            std::lock_guard<std::mutex> guard(Logger::m_logMutex);             \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \
                 LOG(level) << "[TID "                                          \

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -20,6 +20,7 @@
 #include "g3log/g3log.hpp"
 #include "g3log/loglevels.hpp"
 #include "g3log/logworker.hpp"
+#include "libUtils/TimeUtils.h"
 #include <boost/multiprecision/cpp_int.hpp>
 #include <chrono>
 #include <fstream>
@@ -39,7 +40,6 @@ class Logger
 {
 private:
     std::mutex m_nonG3LogMutex;
-    static std::mutex m_timeMutex;
     bool m_logToFile;
     std::streampos m_maxFileSize;
     std::unique_ptr<g3::LogWorker> logworker;
@@ -130,15 +130,6 @@ public:
     static void GetPayloadS(const std::vector<unsigned char>& payload,
                             size_t max_bytes_to_display,
                             std::unique_ptr<char[]>& res);
-
-    /// Get current time with mutex protection (thread-safe)
-    static struct std::tm* GetCurTime()
-    {
-        std::lock_guard<std::mutex> guard(Logger::m_timeMutex);
-        std::time_t curTime = std::chrono::system_clock::to_time_t(
-            std::chrono::system_clock::now());
-        return gmtime(&curTime);
-    }
 };
 
 /// Utility class for automatically logging function or code block exit.
@@ -172,10 +163,12 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
-                       << std::put_time(Logger::GetCurTime(), "%H:%M:%S")      \
-                       << "]["                                                 \
+                       << std::put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:") \
+                       << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)        \
                        << "] " << msg;                                         \
         }                                                                      \
@@ -191,10 +184,12 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
-                       << std::put_time(Logger::GetCurTime(), "%H:%M:%S")      \
-                       << "]["                                                 \
+                       << std::put_time(gmtime_safe(&cur_time_t), "%H:%M:%S:") \
+                       << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN) << "]" \
                        << "[Epoch " << epoch << "] " << msg;                   \
         }                                                                      \
@@ -213,12 +208,15 @@ public:
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(Logger::GetCurTime(), "%H:%M:%S")  \
-                           << "]["                                             \
+                           << std::put_time(gmtime_safe(&cur_time_t),          \
+                                            "%H:%M:%S:")                       \
+                           << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
                            << "): " << payload_string.get() << "...";          \
@@ -227,8 +225,9 @@ public:
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(Logger::GetCurTime(), "%H:%M:%S")  \
-                           << "]["                                             \
+                           << std::put_time(gmtime_safe(&cur_time_t),          \
+                                            "%H:%M:%S:")                       \
+                           << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
                            << "): " << payload_string.get();                   \

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -163,7 +163,7 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
@@ -184,7 +184,7 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
@@ -208,7 +208,7 @@ public:
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \

--- a/src/libUtils/TimeUtils.cpp
+++ b/src/libUtils/TimeUtils.cpp
@@ -15,9 +15,10 @@
 **/
 
 #include "TimeUtils.h"
-
+#include <mutex>
 using namespace std::chrono;
 using namespace boost::multiprecision;
+static std::mutex gmtimeMutex;
 
 system_clock::time_point r_timer_start() { return system_clock::now(); }
 
@@ -32,4 +33,17 @@ uint256_t get_time_as_int()
     microseconds microsecs
         = duration_cast<microseconds>(system_clock::now().time_since_epoch());
     return static_cast<uint256_t>(microsecs.count());
+}
+
+struct tm* gmtime_safe(const time_t* timer)
+{
+    std::lock_guard<std::mutex> guard(gmtimeMutex);
+    return gmtime(timer);
+}
+
+long int get_ms(const time_point<high_resolution_clock> time)
+{
+    return duration_cast<milliseconds>(
+               time - system_clock::from_time_t(system_clock::to_time_t(time)))
+        .count();
 }

--- a/src/libUtils/TimeUtils.cpp
+++ b/src/libUtils/TimeUtils.cpp
@@ -41,7 +41,7 @@ struct tm* gmtime_safe(const time_t* timer)
     return gmtime(timer);
 }
 
-long int get_ms(const time_point<high_resolution_clock> time)
+long int get_ms(const time_point<system_clock>& time)
 {
     return duration_cast<milliseconds>(
                time - system_clock::from_time_t(system_clock::to_time_t(time)))

--- a/src/libUtils/TimeUtils.h
+++ b/src/libUtils/TimeUtils.h
@@ -24,5 +24,7 @@ std::chrono::system_clock::time_point r_timer_start();
 double r_timer_end(std::chrono::system_clock::time_point start_time);
 
 boost::multiprecision::uint256_t get_time_as_int();
-
+struct tm* gmtime_safe(const time_t* timer);
+long int
+get_ms(const std::chrono::time_point<std::chrono::high_resolution_clock> time);
 #endif // __TIMEUTILS_H__

--- a/src/libUtils/TimeUtils.h
+++ b/src/libUtils/TimeUtils.h
@@ -25,6 +25,5 @@ double r_timer_end(std::chrono::system_clock::time_point start_time);
 
 boost::multiprecision::uint256_t get_time_as_int();
 struct tm* gmtime_safe(const time_t* timer);
-long int
-get_ms(const std::chrono::time_point<std::chrono::high_resolution_clock> time);
+long int get_ms(const std::chrono::time_point<std::chrono::system_clock>& time);
 #endif // __TIMEUTILS_H__


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

https://github.com/Zilliqa/Zilliqa/issues/469
By ThreadSanitizer, there is potential race-condition coming from gmtime. Now we adjust the logger mutex to avoid this potential problem.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [ ] local machine test
- [ ] small-scale cloud test
