### PR TITLE
Fixed lastblockhash setting in Node::ProcessDSBlock

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -538,7 +538,7 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
             uint16_t lastBlockHash = 0;
             if (m_mediator.m_currentEpochNum > 1)
             {
-                HashUtils::SerializableToHash16Bits(
+                lastBlockHash = HashUtils::SerializableToHash16Bits(
                     m_mediator.m_txBlockChain.GetLastBlock());
             }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`lastBlockHash` was not set correctly inside `Node::ProcessDSBlock`.
Could not be easily detected during testing, but the side effect was there could be two leaders at one time.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
