### PR TITLE
Travis build speed-up and improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
     install: # left blank
     - pip install --user awscli
     - export PATH=$PATH:$HOME/.local/bin
-    cache: # left blank
+    cache: false
     script:
     - $BUILD_COMMAND
     after_success: # left blank

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,15 @@ add_compile_options(-Werror)
 add_compile_options(-Wextra)
 
 if (ENABLE_COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+    if (NOT TESTS)
+        message(FATAL_ERROR "TESTS is not ON")
+    endif()
     include(CodeCoverage)
     add_compile_options(--coverage)
     link_libraries(--coverage)
     add_custom_target(ctest COMMAND ${CMAKE_CTEST_COMMAND})
-    setup_target_for_coverage(${PROJECT_NAME}_coverage ctest coverage)
+    # TODO: remove the hardcoded number in -j option
+    setup_target_for_coverage(${PROJECT_NAME}_coverage ctest coverage "-j2;--output-on-failure")
 endif()
 
 add_subdirectory (src)

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -27,20 +27,25 @@ esac
 echo "n_parallel=${n_parallel}"
 
 echo "ccache configuration"
+ccache --version
+ccache -M 5G
 ccache -p
 
+ccache -z
 echo "ccache status"
 ccache -s
 
 # assume that it is run from project root directory
 mkdir build && cd build
-cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON -DENABLE_COVERAGE=ON ..
+cmake ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=Debug -DTESTS=ON -DENABLE_COVERAGE=ON ..
 make -j${n_parallel}
 make clang-format
-ctest --output-on-failure -j${n_parallel}
 if [ "$os" = "Linux" ]
 then
-    make -j${n_parallel} Zilliqa_coverage
+    # this target already include "ctest" command, see cmake/CodeCoverage.cmake
+    make Zilliqa_coverage
+else
+    ctest --output-on-failure -j${n_parallel}
 fi
 
 echo "ccache status"

--- a/scripts/ci_report_coverage.sh
+++ b/scripts/ci_report_coverage.sh
@@ -6,7 +6,4 @@
 set -e
 
 # assume that it is run from project root directory
-lcov --gcov-tool gcov-5 --directory . --capture --output-file coverage.info
-lcov --gcov-tool gcov-5 --remove coverage.info '/usr/*' --output-file coverage.info
-lcov --gcov-tool gcov-5 --list coverage.info
 bash <(curl -s https://codecov.io/bash) -g '/usr/**' -x gcov-5 || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The main contribution of this PR is to fix Zilliqa/Issues#124. The previous way of doing code coverage has several issues:
- The target `Zilliqa_coverage` already includes the `lcov` commands listed in `scripts/ci_report_coverage.sh`, 
https://github.com/Zilliqa/Zilliqa/blob/14be39234c99d772affff9bd6c71ff931a8c5053/cmake/CodeCoverage.cmake#L157-L160. So the duplicated command in `scripts/ci_report_coverage.sh` is removed.
- The code coverage prefer `Debug` build to have more accurate coverage report. There was some [discussion](https://github.com/Zilliqa/Zilliqa/pull/58#issuecomment-393599408) about this already. This may increase the `ctest` time a bit but in it's not a majority of the Travis build time.
- In `scripts/ci_build.sh`, we are running `ctest` twice, one via explicitly callinig `ctest`, and the other one via implicitly calling `make Zilliqa_coverage`. This is unnecessary and has been corrected.

The `ccache` configuration also have one issue:

- The setting `max_size` is reported to be ~500MB previously on Linux build jobs while Mac build is using 5GB. Since mac build works fine with 5GB, now explicitly set it to `5GB` via `ccache -M`

## Future Work

The `deploy` stage is not using any cache mechanism. It's now becoming the majority of the build time.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

See the description above and the [build log](https://travis-ci.com/Zilliqa/Zilliqa/builds/80195020?utm_source=github_status&utm_medium=notification) to verify the speed-up.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] ~~local machine test~~
- [x] ~~small-scale cloud test~~
