### PR TITLE
Define protobuf message and serialization for DSBlock

### DIFF
--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -154,6 +154,8 @@ const uint64_t& DSBlockHeader::GetBlockNum() const { return m_blockNum; }
 
 const uint256_t& DSBlockHeader::GetTimestamp() const { return m_timestamp; }
 
+const SWInfo& DSBlockHeader::GetSWInfo() const { return m_swInfo; }
+
 bool DSBlockHeader::operator==(const DSBlockHeader& header) const
 {
     return tie(m_dsDifficulty, m_difficulty, m_prevHash, m_nonce, m_minerPubKey,

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -92,6 +92,9 @@ public:
     /// Returns the Unix time at the time of creation of this block.
     const boost::multiprecision::uint256_t& GetTimestamp() const;
 
+    /// Returns the software version information used during creation of this block.
+    const SWInfo& GetSWInfo() const;
+
     /// Equality operator.
     bool operator==(const DSBlockHeader& header) const;
 

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -36,6 +36,31 @@ message TxSharingAssignments
     repeated AssignedNodes shardnodes = 2;
 }
 
+message ProtoDSBlock
+{
+    message DSBlockHeader
+    {
+        required uint32 dsdifficulty    = 1; // only LSB used
+        required uint32 difficulty      = 2; // only LSB used
+        required bytes prevhash         = 3; // 32 bytes
+        required ByteArray nonce        = 4;
+        required ByteArray minerpubkey  = 5;
+        required ByteArray leaderpubkey = 6;
+        required uint64 blocknum        = 7;
+        required ByteArray timestamp    = 8;
+        required ByteArray swinfo       = 9;
+    }
+    message CoSignatures
+    {
+        required ByteArray cs1          = 1;
+        repeated bool b1                = 2;
+        required ByteArray cs2          = 3;
+        repeated bool b2                = 4;
+    }
+    required DSBlockHeader header       = 1;
+    required CoSignatures cosigs        = 2;
+}
+
 // ============================================================================
 // Directory Service messages
 // ============================================================================
@@ -58,7 +83,7 @@ message DSPoWSubmission
 
 message DSDSBlockAnnouncement
 {
-    required ByteArray dsblock                = 1;
+    required ProtoDSBlock dsblock             = 1;
     required ByteArray powwinnerpeer          = 2;
     required ShardingStructure sharding       = 3;
     required TxSharingAssignments assignments = 4;
@@ -81,7 +106,7 @@ message DSVCBlockAnnouncement
 message NodeDSBlock
 {
     required uint32 shardid                   = 1;
-    required ByteArray dsblock                = 2;
+    required ProtoDSBlock dsblock             = 2;
     required ByteArray powwinnerpeer          = 3;
     required ShardingStructure sharding       = 4;
     required TxSharingAssignments assignments = 5;
@@ -139,13 +164,9 @@ message LookupGetDSBlockFromSeed
 
 message LookupSetDSBlockFromSeed
 {
-    message DSBlock
-    {
-        required ByteArray dsblock = 1;
-    }
     required uint64 lowblocknum    = 1;
     required uint64 highblocknum   = 2;
-    repeated DSBlock dsblocks      = 3;
+    repeated ProtoDSBlock dsblocks = 3;
 }
 
 message LookupGetTxBlockFromSeed


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Previously, DSBlock was just defined as a `ByteArray` type, and we would just serialize it as such.
Now, to prepare for variable-length DSBlockHeader, we are defining a Protobuf-equivalent message for DSBlock with all the fields in it.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
