### PR TITLE
Make protobuf message for ForwardTransaction

### DIFF
--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -125,6 +125,18 @@ public:
                                   std::vector<unsigned char>& stateDelta);
 
     static bool
+    SetNodeForwardTransaction(std::vector<unsigned char>& dst,
+                              const unsigned int offset,
+                              const uint64_t blockNum, const TxnHash& txHash,
+                              const StateHash& stateHash,
+                              const std::vector<TransactionWithReceipt>& txns);
+    static bool
+    GetNodeForwardTransaction(const std::vector<unsigned char>& src,
+                              const unsigned int offset, uint64_t& blockNum,
+                              TxnHash& txHash, StateHash& stateHash,
+                              std::vector<TransactionWithReceipt>& txns);
+
+    static bool
     SetNodeForwardTxnBlock(std::vector<unsigned char>& dst,
                            const unsigned int offset,
                            const uint64_t epochNumber, const uint32_t shardID,

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -121,6 +121,14 @@ message NodeFinalBlock
     required bytes statedelta     = 5;
 }
 
+message NodeForwardTransaction
+{
+    required uint64 blocknum           = 1;
+    required bytes microblocktxhash    = 2;
+    required bytes microblockdeltahash = 3;
+    repeated ByteArray txnswithreceipt = 4;
+}
+
 message NodeForwardTxnBlock
 {
     required uint64 epochnumber     = 1;

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -138,8 +138,14 @@ class Node : public Executable, public Broadcastable
     // std::unordered_map<uint64_t, std::list<TransactionWithReceipt>>
     //     m_committedTransactions;
 
+    struct ForwardedTxnBufferEntry
+    {
+        TxnHash m_txnHash;
+        StateHash m_stateHash;
+        std::vector<TransactionWithReceipt> m_transactions;
+    };
     std::mutex m_mutexForwardedTxnBuffer;
-    std::unordered_map<uint64_t, std::vector<std::vector<unsigned char>>>
+    std::unordered_map<uint64_t, std::vector<ForwardedTxnBufferEntry>>
         m_forwardedTxnBuffer;
 
     std::mutex m_mutexTxnPacketBuffer;
@@ -216,11 +222,6 @@ class Node : public Executable, public Broadcastable
     void BeginNextConsensusRound();
 
     // internal calls from ProcessForwardTransaction
-    bool LoadForwardedTxnsAndCheckRoot(
-        const std::vector<unsigned char>& message, unsigned int cur_offset,
-        TxnHash& microBlockTxHash, StateHash& microBlockStateDeltaHash,
-        std::vector<TransactionWithReceipt>& txnsInForwardedMessage);
-    // std::vector<TxnHash> & txnHashesInForwardedMessage);
     void CommitForwardedTransactions(
         const std::vector<TransactionWithReceipt>& txnsInForwardedMessage,
         const uint64_t& blocknum);
@@ -252,9 +253,7 @@ class Node : public Executable, public Broadcastable
                            unsigned int offset, const Peer& from);
     bool ProcessForwardTransaction(const std::vector<unsigned char>& message,
                                    unsigned int cur_offset, const Peer& from);
-    bool
-    ProcessForwardTransactionCore(const std::vector<unsigned char>& message,
-                                  unsigned int cur_offset);
+    bool ProcessForwardTransactionCore(const ForwardedTxnBufferEntry& entry);
     bool ProcessCreateTransactionFromLookup(
         const std::vector<unsigned char>& message, unsigned int offset,
         const Peer& from);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In this PR `NODE::FORWARDTRANSACTION` has been protobuf-ed.
This message is sent by Node to Lookup.

Tested in local machine with transactions. Both get and set are ok.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Note that `m_forwardedTxnBuffer` type has been changed.
Previously we buffered the raw message.
This time the buffer already contains the deserialized components.
This is to avoid re-deserializing again, because `Node::ProcessForwardTransaction` initially needs the block number part of the message before either processing the message or buffering it for later.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
