### PR TITLE
Fix parseOutput for value with string type

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -553,7 +553,9 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json)
         }
         string vname = s["vname"].asString();
         string type = s["type"].asString();
-        string value = JSONUtils::convertJsontoStr(s["value"]);
+        string value = s["value"].isString()
+            ? s["value"].asString()
+            : JSONUtils::convertJsontoStr(s["value"]);
 
         Account* contractAccount = this->GetAccount(m_curContractAddr);
         if (vname != "_balance")


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Previously in order to handle output from interpreter of for Json arrayValue or objectValue, we converted the output with `JSON::Utils::convertJsonToStr`. But for plain string type, this will add extra `\"` around the value. This PR is to solve this issue.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [ ] local machine test
- [ ] small-scale cloud test
