### PR TITLE
Fix difficulty adjust continually after 1 year epoch problem

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -658,14 +658,25 @@ DirectoryService::CalculateNewDifficulty(const uint8_t& currentDifficulty)
                                      (uint8_t)(POW_DIFFICULTY));
 
     // Every year, always increase the difficulty by 1, to encourage miners to upgrade the hardware over time.
-    // If POW_WINDOW_IN_SECONDS = 300, NUM_FINAL_BLOCK_PER_POW = 5, TXN_SUBMISSION = 4, TXN_BROADCAST = 10, estimated blocks in a year is 420480.
+    // If POW_WINDOW_IN_SECONDS = 300, NUM_FINAL_BLOCK_PER_POW = 50, TX_DISTRIBUTE_TIME_IN_MS = 10000, estimated blocks in a year is 1971000.
     uint64_t estimatedBlocksOneYear = 365 * 24 * 3600
         / ((POW_WINDOW_IN_SECONDS / NUM_FINAL_BLOCK_PER_POW)
-           + (TX_DISTRIBUTE_TIME_IN_MS));
+           + (TX_DISTRIBUTE_TIME_IN_MS / 1000));
 
-    // After 10 years, the difficulty will not automatically increase anymore..
-    newDifficulty += std::min(
-        (uint8_t)(m_mediator.m_currentEpochNum / estimatedBlocksOneYear),
-        MAX_INCREASE_DIFFICULTY_YEARS);
+    // Round to integral multiple of NUM_FINAL_BLOCK_PER_POW
+    estimatedBlocksOneYear = (estimatedBlocksOneYear / NUM_FINAL_BLOCK_PER_POW)
+        * NUM_FINAL_BLOCK_PER_POW;
+
+    // Within 10 years, every year increase the difficulty by one.
+    if (m_mediator.m_currentEpochNum / estimatedBlocksOneYear
+            <= MAX_INCREASE_DIFFICULTY_YEARS
+        && m_mediator.m_currentEpochNum % estimatedBlocksOneYear == 0)
+    {
+        LOG_GENERAL(INFO,
+                    "At one year epoch " << m_mediator.m_currentEpochNum
+                                         << ", increase difficulty by 1.");
+        ++newDifficulty;
+    }
+
     return newDifficulty;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix difficulty adjustment bug, the current algorithm continually increase difficulty after 1 year epoch is reached.
<!-- What is the context of your pull request? -->
Change the difficulty adjust algorithm, only increase difficulty at 1 year epoch.
<!-- What are the related issues and pull requests? -->
Issue 192 [https://github.com/Zilliqa/Issues/issues/192]

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check the CalculateNewDifficulty function, compare it with old one.
<!-- How can the reviewers verify the pull request is working as expected -->
Change the one year epoch to a smaller value, simulate the scenario of 1 year epoch reached, difficulty will increase by 1 on local machine.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
