### PR TITLE
Support logging time-stamp on millisecond precision

### DIFF
--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -21,7 +21,6 @@
 #include <pthread.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-
 using namespace std;
 using namespace g3;
 
@@ -156,8 +155,11 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
 
     if (IsG3Log())
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         LOG(level) << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                   << put_time(gmtime(&curTime), "%H:%M:%S") << "]["
+                   << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                   << PAD(get_ms(cur), 3) << "]["
                    << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg;
         return;
     }
@@ -167,17 +169,22 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                  << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                  << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
-                  << endl
+                  << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
+                  << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-             << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
+             << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "] " << msg << endl
              << flush;
     }
 }
@@ -193,17 +200,23 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                  << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                  << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+                  << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
+                  << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
                   << "[Epoch " << epoch << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-             << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+             << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "]"
              << "[Epoch " << epoch << "] " << msg << endl
              << flush;
     }
@@ -223,33 +236,41 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
         {
             m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                      << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                      << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] "
-                      << msg << " (Len=" << payload.size()
+                      << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                      << PAD(get_ms(cur), 3) << "]["
+                      << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                      << " (Len=" << payload.size()
                       << "): " << payload_string.get() << "..." << endl
                       << flush;
         }
         else
         {
             m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                      << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                      << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] "
-                      << msg << " (Len=" << payload.size()
+                      << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                      << PAD(get_ms(cur), 3) << "]["
+                      << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                      << " (Len=" << payload.size()
                       << "): " << payload_string.get() << endl
                       << flush;
         }
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
+
         if (payload.size() > max_bytes_to_display)
         {
             cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                 << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                 << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                 << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                 << PAD(get_ms(cur), 3) << "]["
+                 << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                  << " (Len=" << payload.size() << "): " << payload_string.get()
                  << "..." << endl
                  << flush;
@@ -257,8 +278,9 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
         else
         {
             cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
-                 << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                 << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+                 << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                 << PAD(get_ms(cur), 3) << "]["
+                 << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                  << " (Len=" << payload.size() << "): " << payload_string.get()
                  << endl
                  << flush;
@@ -279,17 +301,23 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     if (m_logToFile)
     {
         checkLog();
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(tid, TID_LEN) << "]["
-                  << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN)
-                  << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+                  << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+                  << PAD(get_ms(cur), 3) << "]["
+                  << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
                   << "[Epoch " << epoch << "] " << msg << endl
                   << flush;
     }
     else
     {
+        auto cur = chrono::high_resolution_clock::now();
+        auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(tid, TID_LEN) << "]["
-             << PAD(put_time(gmtime(&curTime), "%H:%M:%S"), TIME_LEN) << "]["
-             << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+             << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
+             << PAD(get_ms(cur), 3) << "][" << LIMIT(function, MAX_FUNCNAME_LEN)
+             << "]"
              << "[Epoch " << epoch << "] " << msg << endl
              << flush;
     }

--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -150,12 +150,9 @@ void Logger::LogState(const char* msg, const char*)
 
 void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
 {
-    std::time_t curTime = std::chrono::system_clock::to_time_t(
-        std::chrono::system_clock::now());
-
     if (IsG3Log())
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         LOG(level) << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                    << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -169,7 +166,7 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                   << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -179,7 +176,7 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -192,15 +189,12 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function)
 void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
                       const char* epoch, const char* function)
 {
-    std::time_t curTime = std::chrono::system_clock::to_time_t(
-        std::chrono::system_clock::now());
-
     lock_guard<mutex> guard(m);
 
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(GetPid(), TID_LEN) << "]["
                   << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -211,7 +205,7 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(GetPid(), TID_LEN) << "]["
              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -228,15 +222,12 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
 {
     std::unique_ptr<char[]> payload_string;
     GetPayloadS(payload, max_bytes_to_display, payload_string);
-    std::time_t curTime = std::chrono::system_clock::to_time_t(
-        std::chrono::system_clock::now());
-
     lock_guard<mutex> guard(m);
 
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
@@ -262,7 +253,7 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
         if (payload.size() > max_bytes_to_display)
@@ -292,16 +283,12 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
                           const char* epoch)
 {
     pid_t tid = getCurrentPid();
-
-    std::time_t curTime = std::chrono::system_clock::to_time_t(
-        std::chrono::system_clock::now());
-
     lock_guard<mutex> guard(m);
 
     if (m_logToFile)
     {
         checkLog();
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         m_logFile << "[TID " << PAD(tid, TID_LEN) << "]["
                   << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
@@ -312,7 +299,7 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     }
     else
     {
-        auto cur = chrono::high_resolution_clock::now();
+        auto cur = chrono::system_clock::now();
         auto cur_time_t = chrono::system_clock::to_time_t(cur);
         cout << "[TID " << PAD(tid, TID_LEN) << "]["
              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -163,11 +163,11 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
-                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:") \
+                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:")      \
                        << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)        \
                        << "] " << msg;                                         \
@@ -184,11 +184,11 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
                        << "]["                                                 \
-                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:") \
+                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:")      \
                        << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN) << "]" \
                        << "[Epoch " << epoch << "] " << msg;                   \
@@ -205,19 +205,16 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
-            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur = std::chrono::system_clock::now();                       \
             auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&cur_time_t),          \
-                                            "%H:%M:%S:")                       \
+                           << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:")  \
                            << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
@@ -227,8 +224,7 @@ public:
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&cur_time_t),          \
-                                            "%H:%M:%S:")                       \
+                           << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:")  \
                            << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -20,6 +20,7 @@
 #include "g3log/g3log.hpp"
 #include "g3log/loglevels.hpp"
 #include "g3log/logworker.hpp"
+#include "libUtils/TimeUtils.h"
 #include <boost/multiprecision/cpp_int.hpp>
 #include <chrono>
 #include <fstream>
@@ -162,11 +163,12 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
-                       << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
                        << "]["                                                 \
+                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:") \
+                       << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)        \
                        << "] " << msg;                                         \
         }                                                                      \
@@ -182,11 +184,12 @@ public:
     {                                                                          \
         if (Logger::GetLogger(NULL, true).IsG3Log())                           \
         {                                                                      \
-            std::time_t curTime = std::chrono::system_clock::to_time_t(        \
-                std::chrono::system_clock::now());                             \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             LOG(level) << "[TID " << PAD(Logger::GetPid(), Logger::TID_LEN)    \
-                       << "][" << std::put_time(gmtime(&curTime), "%H:%M:%S")  \
                        << "]["                                                 \
+                       << std::put_time(gmtime(&cur_time_t), "%H:%M:%S:") \
+                       << PAD(get_ms(cur), 3) << "]["                          \
                        << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN) << "]" \
                        << "[Epoch " << epoch << "] " << msg;                   \
         }                                                                      \
@@ -207,12 +210,15 @@ public:
             std::unique_ptr<char[]> payload_string;                            \
             Logger::GetPayloadS(payload, max_bytes_to_display,                 \
                                 payload_string);                               \
+            auto cur = std::chrono::high_resolution_clock::now();              \
+            auto cur_time_t = std::chrono::system_clock::to_time_t(cur);       \
             if ((payload).size() > max_bytes_to_display)                       \
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&curTime), "%H:%M:%S")      \
-                           << "]["                                             \
+                           << std::put_time(gmtime(&cur_time_t),          \
+                                            "%H:%M:%S:")                       \
+                           << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
                            << "): " << payload_string.get() << "...";          \
@@ -221,8 +227,9 @@ public:
             {                                                                  \
                 LOG(level) << "[TID "                                          \
                            << PAD(Logger::GetPid(), Logger::TID_LEN) << "]["   \
-                           << std::put_time(gmtime(&curTime), "%H:%M:%S")      \
-                           << "]["                                             \
+                           << std::put_time(gmtime(&cur_time_t),          \
+                                            "%H:%M:%S:")                       \
+                           << PAD(get_ms(cur), 3) << "]["                      \
                            << LIMIT(__FUNCTION__, Logger::MAX_FUNCNAME_LEN)    \
                            << "] " << msg << " (Len=" << (payload).size()      \
                            << "): " << payload_string.get();                   \

--- a/src/libUtils/TimeUtils.cpp
+++ b/src/libUtils/TimeUtils.cpp
@@ -15,9 +15,10 @@
 **/
 
 #include "TimeUtils.h"
-
+#include <mutex>
 using namespace std::chrono;
 using namespace boost::multiprecision;
+static std::mutex gmtimeMutex;
 
 system_clock::time_point r_timer_start() { return system_clock::now(); }
 
@@ -32,4 +33,17 @@ uint256_t get_time_as_int()
     microseconds microsecs
         = duration_cast<microseconds>(system_clock::now().time_since_epoch());
     return static_cast<uint256_t>(microsecs.count());
+}
+
+struct tm* gmtime_safe(const time_t* timer)
+{
+    std::lock_guard<std::mutex> guard(gmtimeMutex);
+    return gmtime(timer);
+}
+
+long int get_ms(const time_point<high_resolution_clock> time)
+{
+    return duration_cast<milliseconds>(
+               time - system_clock::from_time_t(system_clock::to_time_t(time)))
+        .count();
 }

--- a/src/libUtils/TimeUtils.cpp
+++ b/src/libUtils/TimeUtils.cpp
@@ -41,7 +41,7 @@ struct tm* gmtime_safe(const time_t* timer)
     return gmtime(timer);
 }
 
-long int get_ms(const time_point<high_resolution_clock> time)
+long int get_ms(const time_point<system_clock> time)
 {
     return duration_cast<milliseconds>(
                time - system_clock::from_time_t(system_clock::to_time_t(time)))

--- a/src/libUtils/TimeUtils.h
+++ b/src/libUtils/TimeUtils.h
@@ -24,5 +24,7 @@ std::chrono::system_clock::time_point r_timer_start();
 double r_timer_end(std::chrono::system_clock::time_point start_time);
 
 boost::multiprecision::uint256_t get_time_as_int();
-
+struct tm* gmtime_safe(const time_t* timer);
+long int
+get_ms(const std::chrono::time_point<std::chrono::high_resolution_clock> time);
 #endif // __TIMEUTILS_H__

--- a/src/libUtils/TimeUtils.h
+++ b/src/libUtils/TimeUtils.h
@@ -25,6 +25,5 @@ double r_timer_end(std::chrono::system_clock::time_point start_time);
 
 boost::multiprecision::uint256_t get_time_as_int();
 struct tm* gmtime_safe(const time_t* timer);
-long int
-get_ms(const std::chrono::time_point<std::chrono::high_resolution_clock> time);
+long int get_ms(const std::chrono::time_point<std::chrono::system_clock> time);
 #endif // __TIMEUTILS_H__


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Currently, our logging time-stamp only has second precision. However, there are often lots of messages coming in the same time, from different nodes/threads. It's not easy to distinguish them according to identical time-stamp. Thus we make the logging time-stamp precision as millisecond, trying to let debugging more easily.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
