### PR TITLE
[Graceful Termination] Implement signal handling using libevent

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -123,6 +123,8 @@ int main(int argc, const char* argv[])
         return zilliqa.RetrieveBroadcastList(msg_type, ins_type, from);
     };
 
+    P2PComm::GetInstance().RegisterExitSignal({SIGINT});
+
     P2PComm::GetInstance().StartMessagePump(
         my_network_info.m_listenPortHost, dispatcher, broadcast_list_retriever);
 

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -19,6 +19,7 @@
 
 #include <boost/lockfree/queue.hpp>
 #include <deque>
+#include <event.h>
 #include <event2/util.h>
 #include <functional>
 #include <mutex>
@@ -127,6 +128,9 @@ private:
     static Dispatcher m_dispatcher;
     static BroadcastListFunc m_broadcast_list_retriever;
 
+    std::unique_ptr<struct event_base, decltype(&event_base_free)> m_eventBase;
+    std::vector<std::unique_ptr<struct event>> m_signalEvents;
+
 public:
     /// Accept TCP connection for libevent usage
     static void ConnectionAccept(evconnlistener* listener,
@@ -166,6 +170,12 @@ public:
                             const std::vector<unsigned char>& message);
 
     void SetSelfPeer(const Peer& self);
+
+    /// Register the signal num used for exiting
+    void RegisterExitSignal(std::vector<int>&& sigs);
+
+    /// Signal exit on event loop
+    void SignalExit();
 };
 
 #endif // __P2PCOMM_H__

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -34,4 +34,8 @@ add_test(NAME Test_Blacklist COMMAND Test_Blacklist)
 add_executable (Test_Signal Test_Signal.cpp)
 target_include_directories (Test_Signal PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_Signal PUBLIC Network Utils)
+
+# FIXME: Test_Signal is only able to run on Linux
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 add_test(NAME Test_Signal COMMAND Test_Signal)
+endif()

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -30,3 +30,8 @@ add_executable (Test_Blacklist Test_Blacklist.cpp)
 target_include_directories (Test_Blacklist PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_Blacklist PUBLIC Network Utils)
 add_test(NAME Test_Blacklist COMMAND Test_Blacklist)
+
+add_executable (Test_Signal Test_Signal.cpp)
+target_include_directories (Test_Signal PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries (Test_Signal PUBLIC Network Utils)
+add_test(NAME Test_Signal COMMAND Test_Signal)

--- a/tests/Network/Test_Signal.cpp
+++ b/tests/Network/Test_Signal.cpp
@@ -1,0 +1,76 @@
+/**
+* Copyright (c) 2018 Zilliqa 
+* This source code is being disclosed to you solely for the purpose of your participation in 
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
+* the protocols and algorithms that are programmed into, and intended by, the code. You may 
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
+* including modifying or publishing the code (or any part of it), and developing or forming 
+* another public or private blockchain network. This source code is provided ‘as is’ and no 
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* and which include a reference to GPLv3 in their program files.
+**/
+
+#include "libNetwork/P2PComm.h"
+#include "libUtils/Logger.h"
+#include <csignal>
+#include <thread>
+
+#define BOOST_TEST_MODULE signal
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(test_signal)
+
+BOOST_AUTO_TEST_CASE(test_sigint_termination)
+{
+    INIT_STDOUT_LOGGER();
+
+    auto message_handler
+        = [](pair<vector<unsigned char>, Peer>* message) { (void)message; };
+
+    std::thread deferred_signal([]() {
+        std::this_thread::sleep_for(100ms);
+        std::raise(SIGINT);
+        LOG_GENERAL(INFO, "Testing signal SIGINT sent");
+    });
+
+    P2PComm::GetInstance().RegisterExitSignal({SIGINT});
+
+    P2PComm::GetInstance().StartMessagePump(30303, message_handler, nullptr);
+
+    deferred_signal.join();
+}
+
+BOOST_AUTO_TEST_CASE(test_multiple_termination)
+{
+    INIT_STDOUT_LOGGER();
+
+    auto message_handler
+        = [](pair<vector<unsigned char>, Peer>* message) { (void)message; };
+
+    std::thread deferred_signal([]() {
+        std::this_thread::sleep_for(100ms);
+        std::raise(SIGINT);
+        LOG_GENERAL(INFO, "Testing signal SIGINT sent");
+
+        LOG_GENERAL(INFO, "Not interrupted as SIGINT not registered");
+
+        std::this_thread::sleep_for(100ms);
+        std::raise(SIGTERM);
+        LOG_GENERAL(INFO, "Testing signal SIGTERM sent");
+    });
+
+    P2PComm::GetInstance().RegisterExitSignal({SIGTERM});
+
+    P2PComm::GetInstance().StartMessagePump(30303, message_handler, nullptr);
+
+    deferred_signal.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR adds support for signal handling to terminate the process using <kbd>Ctrl</kbd>-<kbd>C</kbd> or other signals. It's prepared for the graceful termination.

The implementation is based on libevent's signal handling. The signal to be used for exiting is first registered using `RegisterExitSignal` which adds the signal event to the event base (`m_eventBase`) and binds the callback function `OnExitingSignal` to the event. 

A small refactoring is also included in this PR to adopt RAII in libevent-related resource management, including the event base (`m_eventBase`) and signal events (`m_signalEvents`).

The test case `Test_Signal` shows a minimal working example. Due to an unknown issue in CTest on macOS, the test case itself only works on Linux build so a branch condition is added in 
`tests/Network/CMakeLists.txt`. Despite of this issue, the signal handling still works fine when not running in CTest.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Start from the test case `Test_Signal` to have a brief understanding of the idea. Then move to the newly added data member and functions for `P2PComm`. 

If you prefer having a try on the termination for a single node, follow these steps:

1. `./build.sh`
2. `cd build`
3. `./bin/zilliqa $(./bin/genkeypair | awk '{ printf $2 " " $1 }') 127.0.0.1 30303 0 0 0`
4. <kbd>Ctrl</kbd>-<kbd>C</kbd>
5. `tail zilliqa-00001-log.txt`
## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
