### PR TITLE
Move CallActOnFinalblock before BeginNextRound

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1498,6 +1498,7 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
     m_mediator.UpdateTxBlockRand();
 
 #ifndef IS_LOOKUP_NODE
+    CallActOnFinalBlockBasedOnSenderForwarderAssgn(shard_id);
 
     if (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)
     {
@@ -1510,8 +1511,6 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
 
         DetachedFunction(1, main_func);
     }
-
-    CallActOnFinalBlockBasedOnSenderForwarderAssgn(shard_id);
 #else // IS_LOOKUP_NODE
     if (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)
     {


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
There will be situations when RunConsensusOnMicroblock happens earlier than CallActOnFinalblock, especially in vacuous epoch. In that case, the states delta will be calculated based on last epoch before initializing. This PR will reverse the order of CallActOnFinalblock force it being called before running consensus.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
