### PR TITLE
Release helper for upgrading protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ if(TESTS)
 endif()
 
 # installation
-set_target_properties(zilliqa sendcmd sendtxn genkeypair gentxn
+set_target_properties(zilliqa sendcmd sendtxn genkeypair gentxn sign
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_target_properties(Common Trie ethash NAT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ set(CPACK_PACKAGE_NAME $ENV{ZIL_PACK_NAME})
 set(CPACK_DEBIAN_PACKAGE_NAME "zilliqa")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-format-5.0, clang-tidy-5.0, clang-5.0, libboost-system-dev, libboost-filesystem-dev, libboost-test-dev, libssl-dev, libleveldb-dev, libjsoncpp-dev, libsnappy-dev, cmake, libmicrohttpd-dev, libjsonrpccpp-dev, build-essential, pkg-config, libevent-dev, libminiupnpc-dev, libprotobuf-dev, protobuf-compiler")
-set(CPACK_PACKAGE_CONTACT "enquiry@zilliqa.com")
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "members of enquiry@zilliqa.com")
+set(CPACK_PACKAGE_CONTACT "maintainers@zilliqa.com")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Members of maintainers@zilliqa.com")
 
 # compiler and linker options
 
@@ -104,7 +104,7 @@ if(TESTS)
 endif()
 
 # installation
-set_target_properties(zilliqa sendcmd sendtxn genkeypair gentxn sign
+set_target_properties(zilliqa sendcmd sendtxn genkeypair gentxn signmultisig
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_target_properties(Common Trie ethash NAT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,16 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# pack related variables
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_VERSION $ENV{ZIL_VER})
+set(CPACK_PACKAGE_NAME $ENV{ZIL_PACK_NAME})
+set(CPACK_DEBIAN_PACKAGE_NAME "zilliqa")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-format-5.0, clang-tidy-5.0, clang-5.0, libboost-system-dev, libboost-filesystem-dev, libboost-test-dev, libssl-dev, libleveldb-dev, libjsoncpp-dev, libsnappy-dev, cmake, libmicrohttpd-dev, libjsonrpccpp-dev, build-essential, pkg-config, libevent-dev, libminiupnpc-dev, libprotobuf-dev, protobuf-compiler")
+set(CPACK_PACKAGE_CONTACT "enquiry@zilliqa.com")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "members of enquiry@zilliqa.com")
+
 # compiler and linker options
 
 add_compile_options(-Wall)
@@ -116,3 +126,5 @@ install(
 
 # add clang-format and clang-tidy targets lastly
 include(LLVMExtraTools)
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(CPACK_PACKAGE_VERSION $ENV{ZIL_VER})
 set(CPACK_PACKAGE_NAME $ENV{ZIL_PACK_NAME})
 set(CPACK_DEBIAN_PACKAGE_NAME "zilliqa")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "clang-format-5.0, clang-tidy-5.0, clang-5.0, libboost-system-dev, libboost-filesystem-dev, libboost-test-dev, libssl-dev, libleveldb-dev, libjsoncpp-dev, libsnappy-dev, cmake, libmicrohttpd-dev, libjsonrpccpp-dev, build-essential, pkg-config, libevent-dev, libminiupnpc-dev, libprotobuf-dev, protobuf-compiler")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-system-dev, libboost-filesystem-dev, libboost-test-dev, libssl-dev, libleveldb-dev, libjsoncpp-dev, libsnappy-dev, cmake, libmicrohttpd-dev, libjsonrpccpp-dev, build-essential, pkg-config, libevent-dev, libminiupnpc-dev, libprotobuf-dev, protobuf-compiler")
 set(CPACK_PACKAGE_CONTACT "maintainers@zilliqa.com")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Members of maintainers@zilliqa.com")
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,10 @@
+=== Major Version ===
+1
+=== Minor Version ===
+0
+=== Fix Version ===
+0
+=== Expected DS Epoch ===
+5
+=== Git Commit ID ===
+d4af1a6

--- a/VERSION
+++ b/VERSION
@@ -5,8 +5,12 @@
 === Fix Version ===
 0
 === Expected DS Epoch ===
-0
+5
+
+### DO NOT MODIFY FOLLOWING SECTION! IT WILL BE AUTOMATICALLY GENERATED. ###
 === Git Commit ID ===
-c906f07
+c342bc9
 === SHA-256 ===
+
+=== Schnorr Signature ===
 

--- a/VERSION
+++ b/VERSION
@@ -5,6 +5,8 @@
 === Fix Version ===
 0
 === Expected DS Epoch ===
-5
+0
 === Git Commit ID ===
-d4af1a6
+c906f07
+=== SHA-256 ===
+

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright (c) 2018 Zilliqa
+# This source code is being disclosed to you solely for the purpose of your participation in
+# testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to
+# the protocols and algorithms that are programmed into, and intended by, the code. You may
+# not do anything else with the code without express permission from Zilliqa Research Pte. Ltd.,
+# including modifying or publishing the code (or any part of it), and developing or forming
+# another public or private blockchain network. This source code is provided ‘as is’ and no
+# warranties are given as to title or non-infringement, merchantability or fitness for purpose
+# and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+# Some programs in this code are governed by the GNU General Public License v3.0 (available at
+# https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by
+# GPLv3.0 are those programs that are located in the folders src/depends and tests/depends
+# and which include a reference to GPLv3 in their program files.
+
+# Configuration settings
+
+fileName="VERSION"
+majorLine=2
+minorLine=4
+fixLine=6
+DSLine=8
+commitLine=10
+
+# Read current version information from version file
+defaultMajor="$(sed -n ${majorLine}p ${fileName})"
+defaultMinor="$(sed -n ${minorLine}p ${fileName})"
+defaultFix="$(sed -n ${fixLine}p ${fileName})"
+defaultDS="$(sed -n ${DSLine}p ${fileName})"
+defaultCommit="$(sed -n ${commitLine}p ${fileName})"
+
+# Ask user to input new version information
+echo -e "Current software version: ${defaultMajor}.${defaultMinor}.${defaultFix}.${defaultDS}.${defaultCommit}"
+
+read -p "Please enter major version [${defaultMajor}]: " major
+major=${major:-${defaultMajor}}
+
+read -p "Please enter minor version [${defaultMinor}]: " minor
+minor=${minor:-${defaultMinor}}
+
+read -p "Please enter fix version [${defaultFix}]: " fix
+fix=${fix:-${defaultFix}}
+
+read -p "Please enter expected DS epoch [${defaultDS}]: " DS
+DS=${DS:-${defaultDS}}
+
+commit="$(git describe --always)"
+
+# Write new version information into version file
+echo -e "Writing new software version into ${fileName}..."
+
+sed -i "${majorLine}s/.*/${major}/" ${fileName}
+sed -i "${minorLine}s/.*/${minor}/" ${fileName}
+sed -i "${fixLine}s/.*/${fix}/" ${fileName}
+sed -i "${DSLine}s/.*/${DS}/" ${fileName}
+sed -i "${commitLine}s/.*/${commit}/" ${fileName}
+
+echo -e "New software version: ${major}.${minor}.${fix}.${DS}.${commit} is written into ${fileName} successfully.\n"
+
+# Use cpack to making deb file
+
+echo -e "Make deb file..."
+
+# Make SHA-256 & multi-signature
+
+echo -e "Calculate SHA-256..."
+echo -e "Make multi-signature..."
+

--- a/release.sh
+++ b/release.sh
@@ -14,8 +14,8 @@
 # and which include a reference to GPLv3 in their program files.
 
 # Configuration settings
-
-fileName="VERSION"
+packageName="D24"
+versionFile="VERSION"
 majorLine=2
 minorLine=4
 fixLine=6
@@ -23,46 +23,47 @@ DSLine=8
 commitLine=10
 
 # Read current version information from version file
-defaultMajor="$(sed -n ${majorLine}p ${fileName})"
-defaultMinor="$(sed -n ${minorLine}p ${fileName})"
-defaultFix="$(sed -n ${fixLine}p ${fileName})"
-defaultDS="$(sed -n ${DSLine}p ${fileName})"
-defaultCommit="$(sed -n ${commitLine}p ${fileName})"
+defaultMajor="$(sed -n ${majorLine}p ${versionFile})"
+defaultMinor="$(sed -n ${minorLine}p ${versionFile})"
+defaultFix="$(sed -n ${fixLine}p ${versionFile})"
+defaultDS="$(sed -n ${DSLine}p ${versionFile})"
+defaultCommit="$(sed -n ${commitLine}p ${versionFile})"
+currentVer=${defaultMajor}.${defaultMinor}.${defaultFix}.${defaultDS}.${defaultCommit}
 
 # Ask user to input new version information
-echo -e "Current software version: ${defaultMajor}.${defaultMinor}.${defaultFix}.${defaultDS}.${defaultCommit}"
-
+echo -e "Current software version:  ${currentVer}"
 read -p "Please enter major version [${defaultMajor}]: " major
 major=${major:-${defaultMajor}}
-
 read -p "Please enter minor version [${defaultMinor}]: " minor
 minor=${minor:-${defaultMinor}}
-
 read -p "Please enter fix version [${defaultFix}]: " fix
 fix=${fix:-${defaultFix}}
-
 read -p "Please enter expected DS epoch [${defaultDS}]: " DS
 DS=${DS:-${defaultDS}}
-
 commit="$(git describe --always)"
 
 # Write new version information into version file
-echo -e "Writing new software version into ${fileName}..."
-
-sed -i "${majorLine}s/.*/${major}/" ${fileName}
-sed -i "${minorLine}s/.*/${minor}/" ${fileName}
-sed -i "${fixLine}s/.*/${fix}/" ${fileName}
-sed -i "${DSLine}s/.*/${DS}/" ${fileName}
-sed -i "${commitLine}s/.*/${commit}/" ${fileName}
-
-echo -e "New software version: ${major}.${minor}.${fix}.${DS}.${commit} is written into ${fileName} successfully.\n"
+echo -e "Writing new software version into ${versionFile}..."
+sed -i "${majorLine}s/.*/${major}/" ${versionFile}
+sed -i "${minorLine}s/.*/${minor}/" ${versionFile}
+sed -i "${fixLine}s/.*/${fix}/" ${versionFile}
+sed -i "${DSLine}s/.*/${DS}/" ${versionFile}
+sed -i "${commitLine}s/.*/${commit}/" ${versionFile}
+newVer=${major}.${minor}.${fix}.${DS}.${commit}
+export ZIL_VER=${newVer}
+export ZIL_PACK_NAME=${packageName}
+echo -e "New software version: ${newVer} is written into ${versionFile} successfully.\n"
 
 # Use cpack to making deb file
-
-echo -e "Make deb file..."
+echo -e "Make deb package..."
+git clean -dfx
+./build.sh; cd build; make package; cd -
+./build_lookup.sh; cd build_lookup; make package; cd -
+echo -e "Deb packages are generated successfully.\n"
 
 # Make SHA-256 & multi-signature
 
 echo -e "Calculate SHA-256..."
+
 echo -e "Make multi-signature..."
 

--- a/release.sh
+++ b/release.sh
@@ -21,6 +21,7 @@ minorLine=4
 fixLine=6
 DSLine=8
 commitLine=10
+shaLine=12
 
 # Read current version information from version file
 defaultMajor="$(sed -n ${majorLine}p ${versionFile})"
@@ -59,11 +60,21 @@ echo -e "Make deb package..."
 git clean -dfx
 ./build.sh; cd build; make package; cd -
 ./build_lookup.sh; cd build_lookup; make package; cd -
+cp ${versionFile} build/; cp ${versionFile} build_lookup/
+cd build; debFile="$(ls *.deb)"; cd -
 echo -e "Deb packages are generated successfully.\n"
 
 # Make SHA-256 & multi-signature
-
 echo -e "Calculate SHA-256..."
+cd build
+sha="$(md5sum ${debFile}|cut -d ' ' -f1)"
+sed -i "${shaLine}s/.*/${sha}/" ${versionFile}
+cd -
+cd build_lookup
+sha="$(md5sum ${debFile}|cut -d ' ' -f1)"
+sed -i "${shaLine}s/.*/${sha}/" ${versionFile}
+cd -
+echo -e "SHA-256 is written into ${versionFile} successfully.\n"
 
 echo -e "Make multi-signature..."
 

--- a/release.sh
+++ b/release.sh
@@ -85,11 +85,7 @@ echo -e "New software version: ${newVer} is written into ${versionFile} successf
 
 # Use cpack to making deb file
 echo -e "Make deb package..."
-rm -rf build; rm -rf build_lookup
-./build.sh; cd build; make package; cd -
-./build_lookup.sh; cd build_lookup; make package; cd -
-cp ${versionFile} build/; cp ${versionFile} build_lookup/
-cd build; debFile="$(ls *.deb)"; cd -
+rm -rf build; ./build.sh; cd build; make package; cp ../${versionFile} .; debFile="$(ls *.deb)"; cd -
 echo -e "Deb packages are generated successfully.\n"
 
 # Make SHA-256 & multi-signature
@@ -97,12 +93,6 @@ echo -e "Making SHA-256 & multi-signature..."
 privKeyFile="$(realpath $1)"
 pubKeyFile="$(realpath $2)"
 cd build
-sha="$(md5sum ${debFile}|cut -d ' ' -f1)"
-sed -i "${shaLine}s/.*/${sha}/" ${versionFile}
-signature="$(./bin/signmultisig ${sha} ${privKeyFile} ${pubKeyFile})"
-sed -i "${sigLine}s/.*/${signature}/" ${versionFile}
-cd -
-cd build_lookup
 sha="$(md5sum ${debFile}|cut -d ' ' -f1)"
 sed -i "${shaLine}s/.*/${sha}/" ${versionFile}
 signature="$(./bin/signmultisig ${sha} ${privKeyFile} ${pubKeyFile})"
@@ -147,40 +137,20 @@ curl -v -s \
   -H "Authorization: token ${GitHubToken}" \
   -H "Content-Type:application/json" \
   --data-binary @build/${debFile} \
-  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=build_${debFile}" \
+  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=${debFile}" \
   -d '{
   "Content-Type": "application/vnd.debian.binary-package",
-  "name": "'"build_${debFile}"'",
+  "name": "'"${debFile}"'",
   "label": "'"${newVer}"'"
 }'
 curl -v -s \
   -H "Authorization: token ${GitHubToken}" \
   -H "Content-Type:application/json" \
   --data-binary @build/${versionFile} \
-  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=build_${versionFile}" \
+  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=${versionFile}" \
   -d '{
   "Content-Type": "application/octet-stream",
-  "name": "'"build_${versionFile}"'",
-  "label": "'"${newVer}"'"
-}'
-curl -v -s \
-  -H "Authorization: token ${GitHubToken}" \
-  -H "Content-Type:application/json" \
-  --data-binary @build_lookup/${debFile} \
-  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=build_lookup_${debFile}" \
-  -d '{
-  "Content-Type": "application/vnd.debian.binary-package",
-  "name": "'"build_lookup_${debFile}"'",
-  "label": "'"${newVer}"'"
-}'
-curl -v -s \
-  -H "Authorization: token ${GitHubToken}" \
-  -H "Content-Type:application/json" \
-  --data-binary @build_lookup/${versionFile} \
-  "https://uploads.github.com/repos/Zilliqa/${repoName}/releases/${releaseId}/assets?name=build_lookup_${versionFile}" \
-  -d '{
-  "Content-Type": "application/octet-stream",
-  "name": "'"build_lookup_${versionFile}"'",
+  "name": "'"${versionFile}"'",
   "label": "'"${newVer}"'"
 }'
 rm ${releaseLog}

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -36,3 +36,9 @@ add_custom_command(TARGET zilliqa
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gentxn> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
 target_include_directories(gentxn PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(gentxn PUBLIC AccountData)
+add_executable(sign sign.cpp)
+add_custom_command(TARGET zilliqa
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:sign> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
+target_include_directories(sign PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(sign PUBLIC Crypto)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -36,9 +36,10 @@ add_custom_command(TARGET zilliqa
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:gentxn> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
 target_include_directories(gentxn PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(gentxn PUBLIC AccountData)
-add_executable(sign sign.cpp)
+
+add_executable(signmultisig signmultisig.cpp)
 add_custom_command(TARGET zilliqa
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:sign> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
-target_include_directories(sign PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(sign PUBLIC Crypto)
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:signmultisig> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
+target_include_directories(signmultisig PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(signmultisig PUBLIC Crypto)

--- a/src/cmd/sign.cpp
+++ b/src/cmd/sign.cpp
@@ -1,0 +1,96 @@
+/**
+* Copyright (c) 2018 Zilliqa 
+* This source code is being disclosed to you solely for the purpose of your participation in 
+* testing Zilliqa. You may view, compile and run the code for that purpose and pursuant to 
+* the protocols and algorithms that are programmed into, and intended by, the code. You may 
+* not do anything else with the code without express permission from Zilliqa Research Pte. Ltd., 
+* including modifying or publishing the code (or any part of it), and developing or forming 
+* another public or private blockchain network. This source code is provided ‘as is’ and no 
+* warranties are given as to title or non-infringement, merchantability or fitness for purpose 
+* and, to the extent permitted by law, all liability for your use of the code is disclaimed. 
+* Some programs in this code are governed by the GNU General Public License v3.0 (available at 
+* https://www.gnu.org/licenses/gpl-3.0.en.html) (‘GPLv3’). The programs that are governed by 
+* GPLv3.0 are those programs that are located in the folders src/depends and tests/depends 
+* and which include a reference to GPLv3 in their program files.
+**/
+
+#include "libCrypto/Schnorr.h"
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, const char* argv[])
+{
+    if (4 != argc)
+    {
+        cout << "Input format: ./sign message privateKeyFileName "
+                "publicKeyFileName";
+        return -1;
+    }
+
+    const vector<unsigned char> message
+        = DataConversion::HexStrToUint8Vec(string(argv[1]));
+
+    char buf[100];
+    vector<PrivKey> privKeys;
+    FILE* privFile = fopen(argv[2], "r");
+
+    while (fgets(buf, sizeof(buf), privFile))
+    {
+        string s = buf;
+
+        if ('\n' == s.at(s.size() - 1))
+        {
+            s = s.substr(0, s.size() - 1);
+        }
+
+        if (s.empty())
+        {
+            continue;
+        }
+
+        privKeys.emplace_back(DataConversion::HexStrToUint8Vec(s), 0);
+    }
+
+    fclose(privFile);
+
+    vector<PubKey> pubKeys;
+    FILE* pubFile = fopen(argv[3], "r");
+
+    while (fgets(buf, sizeof(buf), pubFile))
+    {
+        string s = buf;
+
+        if ('\n' == s.at(s.size() - 1))
+        {
+            s = s.substr(0, s.size() - 1);
+        }
+
+        if (s.empty())
+        {
+            continue;
+        }
+
+        pubKeys.emplace_back(DataConversion::HexStrToUint8Vec(s), 0);
+    }
+
+    fclose(pubFile);
+
+    if (privKeys.size() != pubKeys.size())
+    {
+        cout << "Private key number must equal to public key number!";
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < privKeys.size(); ++i)
+    {
+        Signature sig;
+        Schnorr::GetInstance().Sign(message, privKeys.at(i), pubKeys.at(i),
+                                    sig);
+        vector<unsigned char> result;
+        sig.Serialize(result, 0);
+        cout << DataConversion::Uint8VecToHexStr(result);
+    }
+
+    return 0;
+}

--- a/src/cmd/signmultisig.cpp
+++ b/src/cmd/signmultisig.cpp
@@ -31,50 +31,26 @@ int main(int argc, const char* argv[])
     const vector<unsigned char> message
         = DataConversion::HexStrToUint8Vec(string(argv[1]));
 
-    char buf[100];
+    string line;
     vector<PrivKey> privKeys;
-    FILE* privFile = fopen(argv[2], "r");
-
-    while (fgets(buf, sizeof(buf), privFile))
     {
-        string s = buf;
+        fstream privFile(argv[2], ios::in);
 
-        if ('\n' == s.at(s.size() - 1))
+        while (getline(privFile, line))
         {
-            s = s.substr(0, s.size() - 1);
+            privKeys.emplace_back(DataConversion::HexStrToUint8Vec(line), 0);
         }
-
-        if (s.empty())
-        {
-            continue;
-        }
-
-        privKeys.emplace_back(DataConversion::HexStrToUint8Vec(s), 0);
     }
-
-    fclose(privFile);
 
     vector<PubKey> pubKeys;
-    FILE* pubFile = fopen(argv[3], "r");
-
-    while (fgets(buf, sizeof(buf), pubFile))
     {
-        string s = buf;
+        fstream pubFile(argv[3], ios::in);
 
-        if ('\n' == s.at(s.size() - 1))
+        while (getline(pubFile, line))
         {
-            s = s.substr(0, s.size() - 1);
+            pubKeys.emplace_back(DataConversion::HexStrToUint8Vec(line), 0);
         }
-
-        if (s.empty())
-        {
-            continue;
-        }
-
-        pubKeys.emplace_back(DataConversion::HexStrToUint8Vec(s), 0);
     }
-
-    fclose(pubFile);
 
     if (privKeys.size() != pubKeys.size())
     {


### PR DESCRIPTION
## Description
<!-- What is the overall goals of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Following upgrading protocol utilities (https://github.com/Zilliqa/Zilliqa/pull/534), the release helper should provide following features:

- [x]  Generate software version (major, minor, fix, expectedDS, commit) to a separated file "VERSION"
- [x]  Generate deb package
- [x]  Make SHA-256, put into "VERSION"
- [x]  Make multi-signature of SHA-256 hash, put into "VERSION"
- [x]  Put the deb package & [SHA-256 & multi-sig] onto GitHub

Usage:
source ./release.sh privateKeyFileName publicKeyFileName

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Release helper is an off-line independent script that will only be executed when a release needed to be generated. No impact to current code flow, so the review focus should be identifying the correctness of generated package (.deb) and relative version information (VERSION).

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (commit: 9f75730)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
