### PR TITLE
Updated new node joining after removal of PoW2 phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Zilliqa is a new blockchain platform capable of processing thousands of transact
 
 ## Available Features
 The current release has the following features implemented:
-* Proof of Work 1 (PoW1) and 2 (PoW2) for joining the network
+* Proof of Work (PoW) for joining the network
 * Network sharding
 * Directory Service
-* Consensus for DS block, Sharding structure, Shard Microblock and Final block 
+* Consensus for DS block (with sharding structure), Shard microblock and Final block 
 * [EC-Schnorr signature](https://en.wikipedia.org/wiki/Schnorr_signature)
 * Data layer and accounts store 
 * Looking up nodes to allow new nodes to join 

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -83,7 +83,10 @@ enum LookupInstructionType : unsigned char
     SETLOOKUPOFFLINE = 0x0E,
     SETLOOKUPONLINE = 0x0F,
     GETOFFLINELOOKUPS = 0x10,
-    SETOFFLINELOOKUPS = 0x11
+    SETOFFLINELOOKUPS = 0x11,
+    RAISESTARTPOW = 0x12,
+    GETSTARTPOWFROMSEED = 0x13,
+    SETSTARTPOWFROMSEED = 0x14
 };
 
 enum TxSharingMode : unsigned char

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -396,16 +396,30 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
                           "Waiting "
                               << POW_WINDOW_IN_SECONDS
                               << " seconds, accepting PoW submissions...");
-                this_thread::sleep_for(chrono::seconds(POW_WINDOW_IN_SECONDS));
+
+                // Notify lookup that it's time to do PoW
+                vector<unsigned char> startpow_message = {
+                    MessageType::LOOKUP, LookupInstructionType::RAISESTARTPOW};
+                m_mediator.m_lookup->SendMessageToLookupNodesSerial(
+                    startpow_message);
+
+                // New nodes poll DSInfo from the lookups every NEW_NODE_SYNC_INTERVAL
+                // So let's add that to our wait time to allow new nodes to get SETSTARTPOW and submit a PoW
+                this_thread::sleep_for(chrono::seconds(
+                    NEW_NODE_SYNC_INTERVAL + POW_WINDOW_IN_SECONDS));
+
                 RunConsensusOnDSBlock();
             }
             else
             {
                 std::unique_lock<std::mutex> cv_lk(m_MutexCVDSBlockConsensus);
 
+                // New nodes poll DSInfo from the lookups every NEW_NODE_SYNC_INTERVAL
+                // So let's add that to our wait time to allow new nodes to get SETSTARTPOW and submit a PoW
                 if (cv_DSBlockConsensus.wait_for(
                         cv_lk,
-                        std::chrono::seconds(POW_BACKUP_WINDOW_IN_SECONDS))
+                        std::chrono::seconds(NEW_NODE_SYNC_INTERVAL
+                                             + POW_BACKUP_WINDOW_IN_SECONDS))
                     == std::cv_status::timeout)
                 {
                     LOG_GENERAL(INFO,

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -73,6 +73,11 @@ class Lookup : public Executable, public Broadcastable
 
     std::mutex m_mutexOfflineLookups;
 
+    // Start PoW variables
+    bool m_receivedRaiseStartPoW = false;
+    std::mutex m_MutexCVStartPoWSubmission;
+    std::condition_variable cv_startPoWSubmission;
+
     // Rsync the lost txBodies from remote lookup nodes if this lookup are doing its recovery
     Peer GetLookupPeerToRsync();
 
@@ -216,6 +221,13 @@ public:
 
     bool ProcessSetOfflineLookups(const std::vector<unsigned char>& message,
                                   unsigned int offset, const Peer& from);
+
+    bool ProcessRaiseStartPoW(const std::vector<unsigned char>& message,
+                              unsigned int offset, const Peer& from);
+    bool ProcessGetStartPoWFromSeed(const std::vector<unsigned char>& message,
+                                    unsigned int offset, const Peer& from);
+    bool ProcessSetStartPoWFromSeed(const std::vector<unsigned char>& message,
+                                    unsigned int offset, const Peer& from);
 
     bool Execute(const std::vector<unsigned char>& message, unsigned int offset,
                  const Peer& from);

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -164,7 +164,8 @@ bool POW::EthashConfigureLightClient(uint64_t block_number)
     {
         LOG_GENERAL(WARNING,
                     "WARNING: How come the latest block number is smaller than "
-                    "current block number.  block_number: "
+                    "current block number? block_number: "
+                        << block_number
                         << " currentBlockNum: " << currentBlockNum);
     }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This was the old way:
1. New node sends `GETDSBLOCKFROMSEED` and `GETTXBLOCKFROMSEED` periodically to Lookup
2. New node receives `SETDSBLOCKFROMSEED`
    If next epoch number will be for PoW -> New node sends `GETDSINFOFROMSEED` to Lookup
3. New node receives `SETTXBLOCKFROMSEED`
    If next epoch number will be for PoW -> New node sends `GETSTATEFROMSEED` to Lookup
4. New node receives `SETDSINFOFROMSEED` and `SETSTATEFROMSEED`
5. If New node received `SETDSINFOFROMSEED` within `POW_WINDOW_IN_SECONDS` -> `InitMining()`

This is the new way:
1. New node sends `GETDSBLOCKFROMSEED` and `GETTXBLOCKFROMSEED` periodically to Lookup
2. New node receives `SETDSBLOCKFROMSEED`
3. New node receives `SETTXBLOCKFROMSEED`
    If next epoch number will be for PoW -> New node sends `GETSTATEFROMSEED` to Lookup
4. New node receives `SETSTATEFROMSEED`
    New node sends `GETDSINFOFROMSEED` to Lookup
5. New node receives `GETDSINFOFROMSEED`
    If next epoch number will be for PoW -> New node sends `GETSTARTPOWFROMSEED` to Lookup
6. Lookup waits for `RAISESTARTPOW` from DS leader before replying to New node
7. DS leader sends `RAISESTARTPOW` to Lookup when the leader is ready to receive PoW
8. Lookup sends `SETSTARTPOWFROMSEED` to New node
9. If New node receives `SETSTARTPOWFROMSEED` -> `InitMining()`

README has also been updated

Tested in both local and small-scale by adding new nodes on-the-fly.

The back-door message `DOREJOIN` has not been updated for a while I think, so inducing rejoin in the middle of a node's execution has not been tested.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Follow the description above while you go through the code changes.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] small-scale cloud test
- [x] large-scale cloud test