### PR TITLE
Safe math log warning enhancement and comments fix

### DIFF
--- a/src/libUtils/SafeMath.h
+++ b/src/libUtils/SafeMath.h
@@ -20,8 +20,6 @@
 #include "Logger.h"
 #include <boost/multiprecision/cpp_int.hpp>
 
-/// Important: SafeMath ONLY support positive value!!!
-
 template<class T> class SafeMath
 {
 public:
@@ -119,4 +117,4 @@ public:
     }
 };
 
-#endif // __OVERFLOWSAFEOPS_H__
+#endif //__SafeMath_H__

--- a/src/libUtils/SafeMath.h
+++ b/src/libUtils/SafeMath.h
@@ -34,7 +34,7 @@ public:
         T c = a * b;
         if (c / a != b)
         {
-            LOG_GENERAL(WARNING, "Multiplication Overflow!");
+            LOG_GENERAL(WARNING, "Multiplication Underflow/Overflow!");
             return false;
         }
         result = c;
@@ -93,7 +93,14 @@ public:
 
         if (aa > 0 && bb < 0 && (c < aa || c < (0 - bb)))
         {
-            LOG_GENERAL(WARNING, "Subtraction Overflow!");
+            if (bPos)
+            {
+                LOG_GENERAL(WARNING, "Subtraction Overflow!");
+            }
+            else
+            {
+                LOG_GENERAL(WARNING, "Subtraction Underflow!");
+            }
             return false;
         }
 
@@ -105,10 +112,14 @@ public:
     {
         T c = a + b;
 
-        if ((a > 0 && b > 0 && (c < a || c < b))
-            || (a < 0 && b < 0 && (c > a || c > b)))
+        if (a > 0 && b > 0 && (c < a || c < b))
         {
             LOG_GENERAL(WARNING, "Addition Overflow!");
+            return false;
+        }
+        else if (a < 0 && b < 0 && (c > a || c > b))
+        {
+            LOG_GENERAL(WARNING, "Addition Underflow!");
             return false;
         }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR fixes the following in `SafeMath`
- Removal of obsolete comments
- Log warning to distinguish between integer overflow and underflow. 

There is no breaking change in this PR. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Review may wish to refer to recent PR #523 for recent changes to SafeMath

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] Build successful
- [ ] ~local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~small-scale cloud test~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
