### PR TITLE
Fix node drop after micro block consensus failed

### DIFF
--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -105,11 +105,6 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
             {
                 return false;
             }
-
-            if (m_state != MICROBLOCK_CONSENSUS)
-            {
-                SetState(WAITING_DSBLOCK);
-            }
         }
         else
         {
@@ -157,7 +152,10 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
         }
     }
 
-    SetState(WAITING_DSBLOCK);
+    if (m_state != MICROBLOCK_CONSENSUS)
+    {
+        SetState(WAITING_DSBLOCK);
+    }
 
     return true;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix node drop out the network after micro block fail because state not correct problem.
<!-- What is the context of your pull request? -->
Add condition check when transit to WAITING_DSBLOCK state for node.
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/206

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check libNode/PoWProcessing.cpp
<!-- How can the reviewers verify the pull request is working as expected -->
Set DS priority to 7, run local test, , there should be no node drop out problem.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
