### PR TITLE
Fix Issue of DS Leader being kicked out to shard, serializes his own IP as 0.0.0.0:0

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -437,8 +437,8 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary()
 
     if (m_mediator.m_DSCommittee->back().first == m_mediator.m_selfKey.second)
     {
-        m_allPoWConns.emplace(make_pair(m_mediator.m_DSCommittee->back().first,
-                                        m_mediator.m_selfPeer));
+        m_allPoWConns.emplace(
+            make_pair(m_mediator.m_selfKey.second, m_mediator.m_selfPeer));
     }
     else
     {

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -434,7 +434,16 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary()
     // Add the oldest DS committee member to m_allPoWs and m_allPoWConns so it gets included in sharding structure
     sortedPoWSolns.emplace_back(array<unsigned char, 32>(),
                                 m_mediator.m_DSCommittee->back().first);
-    m_allPoWConns.emplace(m_mediator.m_DSCommittee->back());
+
+    if (m_mediator.m_DSCommittee->back().first == m_mediator.m_selfKey.second)
+    {
+        m_allPoWConns.emplace(make_pair(m_mediator.m_DSCommittee->back().first,
+                                        m_mediator.m_selfPeer));
+    }
+    else
+    {
+        m_allPoWConns.emplace(m_mediator.m_DSCommittee->back());
+    }
 
     const auto& winnerPeer
         = m_allPoWConns.find(m_pendingDSBlock->GetHeader().GetMinerPubKey());


### PR DESCRIPTION
## Description
DS leader , if were to become a shard member (meaning, he was the oldest ds member) next epoch, while making the Sharding Structure, serializes his own IP as 0.0.0.0 : 0 and hence dies because is unable to recv messages.

Related issue : DS leader is kicker out of DS committee as shard node #205 
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
