### PR TITLE
Fix build error after remove "using namespace std" in Miner.h

### DIFF
--- a/src/depends/libethash-cl/CLMiner.cpp
+++ b/src/depends/libethash-cl/CLMiner.cpp
@@ -209,7 +209,7 @@ static std::string ethCLErrorHelper(const char *msg, cl::Error const &clerr) {
 namespace
 {
 
-void addDefinition(string& _source, char const* _id, unsigned _value)
+void addDefinition(std::string& _source, char const* _id, unsigned _value)
 {
     char buf[256];
     sprintf(buf, "#define %s %uu\n", _id, _value);
@@ -218,7 +218,7 @@ void addDefinition(string& _source, char const* _id, unsigned _value)
 
 std::vector<cl::Platform> getPlatforms()
 {
-    vector<cl::Platform> platforms;
+    std::vector<cl::Platform> platforms;
     try
     {
         cl::Platform::get(&platforms);
@@ -237,8 +237,8 @@ std::vector<cl::Platform> getPlatforms()
 
 std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, unsigned _platformId)
 {
-    vector<cl::Device> devices;
-    size_t platform_num = min<size_t>(_platformId, _platforms.size() - 1);
+    std::vector<cl::Device> devices;
+    size_t platform_num = std::min<size_t>(_platformId, _platforms.size() - 1);
     try
     {
         _platforms[platform_num].getDevices(
@@ -262,7 +262,7 @@ std::vector<cl::Device> getDevices(std::vector<cl::Platform> const& _platforms, 
 
 unsigned CLMiner::s_platformId = 0;
 unsigned CLMiner::s_numInstances = 0;
-vector<int> CLMiner::s_devices(MAX_MINERS, -1);
+std::vector<int> CLMiner::s_devices(MAX_MINERS, -1);
 
 CLMiner::~CLMiner()
 {
@@ -289,7 +289,7 @@ bool CLMiner::mine(const WorkPackage &w, Solution &solution)
                 if (s_dagLoadMode == DAG_LOAD_MODE_SEQUENTIAL)
                 {
                     while (s_dagLoadIndex < index)
-                        this_thread::sleep_for(chrono::seconds(1));
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
                     ++s_dagLoadIndex;
                 }
 
@@ -362,11 +362,11 @@ bool CLMiner::mine(const WorkPackage &w, Solution &solution)
 
 unsigned CLMiner::getNumDevices()
 {
-    vector<cl::Platform> platforms = getPlatforms();
+    std::vector<cl::Platform> platforms = getPlatforms();
     if (platforms.empty())
         return 0;
 
-    vector<cl::Device> devices = getDevices(platforms, s_platformId);
+    std::vector<cl::Device> devices = getDevices(platforms, s_platformId);
     if (devices.empty())
     {
         cwarn << "No OpenCL devices found.";
@@ -377,19 +377,19 @@ unsigned CLMiner::getNumDevices()
 
 void CLMiner::listDevices()
 {
-    string outString ="\nListing OpenCL devices.\nFORMAT: [platformID] [deviceID] deviceName\n";
+    std::string outString ="\nListing OpenCL devices.\nFORMAT: [platformID] [deviceID] deviceName\n";
     unsigned int i = 0;
 
-    vector<cl::Platform> platforms = getPlatforms();
+    std::vector<cl::Platform> platforms = getPlatforms();
     if (platforms.empty())
         return;
     for (unsigned j = 0; j < platforms.size(); ++j)
     {
         i = 0;
-        vector<cl::Device> devices = getDevices(platforms, j);
+        std::vector<cl::Device> devices = getDevices(platforms, j);
         for (auto const& device: devices)
         {
-            outString += "[" + to_string(j) + "] [" + to_string(i) + "] " + device.getInfo<CL_DEVICE_NAME>() + "\n";
+            outString += "[" + std::to_string(j) + "] [" + std::to_string(i) + "] " + device.getInfo<CL_DEVICE_NAME>() + "\n";
             outString += "\tCL_DEVICE_TYPE: ";
             switch (device.getInfo<CL_DEVICE_TYPE>())
             {
@@ -406,9 +406,9 @@ void CLMiner::listDevices()
                 outString += "DEFAULT\n";
                 break;
             }
-            outString += "\tCL_DEVICE_GLOBAL_MEM_SIZE: " + to_string(device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>()) + "\n";
-            outString += "\tCL_DEVICE_MAX_MEM_ALLOC_SIZE: " + to_string(device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>()) + "\n";
-            outString += "\tCL_DEVICE_MAX_WORK_GROUP_SIZE: " + to_string(device.getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>()) + "\n";
+            outString += "\tCL_DEVICE_GLOBAL_MEM_SIZE: " + std::to_string(device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>()) + "\n";
+            outString += "\tCL_DEVICE_MAX_MEM_ALLOC_SIZE: " + std::to_string(device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>()) + "\n";
+            outString += "\tCL_DEVICE_MAX_WORK_GROUP_SIZE: " + std::to_string(device.getInfo<CL_DEVICE_MAX_WORK_GROUP_SIZE>()) + "\n";
             ++i;
         }
     }
@@ -443,13 +443,13 @@ bool CLMiner::configureGPU(
 
     auto dagSize = ethash_get_datasize(epoch); //ethash::get_full_dataset_size(ethash::calculate_full_dataset_num_items(epoch));
 
-    vector<cl::Platform> platforms = getPlatforms();
+    std::vector<cl::Platform> platforms = getPlatforms();
     if (platforms.empty())
         return false;
     if (_platformId >= platforms.size())
         return false;
 
-    vector<cl::Device> devices = getDevices(platforms, _platformId);
+    std::vector<cl::Device> devices = getDevices(platforms, _platformId);
     bool foundSuitableDevice = false;
     for (auto const& device: devices)
     {
@@ -474,7 +474,7 @@ bool CLMiner::configureGPU(
     {
         return true;
     }
-    cout << "No GPU device with sufficient memory was found" << endl;
+    std::cout << "No GPU device with sufficient memory was found" << std::endl;
     return false;
 }
 
@@ -483,14 +483,14 @@ bool CLMiner::init(uint64_t blockNumber)
     // get all platforms
     try
     {
-        vector<cl::Platform> platforms = getPlatforms();
+        std::vector<cl::Platform> platforms = getPlatforms();
         if (platforms.empty())
             return false;
 
         // use selected platform
-        unsigned platformIdx = min<unsigned>(s_platformId, platforms.size() - 1);
+        unsigned platformIdx = std::min<unsigned>(s_platformId, platforms.size() - 1);
 
-        string platformName = platforms[platformIdx].getInfo<CL_PLATFORM_NAME>();
+        std::string platformName = platforms[platformIdx].getInfo<CL_PLATFORM_NAME>();
         ETHCL_LOG("Platform: " << platformName);
 
         int platformId = OPENCL_PLATFORM_UNKNOWN;
@@ -518,7 +518,7 @@ bool CLMiner::init(uint64_t blockNumber)
         }
 
         // get GPU device of the default platform
-        vector<cl::Device> devices = getDevices(platforms, platformIdx);
+        std::vector<cl::Device> devices = getDevices(platforms, platformIdx);
         if (devices.empty())
         {
             ETHCL_LOG("No OpenCL devices found.");
@@ -530,10 +530,10 @@ bool CLMiner::init(uint64_t blockNumber)
         unsigned deviceId = s_devices[idx] > -1 ? s_devices[idx] : index;
         m_hwmoninfo.deviceIndex = deviceId % devices.size();
         cl::Device& device = devices[deviceId % devices.size()];
-        string device_version = device.getInfo<CL_DEVICE_VERSION>();
+        std::string device_version = device.getInfo<CL_DEVICE_VERSION>();
         ETHCL_LOG("Device:   " << device.getInfo<CL_DEVICE_NAME>() << " / " << device_version);
 
-        string clVer = device_version.substr(7, 3);
+        std::string clVer = device_version.substr(7, 3);
         if (clVer == "1.0" || clVer == "1.1")
         {
             if (platformId == OPENCL_PLATFORM_CLOVER)
@@ -563,7 +563,7 @@ bool CLMiner::init(uint64_t blockNumber)
             sprintf(options, "%s", "");
         }
         // create context
-        m_context = cl::Context(vector<cl::Device>(&device, &device + 1));
+        m_context = cl::Context(std::vector<cl::Device>(&device, &device + 1));
         m_queue = cl::CommandQueue(m_context, device);
 
         m_workgroupSize = s_workgroupSize;
@@ -593,11 +593,11 @@ bool CLMiner::init(uint64_t blockNumber)
         // into a byte array by bin2h.cmake. There is no need to load the file by hand in runtime
         // See libethash-cl/CMakeLists.txt: add_custom_command()
         // TODO: Just use C++ raw string literal.
-        string code;
+        std::string code;
 
         if ( s_clKernelName == CLKernelName::Experimental ) {
             cllog << "OpenCL kernel: Experimental kernel";
-            code = string(CLMiner_kernel_experimental, CLMiner_kernel_experimental + sizeof(CLMiner_kernel_experimental));
+            code = std::string(CLMiner_kernel_experimental, CLMiner_kernel_experimental + sizeof(CLMiner_kernel_experimental));
         }
         else { //if(s_clKernelName == CLKernelName::Stable)
             cllog << "OpenCL kernel: Stable kernel";
@@ -607,7 +607,7 @@ bool CLMiner::init(uint64_t blockNumber)
                 cwarn << "The current stable OpenCL kernel only supports exactly 8 threads. Thread parameter will be ignored.";
             }
 
-            code = string(CLMiner_kernel_stable, CLMiner_kernel_stable + sizeof(CLMiner_kernel_stable));
+            code = std::string(CLMiner_kernel_stable, CLMiner_kernel_stable + sizeof(CLMiner_kernel_stable));
         }
         addDefinition(code, "GROUP_SIZE", m_workgroupSize);
         addDefinition(code, "DAG_SIZE", dagNumItems);

--- a/src/depends/libethash-cl/CLMiner.h
+++ b/src/depends/libethash-cl/CLMiner.h
@@ -77,7 +77,7 @@ public:
 		bool 	 _exit);
     static void setNumInstances(unsigned _instances) { s_numInstances = std::min<unsigned>(_instances, getNumDevices()); }
 	static void setThreadsPerHash(unsigned _threadsPerHash){s_threadsPerHash = _threadsPerHash; }
-	static void setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount)
+	static void setDevices(const std::vector<unsigned>& _devices, unsigned _selectedDeviceCount)
 	{
 		for (unsigned i = 0; i < _selectedDeviceCount; i++)
 		{
@@ -107,7 +107,7 @@ private:
 	static unsigned s_numInstances;
 	static unsigned s_threadsPerHash;
 	static CLKernelName s_clKernelName;
-	static vector<int> s_devices;
+	static std::vector<int> s_devices;
 
 	/// The local work size for the search
 	static unsigned s_workgroupSize;

--- a/src/depends/libethash-cuda/CUDAMiner.cpp
+++ b/src/depends/libethash-cuda/CUDAMiner.cpp
@@ -20,13 +20,12 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 #include "libethash/internal.h"
 #include "libethash/ethash.h"
 
-using namespace std;
 using namespace dev;
 using namespace eth;
 
 unsigned CUDAMiner::s_numInstances = 0;
 
-vector<int> CUDAMiner::s_devices(MAX_MINERS, -1);
+std::vector<int> CUDAMiner::s_devices(MAX_MINERS, -1);
 
 #define cudalog s_ssLog
 #define cwarn s_ssWarn
@@ -44,7 +43,7 @@ bool CUDAMiner::init(uint64_t blockNumber)
     try {
         if (s_dagLoadMode == DAG_LOAD_MODE_SEQUENTIAL)
             while (s_dagLoadIndex < index)
-                this_thread::sleep_for(chrono::milliseconds(100));
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
         unsigned device = s_devices[index] > -1 ? s_devices[index] : index;
 
         cnote << "Initialising miner " << index;
@@ -79,7 +78,7 @@ void CUDAMiner::setNumInstances(unsigned _instances)
     s_numInstances = std::min<unsigned>(_instances, getNumDevices());
 }
 
-void CUDAMiner::setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount)
+void CUDAMiner::setDevices(const std::vector<unsigned>& _devices, unsigned _selectedDeviceCount)
 {
     for (unsigned i = 0; i < _selectedDeviceCount; i++)
         s_devices[i] = _devices[i];
@@ -108,18 +107,18 @@ void CUDAMiner::listDevices()
 {
     try
     {
-        cout << "\nListing CUDA devices.\nFORMAT: [deviceID] deviceName\n";
+        std::cout << "\nListing CUDA devices.\nFORMAT: [deviceID] deviceName\n";
         int numDevices = getNumDevices();
         for (int i = 0; i < numDevices; ++i)
         {
             cudaDeviceProp props;
             CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, i));
 
-            cout << "[" + to_string(i) + "] " + string(props.name) + "\n";
-            cout << "\tCompute version: " + to_string(props.major) + "." + to_string(props.minor) + "\n";
-            cout << "\tcudaDeviceProp::totalGlobalMem: " + to_string(props.totalGlobalMem) + "\n";
-            cout << "\tPci: " << setw(4) << setfill('0') << hex << props.pciDomainID << ':' << setw(2)
-                << props.pciBusID << ':' << setw(2) << props.pciDeviceID << '\n';
+            std::cout << "[" + std::to_string(i) + "] " + std::string(props.name) + "\n";
+            std::cout << "\tCompute version: " + std::to_string(props.major) + "." + std::to_string(props.minor) + "\n";
+            std::cout << "\tcudaDeviceProp::totalGlobalMem: " + std::to_string(props.totalGlobalMem) + "\n";
+            std::cout << "\tPci: " << std::setw(4) << std::setfill('0') << std::hex << props.pciDomainID << ':' << std::setw(2)
+                << props.pciBusID << ':' << std::setw(2) << props.pciDeviceID << '\n';
         }
     }
     catch(std::runtime_error const& err)
@@ -155,7 +154,7 @@ bool CUDAMiner::configureGPU(
         _noeval)
         )
     {
-        cout << "No CUDA device with sufficient memory was found. Can't CUDA mine. Remove the -U argument" << endl;
+        std::cout << "No CUDA device with sufficient memory was found. Can't CUDA mine. Remove the -U argument" << std::endl;
         return false;
     }
     return true;
@@ -172,7 +171,7 @@ unsigned const CUDAMiner::c_defaultNumStreams = 2;
 
 bool CUDAMiner::cuda_configureGPU(
     size_t numDevices,
-    const vector<int>& _devices,
+    const std::vector<int>& _devices,
     unsigned _blockSize,
     unsigned _gridSize,
     unsigned _numStreams,
@@ -197,23 +196,23 @@ bool CUDAMiner::cuda_configureGPU(
         {
             if (_devices[i] != -1)
             {
-                int deviceId = min(devicesCount - 1, _devices[i]);
+                int deviceId = std::min(devicesCount - 1, _devices[i]);
                 cudaDeviceProp props;
                 CUDA_SAFE_CALL(cudaGetDeviceProperties(&props, deviceId));
                 if (props.totalGlobalMem >= dagSize)
                 {
-                    cudalog <<  "Found suitable CUDA device [" << string(props.name) << "] with " << props.totalGlobalMem << " bytes of GPU memory";
+                    cudalog <<  "Found suitable CUDA device [" << std::string(props.name) << "] with " << props.totalGlobalMem << " bytes of GPU memory";
                 }
                 else
                 {
-                    cudalog <<  "CUDA device " << string(props.name) << " has insufficient GPU memory. " << props.totalGlobalMem << " bytes of memory found < " << dagSize << " bytes of memory required";
+                    cudalog <<  "CUDA device " << std::string(props.name) << " has insufficient GPU memory. " << props.totalGlobalMem << " bytes of memory found < " << dagSize << " bytes of memory required";
                     return false;
                 }
             }
         }
         return true;
     }
-    catch (runtime_error)
+    catch (std::runtime_error)
     {
         if(s_exit)
             exit(1);
@@ -249,7 +248,7 @@ bool CUDAMiner::cuda_init(
         cudaDeviceProp device_props;
         CUDA_SAFE_CALL(cudaGetDeviceProperties(&device_props, m_device_num));
 
-        cudalog << "Using device: " << device_props.name << " (Compute " + to_string(device_props.major) + "." + to_string(device_props.minor) + ")";
+        cudalog << "Using device: " << device_props.name << " (Compute " + std::to_string(device_props.major) + "." + std::to_string(device_props.minor) + ")";
 
         m_search_buf = new volatile search_results *[s_numStreams];
         m_streams = new cudaStream_t[s_numStreams];
@@ -266,7 +265,7 @@ bool CUDAMiner::cuda_init(
             //Check whether the current device has sufficient memory every time we recreate the dag
             if (device_props.totalGlobalMem < dagSize)
             {
-                cudalog <<  "CUDA device " << string(device_props.name) << " has insufficient GPU memory. " << device_props.totalGlobalMem << " bytes of memory found < " << dagSize << " bytes of memory required";
+                cudalog <<  "CUDA device " << std::string(device_props.name) << " has insufficient GPU memory. " << device_props.totalGlobalMem << " bytes of memory found < " << dagSize << " bytes of memory required";
                 return false;
             }
             //We need to reset the device and recreate the dag  
@@ -333,7 +332,7 @@ bool CUDAMiner::cuda_init(
                     }
                 }else{
                     while(!hostDAG)
-                        this_thread::sleep_for(chrono::milliseconds(100)); 
+                        std::this_thread::sleep_for(std::chrono::milliseconds(100)); 
                     goto cpyDag;
                 }
             }
@@ -350,7 +349,7 @@ cpyDag:
         m_dag_size = dagNumItems;
         return true;
     }
-    catch (runtime_error const&)
+    catch (std::runtime_error const&)
     {
         if(s_exit)
             exit(1);

--- a/src/depends/libethash-cuda/CUDAMiner.h
+++ b/src/depends/libethash-cuda/CUDAMiner.h
@@ -19,9 +19,7 @@ along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ethash_cuda_miner_kernel.h"
 
-//#include <libethcore/EthashAux.h>
 #include <common/Miner.h>
-
 #include <functional>
 
 namespace dev
@@ -53,10 +51,10 @@ public:
 		bool _exit
 		);
 	static void setNumInstances(unsigned _instances);
-	static void setDevices(const vector<unsigned>& _devices, unsigned _selectedDeviceCount);
+	static void setDevices(const std::vector<unsigned>& _devices, unsigned _selectedDeviceCount);
 	static bool cuda_configureGPU(
 		size_t numDevices,
-		const vector<int>& _devices,
+		const std::vector<int>& _devices,
 		unsigned _blockSize,
 		unsigned _gridSize,
 		unsigned _numStreams,
@@ -113,7 +111,7 @@ private:
 	static unsigned m_parallelHash;
 
 	static unsigned s_numInstances;
-	static vector<int> s_devices;
+	static std::vector<int> s_devices;
 };
 
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
The project failed to build GPU mining project after remove "using namespace std" in Miner.h.
<!-- What is the context of your pull request? -->
Put std:: in front of std library types.
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check the CUDAMiner.h/cpp and CLMiner.h/cpp.
<!-- How can the reviewers verify the pull request is working as expected -->
Build the project with "./build.sh cuda", and "./build.sh opencl", the build should can pass.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
