### PR TITLE
Fix wrong port number in tests

### DIFF
--- a/tests/Node/test_node_simple.sh
+++ b/tests/Node/test_node_simple.sh
@@ -47,6 +47,6 @@ done
 
 for port in {01..20}
 do
-    python tests/Zilliqa/test_zilliqa_local.py sendtxn 50$port
+    python tests/Zilliqa/test_zilliqa_local.py sendtxn $((5000 + $port))
 done 
 

--- a/tests/Node/watch_node_simple.sh
+++ b/tests/Node/watch_node_simple.sh
@@ -20,7 +20,7 @@
 
 for id in {01..20}
 do
-    port=50$id
+    porta=$((5000 + $id))
     node_cmd_info=$(pgrep -f "zilliqa.*127\.0\.0\.1 $port" -a | cut -f1,5,6 -d" ")  
     node_log=$(tail -n1 local_run/node_00$id/zilliqa-00001-log.txt)
     if [[ -z $node_cmd_info ]]

--- a/tests/Node/watch_node_simple.sh
+++ b/tests/Node/watch_node_simple.sh
@@ -20,7 +20,7 @@
 
 for id in {01..20}
 do
-    porta=$((5000 + $id))
+    port=$((5000 + $id))
     node_cmd_info=$(pgrep -f "zilliqa.*127\.0\.0\.1 $port" -a | cut -f1,5,6 -d" ")  
     node_log=$(tail -n1 local_run/node_00$id/zilliqa-00001-log.txt)
     if [[ -z $node_cmd_info ]]


### PR DESCRIPTION
## Description

Fix wrong port number in tests:
50$port --> $((5000 + $port)) since 50$port returns 501, 502... instead of 5001, 5002...
