### PR TITLE
Modify log message and avoid terminate program when lookup cannot rec…

### DIFF
--- a/src/libData/BlockChainData/BlockChain.h
+++ b/src/libData/BlockChainData/BlockChain.h
@@ -88,9 +88,11 @@ public:
 
         if (m_blocks[blockNum].GetHeader().GetBlockNum() != blockNum)
         {
-            LOG_GENERAL(FATAL,
-                        "assertion failed (" << __FILE__ << ":" << __LINE__
-                                             << ": " << __FUNCTION__ << ")");
+            LOG_GENERAL(WARNING,
+                        "BlockNum : "
+                            << blockNum << " != GetBlockNum() : "
+                            << m_blocks[blockNum].GetHeader().GetBlockNum());
+            return T();
         }
 
         return m_blocks[blockNum];


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
As https://github.com/Zilliqa/Issues/issues/148 and https://github.com/Zilliqa/Issues/issues/149 discussed, sometimes lookup node cannot received final block on time.
In this PR, we remove the FATAL message that will cause program termination and allow user to handle this situation by themselves.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->
- [ ] local machine test
- [ ] small-scale cloud test
