### PR TITLE
[PoW Merge] Move txn sharing assignments deserialization code

### DIFF
--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -132,160 +132,58 @@ bool Node::ReadVariablesFromShardingMessage(
 void Node::LoadTxnSharingInfo(const vector<unsigned char>& message,
                               unsigned int cur_offset)
 {
-    // Transaction body sharing setup
-    // Everyone (DS and non-DS) needs to remember their sharing assignments for this particular block
-
-    // Transaction body sharing assignments:
-    // PART 1. Select X random nodes from DS committee for receiving Tx bodies and broadcasting to other DS nodes
-    // PART 2. Select X random nodes per shard for receiving Tx bodies and broadcasting to other nodes in the shard
-    // PART 3. Select X random nodes per shard for sending Tx bodies to the receiving nodes in other committees (DS and shards)
-
-    // Message format:
-    // [4-byte num of DS nodes]
-    //   [16-byte IP] [4-byte port]
-    //   [16-byte IP] [4-byte port]
-    //   ...
-    // [4-byte num of committees]
-    // [4-byte num of committee receiving nodes]
-    //   [16-byte IP] [4-byte port]
-    //   [16-byte IP] [4-byte port]
-    //   ...
-    // [4-byte num of committee sending nodes]
-    //   [16-byte IP] [4-byte port]
-    //   [16-byte IP] [4-byte port]
-    //   ...
-    // [4-byte num of committee receiving nodes]
-    //   [16-byte IP] [4-byte port]
-    //   [16-byte IP] [4-byte port]
-    //   ...
-    // [4-byte num of committee sending nodes]
-    //   [16-byte IP] [4-byte port]
-    //   [16-byte IP] [4-byte port]
-    //   ...
-    // ...
     LOG_MARKER();
 
     m_txnSharingIAmSender = false;
     m_txnSharingIAmForwarder = false;
     m_txnSharingAssignedNodes.clear();
 
-    uint32_t num_ds_nodes = Serializable::GetNumber<uint32_t>(
-        message, cur_offset, sizeof(uint32_t));
-    cur_offset += sizeof(uint32_t);
+    vector<Peer> ds_receivers;
+    vector<vector<Peer>> shard_receivers;
+    vector<vector<Peer>> shard_senders;
 
-    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Forwarders inside the DS committee (" << num_ds_nodes << "):");
+    TxnSharingAssignments::Deserialize(message, cur_offset, ds_receivers,
+                                       shard_receivers, shard_senders);
 
-    m_txnSharingAssignedNodes.push_back(vector<Peer>());
+    // m_txnSharingAssignedNodes below is basically just the combination of ds_receivers, shard_receivers, and shard_senders
+    // We will get rid of this inefficiency eventually
 
-    for (unsigned int i = 0; i < num_ds_nodes; i++)
+    m_txnSharingAssignedNodes.emplace_back();
+
+    for (unsigned int i = 0; i < ds_receivers.size(); i++)
     {
-        m_txnSharingAssignedNodes.back().push_back(Peer(message, cur_offset));
-        cur_offset += IP_SIZE + PORT_SIZE;
-
-        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                  m_txnSharingAssignedNodes.back().back());
+        m_txnSharingAssignedNodes.back().emplace_back(ds_receivers.at(i));
     }
 
-    uint32_t num_shards = Serializable::GetNumber<uint32_t>(message, cur_offset,
-                                                            sizeof(uint32_t));
-    cur_offset += sizeof(uint32_t);
-
-    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Number of shards: " << num_shards);
-
-    for (unsigned int i = 0; i < num_shards; i++)
+    for (unsigned int i = 0; i < shard_receivers.size(); i++)
     {
-        if (i == m_myShardID)
+        m_txnSharingAssignedNodes.emplace_back();
+
+        for (unsigned int j = 0; j < shard_receivers.at(i).size(); j++)
         {
-            m_txnSharingAssignedNodes.push_back(vector<Peer>());
+            m_txnSharingAssignedNodes.back().emplace_back(
+                shard_receivers.at(i).at(j));
 
-            uint32_t num_recv = Serializable::GetNumber<uint32_t>(
-                message, cur_offset, sizeof(uint32_t));
-            cur_offset += sizeof(uint32_t);
-
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "  Shard " << i << " forwarders:");
-
-            for (unsigned int j = 0; j < num_recv; j++)
+            if ((i == m_myShardID)
+                && (m_txnSharingAssignedNodes.back().back()
+                    == m_mediator.m_selfPeer))
             {
-                m_txnSharingAssignedNodes.back().push_back(
-                    Peer(message, cur_offset));
-                cur_offset += IP_SIZE + PORT_SIZE;
-
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          m_txnSharingAssignedNodes.back().back());
-
-                if (m_txnSharingAssignedNodes.back().back()
-                    == m_mediator.m_selfPeer)
-                {
-                    m_txnSharingIAmForwarder = true;
-                }
-            }
-
-            m_txnSharingAssignedNodes.push_back(vector<Peer>());
-
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "  Shard " << i << " senders:");
-
-            uint32_t num_send = Serializable::GetNumber<uint32_t>(
-                message, cur_offset, sizeof(uint32_t));
-            cur_offset += sizeof(uint32_t);
-
-            for (unsigned int j = 0; j < num_send; j++)
-            {
-                m_txnSharingAssignedNodes.back().push_back(
-                    Peer(message, cur_offset));
-                cur_offset += IP_SIZE + PORT_SIZE;
-
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          m_txnSharingAssignedNodes.back().back());
-
-                if (m_txnSharingAssignedNodes.back().back()
-                    == m_mediator.m_selfPeer)
-                {
-                    m_txnSharingIAmSender = true;
-                }
+                m_txnSharingIAmForwarder = true;
             }
         }
-        else
+
+        m_txnSharingAssignedNodes.emplace_back();
+
+        for (unsigned int j = 0; j < shard_senders.at(i).size(); j++)
         {
-            m_txnSharingAssignedNodes.push_back(vector<Peer>());
+            m_txnSharingAssignedNodes.back().emplace_back(
+                shard_senders.at(i).at(j));
 
-            uint32_t num_recv = Serializable::GetNumber<uint32_t>(
-                message, cur_offset, sizeof(uint32_t));
-            cur_offset += sizeof(uint32_t);
-
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "  Shard " << i << " forwarders:");
-
-            for (unsigned int j = 0; j < num_recv; j++)
+            if ((i == m_myShardID)
+                && (m_txnSharingAssignedNodes.back().back()
+                    == m_mediator.m_selfPeer))
             {
-                m_txnSharingAssignedNodes.back().push_back(
-                    Peer(message, cur_offset));
-                cur_offset += IP_SIZE + PORT_SIZE;
-
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          m_txnSharingAssignedNodes.back().back());
-            }
-
-            m_txnSharingAssignedNodes.push_back(vector<Peer>());
-
-            LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "  Shard " << i << " senders:");
-
-            uint32_t num_send = Serializable::GetNumber<uint32_t>(
-                message, cur_offset, sizeof(uint32_t));
-            cur_offset += sizeof(uint32_t);
-
-            for (unsigned int j = 0; j < num_send; j++)
-            {
-                m_txnSharingAssignedNodes.back().push_back(
-                    Peer(message, cur_offset));
-                cur_offset += IP_SIZE + PORT_SIZE;
-
-                LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                          m_txnSharingAssignedNodes.back().back());
+                m_txnSharingIAmSender = true;
             }
         }
     }


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another PR in the PoW merging work.

Finally, after #464, #474, and #476, txn sharing info deserialization is now moved to DSBlockMessage.h.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

The deserialization code is straightforward.  There are two places where it is now called:

1. The DS backup during sharding announcement (`SaveTxnBodySharingAssignment`)
2. The Node during sharding message processing (`LoadTxnSharingInfo`)

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
