### PR TITLE
Set m_numShards after deserializing the sharding structure

### DIFF
--- a/src/libNode/ShardingInfoProcessing.cpp
+++ b/src/libNode/ShardingInfoProcessing.cpp
@@ -50,6 +50,7 @@ bool Node::LoadShardingStructure(const vector<unsigned char>& message,
 {
     vector<map<PubKey, Peer>> shards;
     cur_offset = ShardingStructure::Deserialize(message, cur_offset, shards);
+    m_numShards = shards.size();
 
     // Check the shard ID against the deserialized structure
     if (m_myShardID >= shards.size())


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This is the fix for https://github.com/Zilliqa/Issues/issues/136
`m_numShards` should be set after deserializing the sharding structure.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [ ] small-scale cloud test
