### PR TITLE
Change the calling order of Node::Install() to avoid null pointer dereference issue under recovery mode

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -64,10 +64,10 @@ void addBalanceToGenesisAccount()
     }
 }
 
-Node::Node(Mediator& mediator, unsigned int syncType, bool toRetrieveHistory)
+Node::Node(Mediator& mediator, [[gnu::unused]] unsigned int syncType,
+           [[gnu::unused]] bool toRetrieveHistory)
     : m_mediator(mediator)
 {
-    this->Install(syncType, toRetrieveHistory);
 }
 
 Node::~Node() {}

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -80,6 +80,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
 
     m_validator = make_shared<Validator>(m_mediator);
     m_mediator.RegisterColleagues(&m_ds, &m_n, &m_lookup, m_validator.get());
+    m_n.Install(syncType, toRetrieveHistory);
 
     LogSelfNodeInfo(key, peer);
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR fixes the null pointer deference issue when zilliqa is running with recovery option enabled (`<1 if recovery, 0 otherwise>`). This fix won't have any side-effect when recovery option is disabled.

Related discussions:

- fix Zilliqa/Issues#141
- fix Zilliqa/Issues#142

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Read the analysis in Zilliqa/Issues#142

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [x] local machine test
- [x] small-scale cloud test
