### PR TITLE
Add external interface for Schnorr.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -ggdb -DNDEBUG")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 
 # compiler and linker options
 
@@ -101,7 +103,7 @@ endif()
 set_target_properties(zilliqa sendcmd sendtxn genkeypair
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set_target_properties(Common Trie ethash NAT
+set_target_properties(Common Trie ethash NAT schnorr
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 if(OPENCL_MINE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory (common)
 add_subdirectory (depends)
+add_subdirectory (interfaces)
 add_subdirectory (libConsensus)
 add_subdirectory (libCrypto)
 add_subdirectory (libData)

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(schnorr SHARED schnorr.cpp)
+include_directories(${Boost_INCLUDE_DIRS})
+target_include_directories(schnorr PUBLIC ${PROJECT_SOURCE_DIR}/src ${G3LOG_INCLUDE_DIRS})
+target_link_libraries(schnorr PUBLIC ${Boost_LIBRARIES})

--- a/src/interfaces/schnorr.cpp
+++ b/src/interfaces/schnorr.cpp
@@ -27,7 +27,7 @@ void genKeyPair_Z(RawBytes_Z* privKey, RawBytes_Z* pubKey)
     std::vector<unsigned char> privK, pubK;
     int privKSize = kpair.first.Serialize(privK, 0);
     int pubKSize = kpair.second.Serialize(pubK, 0);
-    assert(privKSize == privK.size() && pubKSize == pubK.size()
+    assert(privKSize == (int)privK.size() && pubKSize == (int)pubK.size()
            && "Output size of generate key mismatches reported size");
     if (privKey->len != privKSize)
         err_abort("Schnorr::genKeyPair_Z: Incorrect memory allocated for "
@@ -69,7 +69,7 @@ void sign_Z(const RawBytes_Z* privKey, const RawBytes_Z* pubKey,
     // Extract signature into byte array.
     sig.Serialize(S, 0);
 
-    if (S.size() != (unsigned)signature->len)
+    if ((int)S.size() != signature->len)
         err_abort("Schnorr::size_Z: Incorrect memory allocated for signature");
 
     // Copy the results for use by caller.

--- a/src/interfaces/schnorr.cpp
+++ b/src/interfaces/schnorr.cpp
@@ -1,0 +1,108 @@
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include "schnorr.h"
+#include "libCrypto/Schnorr.h"
+
+// OCaml CTypes does not support handling exceptions. So just abort.
+void err_abort(const char* msg)
+{
+    fprintf(stderr, "%s\n", msg);
+    abort();
+}
+
+extern "C" {
+
+// Generate a private/public key pair.
+// Memory must already be allocated by caller.
+void genKeyPair_Z(RawBytes_Z* privKey, RawBytes_Z* pubKey)
+{
+    // Get key pair from C++ lib.
+    Schnorr& s = Schnorr::GetInstance();
+    std::pair<PrivKey, PubKey> kpair = s.GenKeyPair();
+
+    // Make sure we can pass on the result back.
+    std::vector<unsigned char> privK, pubK;
+    int privKSize = kpair.first.Serialize(privK, 0);
+    int pubKSize = kpair.second.Serialize(pubK, 0);
+    assert(privKSize == privK.size() && pubKSize == pubK.size()
+           && "Output size of generate key mismatches reported size");
+    if (privKey->len != privKSize)
+        err_abort("Schnorr::genKeyPair_Z: Incorrect memory allocated for "
+                  "private key");
+    if (pubKey->len != pubKSize)
+        err_abort(
+            "Schnorr::genKeyPair_Z: Incorrect memory allocated for public key");
+
+    // Pass on the result.
+    std::memcpy(privKey->data, privK.data(), privKSize);
+    std::memcpy(pubKey->data, pubK.data(), pubKSize);
+}
+
+// Sign message with privKey/pubKey. Memory for signature must be allocated by caller.
+void sign_Z(const RawBytes_Z* privKey, const RawBytes_Z* pubKey,
+            const RawBytes_Z* message, RawBytes_Z* signature)
+{
+    std::vector<unsigned char> privK(privKey->len), pubK(pubKey->len),
+        M(message->len), S;
+
+    if (privKey->len != privkey_len)
+        err_abort("Schnorr::sign_Z: Incorrect memory allocated for "
+                  "private key");
+    if (pubKey->len != pubkey_len)
+        err_abort("Schnorr::sign_Z: Incorrect memory allocated for public key");
+
+    // Copy inputs to vectors for use by Schnorr.
+    std::memcpy(privK.data(), privKey->data, privKey->len);
+    std::memcpy(pubK.data(), pubKey->data, pubKey->len);
+    std::memcpy(M.data(), message->data, message->len);
+
+    Schnorr& s = Schnorr::GetInstance();
+    PrivKey keyPriv(privK, 0);
+    PubKey keyPub(pubK, 0);
+    Signature sig;
+
+    // Sign the message.
+    s.Sign(M, keyPriv, keyPub, sig);
+    // Extract signature into byte array.
+    sig.Serialize(S, 0);
+
+    if (S.size() != (unsigned)signature->len)
+        err_abort("Schnorr::size_Z: Incorrect memory allocated for signature");
+
+    // Copy the results for use by caller.
+    std::memcpy(signature->data, S.data(), S.size());
+}
+
+// Verify message with signature and public key of signer
+int verify_Z(const RawBytes_Z* pubKey, const RawBytes_Z* message,
+             RawBytes_Z* signature)
+{
+    std::vector<unsigned char> pubK(pubKey->len), M(message->len),
+        S(signature->len);
+
+    if (pubKey->len != pubkey_len)
+        err_abort(
+            "Schnorr::verify_Z: Incorrect memory allocated for public key");
+    if (signature->len != signature_len)
+        err_abort(
+            "Schnorr::verify_Z: Incorrect memory allocated for signature");
+
+    // Copy inputs to vectors for use by Schnorr.
+    std::memcpy(pubK.data(), pubKey->data, pubKey->len);
+    std::memcpy(M.data(), message->data, message->len);
+    std::memcpy(S.data(), signature->data, signature->len);
+
+    Schnorr& s = Schnorr::GetInstance();
+    PubKey keyPub(pubK, 0);
+    Signature sig(S, 0);
+
+    // Sign the message.
+    if (s.Verify(M, sig, keyPub))
+        return 1;
+    else
+        return 0;
+}
+}

--- a/src/interfaces/schnorr.h
+++ b/src/interfaces/schnorr.h
@@ -1,0 +1,34 @@
+#ifndef SCHNORR_H
+#define SCHNORR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define privkey_len 32
+#define pubkey_len 33
+#define signature_len 64
+
+typedef struct
+{
+    char* data;
+    int len;
+} RawBytes_Z;
+
+// Generate a private/public key pair.
+// Memory must already be allocated by caller.
+void genKeyPair_Z(RawBytes_Z* privKey, RawBytes_Z* pubKey);
+
+// Sign message with privKey/pubKey. Memory for signature must be allocated by caller.
+void sign_Z(const RawBytes_Z* privKey, const RawBytes_Z* pubKey,
+            const RawBytes_Z* message, RawBytes_Z* signature);
+
+// Verify message with signature and public key of signer
+int verify_Z(const RawBytes_Z* pubKey, const RawBytes_Z* message,
+             RawBytes_Z* signature);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // SCHNORR_H


### PR DESCRIPTION
To link from outside, make all builds use -fPIC flag.

## Description
To expose an external interface for the Schnorr implementation for use from Scilla.
See relevant Scilla "Issue" here:  https://github.com/Zilliqa/scilla/issues/66

## Review Suggestion
The external interface is highly simplified for easy use from OCaml. I request the reviewers to help me make sure  that the other parts of the PR (changes to build system) does not break anything else.

There also is a related change in the g3log repo for this.

### Implementation
- [*] **ready for review**

### Integration Test (Core Team)
None
