### PR TITLE
[fix] TxBlockListing read currBlockNum from m_txBlockChain not m_dsBlockChain

### DIFF
--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -907,7 +907,7 @@ Json::Value Server::TxBlockListing(unsigned int page)
     LOG_MARKER();
 
     uint64_t currBlockNum
-        = m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
+        = m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
     Json::Value _json;
 
     auto maxPages = (currBlockNum / PAGE_SIZE) + 1;


### PR DESCRIPTION
Server::TxBlockListing is returning the wrong TX Block count due to reading DS instead of TX Blockchain.
