### PR TITLE
Use standard libevent procedure

### DIFF
--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -264,6 +264,8 @@ bool P2PComm::SendMessageSocketCore(const Peer& peer,
     serv_addr.sin_addr.s_addr = peer.m_ipAddress.convert_to<unsigned long>();
     serv_addr.sin_port = htons(peer.m_listenPortHost);
 
+    signal(SIGPIPE, SIG_IGN);
+
     struct event_base* base = event_base_new();
     struct bufferevent* bev
         = bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
@@ -308,8 +310,6 @@ bool P2PComm::SendMessageSocketCore(const Peer& peer,
                                   (unsigned char)((length >> 16) & 0xFF),
                                   (unsigned char)((length >> 8) & 0xFF),
                                   (unsigned char)(length & 0xFF)};
-
-    signal(SIGPIPE, SIG_IGN);
 
     if (HDR_LEN != writeMsg(buf, cli_sock, peer, HDR_LEN))
     {

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -264,8 +264,6 @@ bool P2PComm::SendMessageSocketCore(const Peer& peer,
     serv_addr.sin_addr.s_addr = peer.m_ipAddress.convert_to<unsigned long>();
     serv_addr.sin_port = htons(peer.m_listenPortHost);
 
-    signal(SIGPIPE, SIG_IGN);
-
     struct event_base* base = event_base_new();
     struct bufferevent* bev
         = bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
@@ -310,6 +308,8 @@ bool P2PComm::SendMessageSocketCore(const Peer& peer,
                                   (unsigned char)((length >> 16) & 0xFF),
                                   (unsigned char)((length >> 8) & 0xFF),
                                   (unsigned char)(length & 0xFF)};
+
+    signal(SIGPIPE, SIG_IGN);
 
     if (HDR_LEN != writeMsg(buf, cli_sock, peer, HDR_LEN))
     {

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -16,7 +16,6 @@
 
 #include <cstring>
 #include <errno.h>
-#include <event2/bufferevent.h>
 #include <event2/event.h>
 #include <event2/listener.h>
 #include <memory>
@@ -55,6 +54,15 @@ struct hash_compare
         return equal(l.begin(), l.end(), r.begin());
     }
 };
+
+static void close_socket(int* cli_sock)
+{
+    if (cli_sock != NULL)
+    {
+        shutdown(*cli_sock, SHUT_RDWR);
+        close(*cli_sock);
+    }
+}
 
 static bool comparePairSecond(
     const pair<vector<unsigned char>, chrono::time_point<chrono::system_clock>>&
@@ -233,6 +241,7 @@ namespace
     {
         return (buf[2] << 24) + (buf[3] << 16) + (buf[4] << 8) + buf[5];
     }
+
 } // anonymous namespace
 
 bool P2PComm::SendMessageSocketCore(const Peer& peer,
@@ -258,95 +267,95 @@ bool P2PComm::SendMessageSocketCore(const Peer& peer,
         return true;
     }
 
-    struct sockaddr_in serv_addr;
-    memset(&serv_addr, 0, sizeof(struct sockaddr_in));
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = peer.m_ipAddress.convert_to<unsigned long>();
-    serv_addr.sin_port = htons(peer.m_listenPortHost);
-
-    struct event_base* base = event_base_new();
-    struct bufferevent* bev
-        = bufferevent_socket_new(base, -1, BEV_OPT_CLOSE_ON_FREE);
-    if (bufferevent_socket_connect(bev, (struct sockaddr*)&serv_addr,
-                                   sizeof(struct sockaddr_in))
-        < 0)
+    try
     {
-        LOG_GENERAL(WARNING,
-                    "Socket connect failed. Code = "
-                        << errno << " Desc: " << std::strerror(errno)
-                        << ". IP address: " << peer);
-        return false;
-    }
+        int cli_sock = socket(AF_INET, SOCK_STREAM, 0);
+        unique_ptr<int, void (*)(int*)> cli_sock_closer(&cli_sock,
+                                                        close_socket);
 
-    evutil_socket_t cli_sock = bufferevent_getfd(bev);
+        // LINUX HAS NO SO_NOSIGPIPE
+        //int set = 1;
+        //setsockopt(cli_sock, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+        signal(SIGPIPE, SIG_IGN);
+        if (cli_sock < 0)
+        {
+            LOG_GENERAL(WARNING,
+                        "Socket creation failed. Code = "
+                            << errno << " Desc: " << std::strerror(errno)
+                            << ". IP address: " << peer);
+            return false;
+        }
 
-    // Transmission format:
-    // 0x01 ~ 0xFF - version, defined in constant file
-    // 0x11 - start byte
-    // 0xLL 0xLL 0xLL 0xLL - 4-byte length of message
-    // <message>
+        struct sockaddr_in serv_addr;
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_addr.s_addr
+            = peer.m_ipAddress.convert_to<unsigned long>();
+        serv_addr.sin_port = htons(peer.m_listenPortHost);
 
-    // 0x01 ~ 0xFF - version, defined in constant file
-    // 0x22 - start byte (broadcast)
-    // 0xLL 0xLL 0xLL 0xLL - 4-byte length of hash + message
-    // <32-byte hash> <message>
+        if (connect(cli_sock, (struct sockaddr*)&serv_addr, sizeof(serv_addr))
+            < 0)
+        {
+            LOG_GENERAL(WARNING,
+                        "Socket connect failed. Code = "
+                            << errno << " Desc: " << std::strerror(errno)
+                            << ". IP address: " << peer);
+            return false;
+        }
 
-    // 0x01 ~ 0xFF - version, defined in constant file
-    // 0x33 - start byte (report)
-    // 0x00 0x00 0x00 0x01 - 4-byte length of message
-    // 0x00
-    uint32_t length = message.size();
+        // Transmission format:
+        // 0x01 ~ 0xFF - version, defined in constant file
+        // 0x11 - start byte
+        // 0xLL 0xLL 0xLL 0xLL - 4-byte length of message
+        // <message>
 
-    if (start_byte == START_BYTE_BROADCAST)
-    {
-        length += HASH_LEN;
-    }
+        // 0x01 ~ 0xFF - version, defined in constant file
+        // 0x22 - start byte (broadcast)
+        // 0xLL 0xLL 0xLL 0xLL - 4-byte length of hash + message
+        // <32-byte hash> <message>
 
-    unsigned char buf[HDR_LEN] = {(unsigned char)(MSG_VERSION & 0xFF),
-                                  start_byte,
-                                  (unsigned char)((length >> 24) & 0xFF),
-                                  (unsigned char)((length >> 16) & 0xFF),
-                                  (unsigned char)((length >> 8) & 0xFF),
-                                  (unsigned char)(length & 0xFF)};
+        // 0x01 ~ 0xFF - version, defined in constant file
+        // 0x33 - start byte (report)
+        // 0x00 0x00 0x00 0x01 - 4-byte length of message
+        // 0x00
+        uint32_t length = message.size();
 
-    signal(SIGPIPE, SIG_IGN);
+        if (start_byte == START_BYTE_BROADCAST)
+        {
+            length += HASH_LEN;
+        }
 
-    if (HDR_LEN != writeMsg(buf, cli_sock, peer, HDR_LEN))
-    {
-        LOG_GENERAL(WARNING, "Cannot write header message.");
+        unsigned char buf[HDR_LEN] = {(unsigned char)(MSG_VERSION & 0xFF),
+                                      start_byte,
+                                      (unsigned char)((length >> 24) & 0xFF),
+                                      (unsigned char)((length >> 16) & 0xFF),
+                                      (unsigned char)((length >> 8) & 0xFF),
+                                      (unsigned char)(length & 0xFF)};
 
-        event_base_dispatch(base);
-        bufferevent_free(bev);
-        event_base_free(base);
-        return false;
-    }
+        if (HDR_LEN != writeMsg(buf, cli_sock, peer, HDR_LEN))
+        {
+            LOG_GENERAL(INFO, "DEBUG: not written_length == " << HDR_LEN);
+        }
 
-    if (start_byte != START_BYTE_BROADCAST)
-    {
+        if (start_byte != START_BYTE_BROADCAST)
+        {
+            writeMsg(&message.at(0), cli_sock, peer, length);
+            return true;
+        }
+
+        if (HASH_LEN != writeMsg(&msg_hash.at(0), cli_sock, peer, HASH_LEN))
+        {
+            LOG_GENERAL(WARNING, "Wrong message hash length.");
+            return false;
+        }
+
+        length -= HASH_LEN;
         writeMsg(&message.at(0), cli_sock, peer, length);
-
-        event_base_dispatch(base);
-        bufferevent_free(bev);
-        event_base_free(base);
-        return true;
     }
-
-    if (HASH_LEN != writeMsg(&msg_hash.at(0), cli_sock, peer, HASH_LEN))
+    catch (const std::exception& e)
     {
-        LOG_GENERAL(WARNING, "Cannot write hash message.");
-
-        event_base_dispatch(base);
-        bufferevent_free(bev);
-        event_base_free(base);
+        LOG_GENERAL(WARNING, "Error with write socket." << ' ' << e.what());
         return false;
     }
-
-    length -= HASH_LEN;
-    writeMsg(&message.at(0), cli_sock, peer, length);
-
-    event_base_dispatch(base);
-    bufferevent_free(bev);
-    event_base_free(base);
     return true;
 }
 
@@ -373,6 +382,8 @@ void P2PComm::HandleAcceptedConnection(int cli_sock, Peer from)
     //LOG_MARKER();
 
     LOG_GENERAL(INFO, "Incoming message from " << from);
+
+    SocketCloser cli_sock_closer(&cli_sock, close_socket);
 
     // Reception format:
     // 0x01 ~ 0xFF - version, defined in constant file
@@ -412,12 +423,13 @@ void P2PComm::HandleAcceptedConnection(int cli_sock, Peer from)
 
     if (startByte == START_BYTE_BROADCAST)
     {
-        HandleAcceptedConnectionBroadcast(cli_sock, from,
-                                          messageLength(header));
+        HandleAcceptedConnectionBroadcast(cli_sock, from, messageLength(header),
+                                          move(cli_sock_closer));
     }
     else if (startByte == START_BYTE_NORMAL)
     {
-        HandleAcceptedConnectionNormal(cli_sock, from, messageLength(header));
+        HandleAcceptedConnectionNormal(cli_sock, from, messageLength(header),
+                                       move(cli_sock_closer));
     }
     else
     {
@@ -427,7 +439,8 @@ void P2PComm::HandleAcceptedConnection(int cli_sock, Peer from)
 }
 
 void P2PComm::HandleAcceptedConnectionNormal(int cli_sock, Peer from,
-                                             uint32_t message_length)
+                                             uint32_t message_length,
+                                             SocketCloser cli_sock_closer)
 {
     vector<unsigned char> message;
 
@@ -436,11 +449,14 @@ void P2PComm::HandleAcceptedConnectionNormal(int cli_sock, Peer from,
         return;
     }
 
+    cli_sock_closer.reset(); // close socket now so it can be reused
+
     m_dispatcher(message, from);
 }
 
 void P2PComm::HandleAcceptedConnectionBroadcast(int cli_sock, Peer from,
-                                                uint32_t message_length)
+                                                uint32_t message_length,
+                                                SocketCloser cli_sock_closer)
 {
     vector<unsigned char> msg_hash;
 
@@ -480,6 +496,8 @@ void P2PComm::HandleAcceptedConnectionBroadcast(int cli_sock, Peer from,
             }
         }
     }
+
+    cli_sock_closer.reset(); // close socket now so it can be reused
 
     if (found)
     {

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -43,7 +43,7 @@ const unsigned int HDR_LEN = 6;
 const unsigned int HASH_LEN = 32;
 
 P2PComm::Dispatcher P2PComm::m_dispatcher;
-P2PComm::Broadcast_list_func P2PComm::m_broadcast_list_retriever;
+P2PComm::BroadcastListFunc P2PComm::m_broadcast_list_retriever;
 
 /// Comparison operator for ordering the list of message hashes.
 struct hash_compare
@@ -157,7 +157,7 @@ namespace
         uint32_t read_length = 0;
         uint32_t retryDuration = 1;
 
-        while (read_length != message_length)
+        while (read_length < message_length)
         {
             ssize_t n = read(cli_sock, &buf->at(read_length),
                              message_length - read_length);
@@ -202,7 +202,7 @@ namespace
     {
         uint32_t written_length = 0;
 
-        while (written_length != message_length)
+        while (written_length < message_length)
         {
             ssize_t n = write(cli_sock, (unsigned char*)buf + written_length,
                               message_length - written_length);
@@ -553,7 +553,7 @@ void P2PComm::ConnectionAccept([[gnu::unused]] evconnlistener* listener,
 }
 
 void P2PComm::StartMessagePump(uint32_t listen_port_host, Dispatcher dispatcher,
-                               Broadcast_list_func broadcast_list_retriever)
+                               BroadcastListFunc broadcast_list_retriever)
 {
     LOG_MARKER();
 

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -94,23 +94,27 @@ public:
     /// Returns the singleton P2PComm instance.
     static P2PComm& GetInstance();
 
+    using Dispatcher
+        = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
+
+    using Broadcast_list_func = std::function<std::vector<Peer>(
+        unsigned char msg_type, unsigned char ins_type, const Peer&)>;
+
     /// Receives incoming message and assigns to designated message dispatcher.
     static void HandleAcceptedConnection(int cli_sock, Peer from);
 
 private:
-    using Dispatcher
-        = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
+    using SocketCloser = std::unique_ptr<int, void (*)(int*)>;
     static Dispatcher m_dispatcher;
-
-    using Broadcast_list_func = std::function<std::vector<Peer>(
-        unsigned char msg_type, unsigned char ins_type, const Peer&)>;
     static Broadcast_list_func m_broadcast_list_retriever;
 
     static void HandleAcceptedConnectionNormal(int cli_sock, Peer from,
-                                               uint32_t message_length);
+                                               uint32_t message_length,
+                                               SocketCloser cli_sock_closer);
 
     static void HandleAcceptedConnectionBroadcast(int cli_sock, Peer from,
-                                                  uint32_t message_length);
+                                                  uint32_t message_length,
+                                                  SocketCloser cli_sock_closer);
 
 public:
     /// Accept TCP connection for libevent usage

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -18,6 +18,7 @@
 #define __P2PCOMM_H__
 
 #include <deque>
+#include <event2/util.h>
 #include <functional>
 #include <mutex>
 #include <set>
@@ -27,6 +28,8 @@
 #include "common/Constants.h"
 #include "libUtils/Logger.h"
 #include "libUtils/ThreadPool.h"
+
+struct evconnlistener;
 
 /// Provides network layer functionality.
 class P2PComm
@@ -115,7 +118,10 @@ private:
 
 public:
     /// Accept TCP connection for libevent usage
-    static void ConnectionAccept(int serv_sock, short event, void* arg);
+    static void ConnectionAccept(evconnlistener* listener,
+                                 evutil_socket_t cli_sock,
+                                 struct sockaddr* cli_addr, int socklen,
+                                 void* arg);
 
     /// Listens for incoming socket connections.
     void StartMessagePump(uint32_t listen_port_host, Dispatcher dispatcher,

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -28,10 +28,6 @@
 #include "libUtils/Logger.h"
 #include "libUtils/ThreadPool.h"
 
-typedef std::function<std::vector<Peer>(unsigned char msg_type,
-                                        unsigned char ins_type, const Peer&)>
-    broadcast_list_func;
-
 /// Provides network layer functionality.
 class P2PComm
 {
@@ -98,23 +94,24 @@ public:
     using Dispatcher
         = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
 
+    using Broadcast_list_func = std::function<std::vector<Peer>(
+        unsigned char msg_type, unsigned char ins_type, const Peer&)>;
+
     /// Receives incoming message and assigns to designated message dispatcher.
-    static void
-    HandleAcceptedConnection(int cli_sock, Peer from, Dispatcher dispatcher,
-                             broadcast_list_func broadcast_list_retriever);
+    static void HandleAcceptedConnection(int cli_sock, Peer from);
 
 private:
     using SocketCloser = std::unique_ptr<int, void (*)(int*)>;
+    static Dispatcher m_dispatcher;
+    static Broadcast_list_func m_broadcast_list_retriever;
 
     static void HandleAcceptedConnectionNormal(int cli_sock, Peer from,
-                                               Dispatcher dispatcher,
                                                uint32_t message_length,
                                                SocketCloser cli_sock_closer);
 
-    static void HandleAcceptedConnectionBroadcast(
-        int cli_sock, Peer from, Dispatcher dispatcher,
-        broadcast_list_func broadcast_list_retriever, uint32_t message_length,
-        SocketCloser cli_sock_closer);
+    static void HandleAcceptedConnectionBroadcast(int cli_sock, Peer from,
+                                                  uint32_t message_length,
+                                                  SocketCloser cli_sock_closer);
 
 public:
     /// Accept TCP connection for libevent usage
@@ -122,7 +119,7 @@ public:
 
     /// Listens for incoming socket connections.
     void StartMessagePump(uint32_t listen_port_host, Dispatcher dispatcher,
-                          broadcast_list_func broadcast_list_retriever);
+                          Broadcast_list_func broadcast_list_retriever);
 
     /// Multicasts message to specified list of peers.
     void SendMessage(const std::vector<Peer>& peers,

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -97,7 +97,7 @@ public:
     using Dispatcher
         = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
 
-    using Broadcast_list_func = std::function<std::vector<Peer>(
+    using BroadcastListFunc = std::function<std::vector<Peer>(
         unsigned char msg_type, unsigned char ins_type, const Peer&)>;
 
     /// Receives incoming message and assigns to designated message dispatcher.
@@ -106,7 +106,7 @@ public:
 private:
     using SocketCloser = std::unique_ptr<int, void (*)(int*)>;
     static Dispatcher m_dispatcher;
-    static Broadcast_list_func m_broadcast_list_retriever;
+    static BroadcastListFunc m_broadcast_list_retriever;
 
     static void HandleAcceptedConnectionNormal(int cli_sock, Peer from,
                                                uint32_t message_length,
@@ -125,7 +125,7 @@ public:
 
     /// Listens for incoming socket connections.
     void StartMessagePump(uint32_t listen_port_host, Dispatcher dispatcher,
-                          Broadcast_list_func broadcast_list_retriever);
+                          BroadcastListFunc broadcast_list_retriever);
 
     /// Multicasts message to specified list of peers.
     void SendMessage(const std::vector<Peer>& peers,

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -94,27 +94,23 @@ public:
     /// Returns the singleton P2PComm instance.
     static P2PComm& GetInstance();
 
-    using Dispatcher
-        = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
-
-    using Broadcast_list_func = std::function<std::vector<Peer>(
-        unsigned char msg_type, unsigned char ins_type, const Peer&)>;
-
     /// Receives incoming message and assigns to designated message dispatcher.
     static void HandleAcceptedConnection(int cli_sock, Peer from);
 
 private:
-    using SocketCloser = std::unique_ptr<int, void (*)(int*)>;
+    using Dispatcher
+        = std::function<void(const std::vector<unsigned char>&, const Peer&)>;
     static Dispatcher m_dispatcher;
+
+    using Broadcast_list_func = std::function<std::vector<Peer>(
+        unsigned char msg_type, unsigned char ins_type, const Peer&)>;
     static Broadcast_list_func m_broadcast_list_retriever;
 
     static void HandleAcceptedConnectionNormal(int cli_sock, Peer from,
-                                               uint32_t message_length,
-                                               SocketCloser cli_sock_closer);
+                                               uint32_t message_length);
 
     static void HandleAcceptedConnectionBroadcast(int cli_sock, Peer from,
-                                                  uint32_t message_length,
-                                                  SocketCloser cli_sock_closer);
+                                                  uint32_t message_length);
 
 public:
     /// Accept TCP connection for libevent usage


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Since P2PComm implementation is based on libevent, some standard procedure should be followed, in order to improve maintenance and readability.

1. Re-factor reading, apply event_base & evconnlistener to handle socket bind()/listen()/accept()
2. For writing part, it's unnecessary to re-factor to libevent-style because there is no obviously performance gain however will cause SIGPIPE problem for socket closing
3. Wrap socket read() & write() function to be more modularize
4. For EAGAIN error raised in non-blocking read(), allow to retry
5. Make Dispatcher and Broadcast_list_func as P2PComm member variables

Follow-up PR: provide blacklist API in P2PComm

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] small-scale cloud test
- [x] large-scale cloud test
