### PR TITLE
Delay setting DSBlock consensus structures until after consensus is done

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -581,6 +581,17 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
         winnerpeer = m_allPoWConns.at(lastDSBlock.GetHeader().GetMinerPubKey());
     }
 
+    // Now we can update the sharding structure and transaction sharing assignments
+    if (m_mode == BACKUP_DS)
+    {
+        m_DSReceivers = move(m_tempDSReceivers);
+        m_shardReceivers = move(m_tempShardReceivers);
+        m_shardSenders = move(m_tempShardSenders);
+        m_shards = move(m_tempShards);
+        m_publicKeyToShardIdMap = move(m_tempPublicKeyToShardIdMap);
+        ProcessTxnBodySharingAssignment();
+    }
+
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "DSBlock to be sent to the lookup nodes");
 

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -208,7 +208,7 @@ void DirectoryService::ComputeSharding(
     }
 }
 
-bool DirectoryService::VerifyPoWOrdering()
+bool DirectoryService::VerifyPoWOrdering(const VectorOfShard& shards)
 {
     //Requires mutex for m_shards
     vector<unsigned char> lastBlockHash(BLOCK_HASH_SIZE, 0);
@@ -226,7 +226,7 @@ bool DirectoryService::VerifyPoWOrdering()
     vector<unsigned char> hashVec;
     bool ret = true;
     vector<unsigned char> vec(BLOCK_HASH_SIZE);
-    for (const auto& shard : m_shards)
+    for (const auto& shard : shards)
     {
 
         for (const auto& j : shard)
@@ -573,10 +573,10 @@ bool DirectoryService::DSBlockValidator(
 
     Peer winnerPeer;
 
-    m_shards.clear();
-    m_DSReceivers.clear();
-    m_shardReceivers.clear();
-    m_shardSenders.clear();
+    m_tempDSReceivers.clear();
+    m_tempShardReceivers.clear();
+    m_tempShardSenders.clear();
+    m_tempShards.clear();
 
     lock(m_mutexPendingDSBlock, m_mutexAllPoWConns);
     lock_guard<mutex> g(m_mutexPendingDSBlock, adopt_lock);
@@ -586,8 +586,8 @@ bool DirectoryService::DSBlockValidator(
 
     if (!Messenger::GetDSDSBlockAnnouncement(
             message, offset, consensusID, blockHash, leaderID, leaderKey,
-            *m_pendingDSBlock, winnerPeer, m_shards, m_DSReceivers,
-            m_shardReceivers, m_shardSenders, messageToCosign))
+            *m_pendingDSBlock, winnerPeer, m_tempShards, m_tempDSReceivers,
+            m_tempShardReceivers, m_tempShardSenders, messageToCosign))
     {
         LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Messenger::GetDSDSBlockAnnouncement failed.");
@@ -657,18 +657,18 @@ bool DirectoryService::DSBlockValidator(
         }
     }
 
-    if (!ProcessShardingStructure())
+    if (!ProcessShardingStructure(m_tempShards, m_tempPublicKeyToShardIdMap))
     {
         return false;
     }
 
-    if (!VerifyPoWOrdering())
+    if (!VerifyPoWOrdering(m_tempShards))
     {
         LOG_GENERAL(INFO, "Failed to verify ordering");
         //return false; [TODO] Enable this check after fixing the PoW order issue.
     }
 
-    ProcessTxnBodySharingAssignment();
+    //ProcessTxnBodySharingAssignment();
 
     return true;
 }
@@ -719,7 +719,8 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSBackup()
     return true;
 }
 
-bool DirectoryService::ProcessShardingStructure()
+bool DirectoryService::ProcessShardingStructure(
+    const VectorOfShard& shards, map<PubKey, uint32_t>& publicKeyToShardIdMap)
 {
     if (LOOKUP_NODE_MODE)
     {
@@ -729,11 +730,11 @@ bool DirectoryService::ProcessShardingStructure()
         return true;
     }
 
-    m_publicKeyToShardIdMap.clear();
+    publicKeyToShardIdMap.clear();
 
-    for (unsigned int i = 0; i < m_shards.size(); i++)
+    for (unsigned int i = 0; i < shards.size(); i++)
     {
-        for (const auto& j : m_shards.at(i))
+        for (const auto& j : shards.at(i))
         {
             auto storedMember = m_allPoWConns.find(j.first);
 
@@ -755,7 +756,7 @@ bool DirectoryService::ProcessShardingStructure()
                 m_allPoWConns.emplace(j.first, j.second);
             }
 
-            m_publicKeyToShardIdMap.emplace(j.first, i);
+            publicKeyToShardIdMap.emplace(j.first, i);
         }
     }
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -519,7 +519,9 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
                       "I won PoW :-) I am now in the DS committee !");
 
             // Process sharding structure as a DS node
-            if (!m_mediator.m_ds->ProcessShardingStructure())
+            if (!m_mediator.m_ds->ProcessShardingStructure(
+                    m_mediator.m_ds->m_shards,
+                    m_mediator.m_ds->m_publicKeyToShardIdMap))
             {
                 return false;
             }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In the switch to protobuf (#590), the DS backup nodes are now setting their sharding and txn sharing-related members prematurely during the announcement validation.  These should be set only after consensus is done.

In this PR, the announcement data will be buffered inside temp members.  When consensus is done, we'll take advantage of move semantics to efficiently transfer the temp values into the final members for the sharding and txn sharing.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
