### PR TITLE
[PoW Merge] Update SHARDING message sent to Node

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -176,8 +176,8 @@ class DirectoryService : public Executable, public Broadcastable
     SetupMulticastConfigForShardingStructure(unsigned int& my_DS_cluster_num,
                                              unsigned int& my_shards_lo,
                                              unsigned int& my_shards_hi);
-    void SendingShardingStructureToShard(
-        vector<std::map<PubKey, Peer>>::iterator& p);
+    void SendEntireShardingStructureToShardNodes(unsigned int my_shards_lo,
+                                                 unsigned int my_shards_hi);
 
     // PoW (DS block) consensus functions
     void RunConsensusOnDSBlock(bool isRejoin = false);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -187,10 +187,6 @@ class Node : public Executable, public Broadcastable
                                  unsigned int offset, const Peer& from);
 #endif // IS_LOOKUP_NODE
 
-    // internal call from ProcessSharding
-    bool ReadVariablesFromShardingMessage(const vector<unsigned char>& message,
-                                          unsigned int& offset);
-
     // internal calls from ActOnFinalBlock for NODE_FORWARD_ONLY and SEND_AND_FORWARD
     void LoadForwardingAssignmentFromFinalBlock(
         const vector<Peer>& fellowForwarderNodes, const uint64_t& blocknum);
@@ -257,6 +253,8 @@ class Node : public Executable, public Broadcastable
     void ScheduleTxnSubmission();
     void ScheduleMicroBlockConsensus();
     void BeginNextConsensusRound();
+    bool LoadShardingStructure(const vector<unsigned char>& message,
+                               unsigned int& cur_offset);
     void LoadTxnSharingInfo(const vector<unsigned char>& message,
                             unsigned int cur_offset);
     void CallActOnFinalBlockBasedOnSenderForwarderAssgn(uint8_t shard_id);


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Another PR in the PoW merging work.

Now we can use the sharding structure serialization (#464) and deserialization (#476) functions in the part where the DS nodes send the SHARDING message to the shard nodes after PoW2 consensus.

To do this, we have to change the SHARDING message a bit.  Currently, it contains only the portion of the sharding structure that is relevant to the shard nodes.  Now, to be able to reuse the serialization/deserialization functions, the message will contain the entire sharding structure.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] ~~small-scale cloud test~~
