### PR TITLE
Make SafeMath as template

### DIFF
--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -601,7 +601,7 @@ int Account::DeserializeDelta(const vector<unsigned char>& src,
 
 bool Account::IncreaseBalance(const uint256_t& delta)
 {
-    return SafeMath::add(m_balance, delta, m_balance);
+    return SafeMath<uint256_t>::add(m_balance, delta, m_balance);
 }
 
 bool Account::DecreaseBalance(const uint256_t& delta)
@@ -611,7 +611,7 @@ bool Account::DecreaseBalance(const uint256_t& delta)
         return false;
     }
 
-    return SafeMath::sub(m_balance, delta, m_balance);
+    return SafeMath<uint256_t>::sub(m_balance, delta, m_balance);
 }
 
 bool Account::ChangeBalance(const int256_t& delta)

--- a/src/libData/AccountData/AccountStoreBase.tpp
+++ b/src/libData/AccountData/AccountStoreBase.tpp
@@ -204,13 +204,13 @@ bool AccountStoreBase<MAP>::CalculateGasRefund(const uint256_t& gasDeposit,
                                                uint256_t& gasRefund)
 {
     uint256_t gasFee;
-    if (!SafeMath::mul(gasUnit, gasPrice, gasFee))
+    if (!SafeMath<uint256_t>::mul(gasUnit, gasPrice, gasFee))
     {
         LOG_GENERAL(WARNING, "gasUnit * transaction.GetGasPrice() overflow!");
         return false;
     }
 
-    if (!SafeMath::sub(gasDeposit, gasFee, gasRefund))
+    if (!SafeMath<uint256_t>::sub(gasDeposit, gasFee, gasRefund))
     {
         LOG_GENERAL(WARNING, "gasDeposit - gasFee overflow!");
         return false;

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -54,8 +54,8 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
 
     // FIXME: Possible integer overflow here
     uint256_t gasDeposit;
-    if (!SafeMath::mul(transaction.GetGasLimit(), transaction.GetGasPrice(),
-                       gasDeposit))
+    if (!SafeMath<uint256_t>::mul(transaction.GetGasLimit(),
+                                  transaction.GetGasPrice(), gasDeposit))
     {
         return false;
     }

--- a/src/libUtils/SafeMath.h
+++ b/src/libUtils/SafeMath.h
@@ -20,11 +20,19 @@
 #include "Logger.h"
 #include <boost/multiprecision/cpp_int.hpp>
 
+/// Important: SafeMath ONLY support positive value!!!
+
 template<class T> class SafeMath
 {
 public:
     static bool mul(const T& a, const T& b, T& result)
     {
+        if (a < 0 || b < 0)
+        {
+            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
+            return false;
+        }
+
         if (a == 0)
         {
             result = 0;
@@ -43,6 +51,12 @@ public:
 
     static bool div(const T& a, const T& b, T& result)
     {
+        if (a < 0 || b < 0)
+        {
+            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
+            return false;
+        }
+
         if (b <= 0)
         {
             LOG_GENERAL(WARNING, "Denominator cannot be zero!");
@@ -61,6 +75,12 @@ public:
 
     static bool sub(const T& a, const T& b, T& result)
     {
+        if (a < 0 || b < 0)
+        {
+            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
+            return false;
+        }
+
         if (b > a)
         {
             LOG_GENERAL(WARNING, "Invalid Subtraction for Unsigned Integer!");
@@ -73,8 +93,15 @@ public:
 
     static bool add(const T& a, const T& b, T& result)
     {
+        if (a < 0 || b < 0)
+        {
+            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
+            return false;
+        }
+
         T c = a + b;
-        if (c - a != b)
+
+        if (c < a || c < b)
         {
             LOG_GENERAL(WARNING, "Addition Overflow!");
             return false;

--- a/src/libUtils/SafeMath.h
+++ b/src/libUtils/SafeMath.h
@@ -27,13 +27,7 @@ template<class T> class SafeMath
 public:
     static bool mul(const T& a, const T& b, T& result)
     {
-        if (a < 0 || b < 0)
-        {
-            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
-            return false;
-        }
-
-        if (a == 0)
+        if (a == 0 || b == 0)
         {
             result = 0;
             return true;
@@ -51,13 +45,7 @@ public:
 
     static bool div(const T& a, const T& b, T& result)
     {
-        if (a < 0 || b < 0)
-        {
-            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
-            return false;
-        }
-
-        if (b <= 0)
+        if (b == 0)
         {
             LOG_GENERAL(WARNING, "Denominator cannot be zero!");
             return false;
@@ -75,33 +63,52 @@ public:
 
     static bool sub(const T& a, const T& b, T& result)
     {
-        if (a < 0 || b < 0)
+        if (a == b)
         {
-            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
+            result = 0;
+            return true;
+        }
+
+        T aa = a, bb = b;
+        bool bPos = true;
+
+        if (a < b)
+        {
+            bPos = false;
+            aa = b;
+            bb = a;
+        }
+
+        if (aa == 0)
+        {
+            result = bPos ? (0 - bb) : bb;
+            return true;
+        }
+
+        if (bb == 0)
+        {
+            result = bPos ? aa : (0 - aa);
+            return true;
+        }
+
+        T c = aa - bb;
+
+        if (aa > 0 && bb < 0 && (c < aa || c < (0 - bb)))
+        {
+            LOG_GENERAL(WARNING, "Subtraction Overflow!");
             return false;
         }
 
-        if (b > a)
-        {
-            LOG_GENERAL(WARNING, "Invalid Subtraction for Unsigned Integer!");
-            return false;
-        }
-
-        result = a - b;
+        result = bPos ? c : (0 - c);
         return true;
     }
 
     static bool add(const T& a, const T& b, T& result)
     {
-        if (a < 0 || b < 0)
-        {
-            LOG_GENERAL(WARNING, "SafeMath only support positive value!");
-            return false;
-        }
-
         T c = a + b;
 
-        if (c < a || c < b)
+        if ((a > 0 && b > 0 && (c < a || c < b))
+            || (a < 0 && b < 0 && (c > a || c > b)))
         {
             LOG_GENERAL(WARNING, "Addition Overflow!");
             return false;

--- a/src/libUtils/SafeMath.h
+++ b/src/libUtils/SafeMath.h
@@ -20,12 +20,10 @@
 #include "Logger.h"
 #include <boost/multiprecision/cpp_int.hpp>
 
-class SafeMath
+template<class T> class SafeMath
 {
 public:
-    static bool mul(const boost::multiprecision::uint256_t& a,
-                    const boost::multiprecision::uint256_t& b,
-                    boost::multiprecision::uint256_t& result)
+    static bool mul(const T& a, const T& b, T& result)
     {
         if (a == 0)
         {
@@ -33,7 +31,7 @@ public:
             return true;
         }
 
-        boost::multiprecision::uint256_t c = a * b;
+        T c = a * b;
         if (c / a != b)
         {
             LOG_GENERAL(WARNING, "Multiplication Overflow!");
@@ -43,9 +41,7 @@ public:
         return true;
     }
 
-    static bool div(const boost::multiprecision::uint256_t& a,
-                    const boost::multiprecision::uint256_t& b,
-                    boost::multiprecision::uint256_t& result)
+    static bool div(const T& a, const T& b, T& result)
     {
         if (b <= 0)
         {
@@ -53,7 +49,7 @@ public:
             return false;
         }
 
-        boost::multiprecision::uint256_t c = a / b;
+        T c = a / b;
         if (a != b * c + a % b)
         {
             return false;
@@ -63,9 +59,7 @@ public:
         return true;
     }
 
-    static bool sub(const boost::multiprecision::uint256_t& a,
-                    const boost::multiprecision::uint256_t& b,
-                    boost::multiprecision::uint256_t& result)
+    static bool sub(const T& a, const T& b, T& result)
     {
         if (b > a)
         {
@@ -77,11 +71,9 @@ public:
         return true;
     }
 
-    static bool add(const boost::multiprecision::uint256_t& a,
-                    const boost::multiprecision::uint256_t& b,
-                    boost::multiprecision::uint256_t& result)
+    static bool add(const T& a, const T& b, T& result)
     {
-        boost::multiprecision::uint256_t c = a + b;
+        T c = a + b;
         if (c - a != b)
         {
             LOG_GENERAL(WARNING, "Addition Overflow!");

--- a/tests/Utils/CMakeLists.txt
+++ b/tests/Utils/CMakeLists.txt
@@ -57,3 +57,8 @@ add_executable(Test_IPConverter Test_IPConverter.cpp)
 target_include_directories(Test_IPConverter PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_IPConverter LINK_PUBLIC Utils)
 add_test(NAME Test_IPConverter COMMAND Test_IPConverter)
+
+add_executable(Test_SafeMath Test_SafeMath.cpp)
+target_include_directories(Test_SafeMath PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries (Test_SafeMath PUBLIC Utils)
+add_test(NAME Test_SafeMath COMMAND Test_SafeMath)

--- a/tests/Utils/Test_SafeMath.cpp
+++ b/tests/Utils/Test_SafeMath.cpp
@@ -1,0 +1,536 @@
+/**
+* Copyright (c) 2018 Zilliqa 
+* This source code is being disclosed to you solely for the purpose of your participation in 
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
+* the protocols and algorithms that are programmed into, and intended by, the code. You may 
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
+* including modifying or publishing the code (or any part of it), and developing or forming 
+* another public or private blockchain network. This source code is provided ‘as is’ and no 
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* and which include a reference to GPLv3 in their program files.
+**/
+
+#include "libUtils/Logger.h"
+#include "libUtils/SafeMath.h"
+
+#define BOOST_TEST_MODULE safemath
+#include <boost/test/included/unit_test.hpp>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(safemath)
+
+BOOST_AUTO_TEST_CASE(test_uint8_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test uint8_t start...");
+
+    uint8_t num1 = 0x0F, num2 = 0x0B, addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::add(num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::sub(addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::sub(addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = 0xFF;
+    num2 = 0x01;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::add(num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::sub(num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = 0x0F;
+    num2 = 0x0B;
+    uint8_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::mul(num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::div(mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint8_t>::div(mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = 0xFF;
+    num2 = 0xCC;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::mul(num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::div(num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test uint8_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_uint16_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test uint16_t start...");
+
+    uint16_t num1 = 0x0FFF, num2 = 0x0BBB, addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::add(num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::sub(addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::sub(addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = 0xFFFF;
+    num2 = 0x0001;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::add(num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::sub(num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = 0x0FFF;
+    num2 = 0x000B;
+    uint16_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::mul(num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::div(mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint16_t>::div(mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = 0xFFFF;
+    num2 = 0xCCCC;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::mul(num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::div(num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test uint16_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_uint32_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test uint32_t start...");
+
+    uint32_t num1 = 0x0000FFFF, num2 = 0x00000BBB, addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::add(num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::sub(addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::sub(addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = 0xFFFFFFFF;
+    num2 = 0x00000001;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::add(num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::sub(num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = 0x00FFFFFF;
+    num2 = 0x000000BB;
+    uint32_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::mul(num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::div(mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint32_t>::div(mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = 0xFFFFFFFF;
+    num2 = 0xCCCCCCCC;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::mul(num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::div(num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test uint32_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_uint64_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test uint64_t start...");
+
+    uint64_t num1 = 0x000FFFFFFFFFFFFF, num2 = 0x00BBBBBBBBBBBBBB, addRes,
+             subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::add(num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::sub(addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::sub(addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = 0xFFFFFFFFFFFFFFFF;
+    num2 = 0x0000000000000001;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::add(num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::sub(num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = 0x000000FFFFFFFFFF;
+    num2 = 0x000000000000BBBB;
+    uint64_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::mul(num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::div(mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true == SafeMath<uint64_t>::div(mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = 0xFFFFFFFFFFFFFFFF;
+    num2 = 0xCCCCCCCCCCCCCCCC;
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::mul(num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::div(num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test uint64_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_boost_uint128_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test boost_uint128_t start...");
+
+    boost::multiprecision::uint128_t num1("0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+        num2("0x0000000000000000000000000000000B"), addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::add(
+                                   num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::sub(
+                                   addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::sub(
+                                   addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = boost::multiprecision::uint128_t(
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint128_t(
+        "0x00000000000000000000000000000001");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint128_t>::add(
+                                   num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint128_t>::sub(
+                                   num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = boost::multiprecision::uint128_t(
+        "0x00000000000000000FFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint128_t(
+        "0x000000000000000000000BBBBBBBBBBB");
+    boost::multiprecision::uint128_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::div(
+                                   mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint128_t>::div(
+                                   mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = boost::multiprecision::uint128_t(
+        "0x000000000FFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint128_t(
+        "0x0000000000CCCCCCCCCCCCCCCCCCCCCC");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint128_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint128_t>::div(
+                                   num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test boost_uint128_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_boost_uint256_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test boost_uint256_t start...");
+
+    boost::multiprecision::uint256_t num1(
+        "0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+        num2("0x000000000000000000000000000000000000000000000000000000000000000"
+             "B"),
+        addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::add(
+                                   num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::sub(
+                                   addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::sub(
+                                   addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = boost::multiprecision::uint256_t(
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint256_t(
+        "0x0000000000000000000000000000000000000000000000000000000000000001");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint256_t>::add(
+                                   num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint256_t>::sub(
+                                   num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = boost::multiprecision::uint256_t(
+        "0x000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint256_t(
+        "0x00000000000000000000000000000000000000BBBBBBBBBBBBBBBBBBBBBBBBBB");
+    boost::multiprecision::uint256_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::div(
+                                   mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint256_t>::div(
+                                   mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = boost::multiprecision::uint256_t(
+        "0x000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint256_t(
+        "0x0000000000CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint256_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint256_t>::div(
+                                   num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test boost_uint256_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_boost_uint512_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test boost_uint512_t start...");
+
+    boost::multiprecision::uint512_t num1(
+        "0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+        num2("0x000000000000000000000000000000000000000000000000000000000000000"
+             "0000000000000000000000000000000000000000000000000000000000000000"
+             "B"),
+        addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::add(
+                                   num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::sub(
+                                   addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::sub(
+                                   addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = boost::multiprecision::uint512_t(
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint512_t(
+        "0x00000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000001");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint512_t>::add(
+                                   num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint512_t>::sub(
+                                   num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = boost::multiprecision::uint512_t(
+        "0x0000000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint512_t(
+        "0x00000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+    boost::multiprecision::uint512_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::div(
+                                   mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint512_t>::div(
+                                   mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = boost::multiprecision::uint512_t(
+        "0x000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint512_t(
+        "0x0000000000CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint512_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint512_t>::div(
+                                   num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test boost_uint512_t done!");
+}
+
+BOOST_AUTO_TEST_CASE(test_boost_uint1024_t)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test boost_uint1024_t start...");
+
+    boost::multiprecision::uint1024_t num1(
+        "0x0FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+        num2("0x000000000000000000000000000000000000000000000000000000000000000"
+             "00000000000000000000000000000000000000000000000000000000000000000"
+             "00000000000000000000000000000000000000000000000000000000000000000"
+             "00000000000000000000000000000000000000000000000000000000000000B"),
+        addRes, subRes1, subRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::add(
+                                   num1, num2, addRes),
+                        "Test add failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::sub(
+                                   addRes, num1, subRes1),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::sub(
+                                   addRes, num2, subRes2),
+                        "Test sub failed!");
+    BOOST_CHECK_MESSAGE(num1 == subRes2, "Test add/sub failed!");
+    BOOST_CHECK_MESSAGE(num2 == subRes1, "Test add/sub failed!");
+
+    num1 = boost::multiprecision::uint1024_t(
+        "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint1024_t(
+        "0x00000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000001");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint1024_t>::add(
+                                   num1, num2, addRes),
+                        "Test add overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint1024_t>::sub(
+                                   num2, num1, subRes1),
+                        "Test sub error-handling failed!");
+
+    num1 = boost::multiprecision::uint1024_t(
+        "0x00000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint1024_t(
+        "0x00000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+    boost::multiprecision::uint1024_t mulRes, divRes1, divRes2;
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::div(
+                                   mulRes, num1, divRes1),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(true
+                            == SafeMath<boost::multiprecision::uint1024_t>::div(
+                                   mulRes, num2, divRes2),
+                        "Test div failed!");
+    BOOST_CHECK_MESSAGE(num1 == divRes2, "Test mul/div failed!");
+    BOOST_CHECK_MESSAGE(num2 == divRes1, "Test mul/div failed!");
+
+    num1 = boost::multiprecision::uint1024_t(
+        "0x00000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    num2 = boost::multiprecision::uint1024_t(
+        "0x0000000000CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint1024_t>::mul(
+                                   num1, num2, mulRes),
+                        "Test mul overflow failed!");
+    BOOST_CHECK_MESSAGE(false
+                            == SafeMath<boost::multiprecision::uint1024_t>::div(
+                                   num2, 0, divRes1),
+                        "Test div error-handling failed!");
+
+    LOG_GENERAL(INFO, "Test boost_uint1024_t done!");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/Utils/Test_SafeMath.cpp
+++ b/tests/Utils/Test_SafeMath.cpp
@@ -24,33 +24,6 @@ using namespace std;
 
 BOOST_AUTO_TEST_SUITE(safemath)
 
-BOOST_AUTO_TEST_CASE(test_integrity)
-{
-    INIT_STDOUT_LOGGER();
-
-    LOG_GENERAL(INFO, "Test integrity start...");
-
-    int8_t num;
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::add(-1, 1, num),
-                        "Test add integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::add(1, -1, num),
-                        "Test add integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::sub(-1, 1, num),
-                        "Test sub integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::sub(1, -1, num),
-                        "Test sub integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::mul(-1, 1, num),
-                        "Test mul integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::mul(1, -1, num),
-                        "Test mul integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::div(-1, 1, num),
-                        "Test div integrity failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::div(1, -1, num),
-                        "Test div integrity failed!");
-
-    LOG_GENERAL(INFO, "Test integrity done!");
-}
-
 BOOST_AUTO_TEST_CASE(test_uint8_t)
 {
     INIT_STDOUT_LOGGER();
@@ -71,8 +44,6 @@ BOOST_AUTO_TEST_CASE(test_uint8_t)
     num2 = 0x01;
     BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::add(num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<uint8_t>::sub(num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = 0x0F;
     num2 = 0x0B;
@@ -116,8 +87,6 @@ BOOST_AUTO_TEST_CASE(test_uint16_t)
     num2 = 0x0001;
     BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::add(num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<uint16_t>::sub(num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = 0x0FFF;
     num2 = 0x000B;
@@ -161,8 +130,6 @@ BOOST_AUTO_TEST_CASE(test_uint32_t)
     num2 = 0x00000001;
     BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::add(num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<uint32_t>::sub(num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = 0x00FFFFFF;
     num2 = 0x000000BB;
@@ -207,8 +174,6 @@ BOOST_AUTO_TEST_CASE(test_uint64_t)
     num2 = 0x0000000000000001;
     BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::add(num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false == SafeMath<uint64_t>::sub(num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = 0x000000FFFFFFFFFF;
     num2 = 0x000000000000BBBB;
@@ -263,10 +228,6 @@ BOOST_AUTO_TEST_CASE(test_boost_uint128_t)
                             == SafeMath<boost::multiprecision::uint128_t>::add(
                                    num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false
-                            == SafeMath<boost::multiprecision::uint128_t>::sub(
-                                   num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = boost::multiprecision::uint128_t(
         "0x00000000000000000FFFFFFFFFFFFFFF");
@@ -338,10 +299,6 @@ BOOST_AUTO_TEST_CASE(test_boost_uint256_t)
                             == SafeMath<boost::multiprecision::uint256_t>::add(
                                    num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false
-                            == SafeMath<boost::multiprecision::uint256_t>::sub(
-                                   num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = boost::multiprecision::uint256_t(
         "0x000000000000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
@@ -417,10 +374,6 @@ BOOST_AUTO_TEST_CASE(test_boost_uint512_t)
                             == SafeMath<boost::multiprecision::uint512_t>::add(
                                    num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false
-                            == SafeMath<boost::multiprecision::uint512_t>::sub(
-                                   num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = boost::multiprecision::uint512_t(
         "0x0000000000000000000000000000000000000000000000000000FFFFFFFFFFFFFFFF"
@@ -507,10 +460,6 @@ BOOST_AUTO_TEST_CASE(test_boost_uint1024_t)
                             == SafeMath<boost::multiprecision::uint1024_t>::add(
                                    num1, num2, addRes),
                         "Test add overflow failed!");
-    BOOST_CHECK_MESSAGE(false
-                            == SafeMath<boost::multiprecision::uint1024_t>::sub(
-                                   num2, num1, subRes1),
-                        "Test sub error-handling failed!");
 
     num1 = boost::multiprecision::uint1024_t(
         "0x00000000000000000000000000000000000000000000000000000000000000000000"

--- a/tests/Utils/Test_SafeMath.cpp
+++ b/tests/Utils/Test_SafeMath.cpp
@@ -24,6 +24,33 @@ using namespace std;
 
 BOOST_AUTO_TEST_SUITE(safemath)
 
+BOOST_AUTO_TEST_CASE(test_integrity)
+{
+    INIT_STDOUT_LOGGER();
+
+    LOG_GENERAL(INFO, "Test integrity start...");
+
+    int8_t num;
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::add(-1, 1, num),
+                        "Test add integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::add(1, -1, num),
+                        "Test add integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::sub(-1, 1, num),
+                        "Test sub integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::sub(1, -1, num),
+                        "Test sub integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::mul(-1, 1, num),
+                        "Test mul integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::mul(1, -1, num),
+                        "Test mul integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::div(-1, 1, num),
+                        "Test div integrity failed!");
+    BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::div(1, -1, num),
+                        "Test div integrity failed!");
+
+    LOG_GENERAL(INFO, "Test integrity done!");
+}
+
 BOOST_AUTO_TEST_CASE(test_uint8_t)
 {
     INIT_STDOUT_LOGGER();


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
As https://github.com/Zilliqa/Issues/issues/152 described, SafeMath should be a type-independent class. Hence we make it as template, and at the same time, add some unit test cases for it.

Known issue: (fixed)
Overflow-checking of add() only works on uint8_t and uint16_t, not work on bigger data size.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] unit test
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] large-scale cloud test (commit: e71c2ec)
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
