### PR TITLE
Make protobuf message for MicroblockSubmission

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -91,8 +91,19 @@ class DirectoryService : public Executable, public Broadcastable
     // Final block consensus variables
     std::shared_ptr<TxBlock> m_finalBlock;
 
+    struct MBSubmissionBufferEntry
+    {
+        std::vector<MicroBlock> m_microBlocks;
+        std::vector<unsigned char> m_stateDelta;
+        MBSubmissionBufferEntry(const std::vector<MicroBlock>& microBlocks,
+                                const std::vector<unsigned char>& stateDelta)
+            : m_microBlocks(microBlocks)
+            , m_stateDelta(stateDelta)
+        {
+        }
+    };
     std::mutex m_mutexMBSubmissionBuffer;
-    std::unordered_map<uint64_t, std::vector<std::vector<unsigned char>>>
+    std::unordered_map<uint64_t, std::vector<MBSubmissionBufferEntry>>
         m_MBSubmissionBuffer;
 
     std::mutex m_mutexFinalBlockConsensusBuffer;
@@ -230,13 +241,14 @@ class DirectoryService : public Executable, public Broadcastable
     bool CheckWhetherDSBlockIsFresh(const uint64_t dsblock_num);
     void CommitMBSubmissionMsgBuffer();
     bool ProcessMicroblockSubmissionFromShard(
-        const std::vector<unsigned char>& message, unsigned int offset,
-        const Peer& from);
+        const uint64_t blockNumber, const std::vector<MicroBlock>& microBlocks,
+        const std::vector<unsigned char>& stateDelta);
     bool ProcessMicroblockSubmissionFromShardCore(
-        const std::vector<unsigned char>& message, unsigned int curr_offset);
+        const std::vector<MicroBlock>& microBlocks,
+        const std::vector<unsigned char>& stateDelta);
     bool ProcessMissingMicroblockSubmission(
-        const std::vector<unsigned char>& message, unsigned int offset,
-        const Peer& from);
+        const uint64_t blockNumber, const std::vector<MicroBlock>& microBlocks,
+        const std::vector<unsigned char>& stateDelta);
     void ExtractDataFromMicroblocks(
         TxnHash& microblockTxnTrieRoot, StateHash& microblockDeltaTrieRoot,
         TxnHash& microblockTranReceiptRoot,
@@ -247,8 +259,7 @@ class DirectoryService : public Executable, public Broadcastable
         std::vector<bool>& isMicroBlockEmpty, uint32_t& numMicroBlocks);
     bool VerifyMicroBlockCoSignature(const MicroBlock& microBlock,
                                      uint32_t shardId);
-    bool ProcessStateDelta(const std::vector<unsigned char>& message,
-                           unsigned int cur_offset,
+    bool ProcessStateDelta(const std::vector<unsigned char>& stateDelta,
                            const StateHash& microBlockStateDeltaHash);
 
     // FinalBlockValidator functions

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -28,6 +28,7 @@
 #include "depends/libTrie/TrieHash.h"
 #include "libCrypto/Sha2.h"
 #include "libMediator/Mediator.h"
+#include "libMessage/Messenger.h"
 #include "libNetwork/P2PComm.h"
 #include "libUtils/BitVector.h"
 #include "libUtils/DataConversion.h"
@@ -136,9 +137,11 @@ bool DirectoryService::VerifyMicroBlockCoSignature(const MicroBlock& microBlock,
 }
 
 bool DirectoryService::ProcessStateDelta(
-    const vector<unsigned char>& message, unsigned int cur_offset,
+    const vector<unsigned char>& stateDelta,
     const StateHash& microBlockStateDeltaHash)
 {
+    LOG_MARKER();
+
     if (LOOKUP_NODE_MODE)
     {
         LOG_GENERAL(WARNING,
@@ -146,8 +149,6 @@ bool DirectoryService::ProcessStateDelta(
                     "called from LookUp node.");
         return true;
     }
-
-    LOG_MARKER();
 
     LOG_GENERAL(INFO,
                 "Received MicroBlock State Delta hash : "
@@ -162,22 +163,18 @@ bool DirectoryService::ProcessStateDelta(
         return true;
     }
 
-    vector<unsigned char> stateDeltaBytes;
-    copy(message.begin() + cur_offset, message.end(),
-         back_inserter(stateDeltaBytes));
-
-    if (stateDeltaBytes.empty())
+    if (stateDelta.empty())
     {
         LOG_GENERAL(INFO, "State Delta is empty");
         return true;
     }
     else
     {
-        LOG_GENERAL(INFO, "State Delta size: " << stateDeltaBytes.size());
+        LOG_GENERAL(INFO, "State Delta size: " << stateDelta.size());
     }
 
     SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
-    sha2.Update(stateDeltaBytes);
+    sha2.Update(stateDelta);
     StateHash stateDeltaHash(sha2.Finalize());
 
     LOG_GENERAL(INFO, "Calculated StateHash: " << stateDeltaHash);
@@ -195,8 +192,7 @@ bool DirectoryService::ProcessStateDelta(
         return false;
     }
 
-    if (AccountStore::GetInstance().DeserializeDeltaTemp(stateDeltaBytes, 0)
-        != 0)
+    if (AccountStore::GetInstance().DeserializeDeltaTemp(stateDelta, 0) != 0)
     {
         LOG_GENERAL(WARNING,
                     "AccountStore::GetInstance().DeserializeDeltaTemp failed");
@@ -211,7 +207,8 @@ bool DirectoryService::ProcessStateDelta(
 }
 
 bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
-    const vector<unsigned char>& message, unsigned int curr_offset)
+    const vector<MicroBlock>& microBlocks,
+    const vector<unsigned char>& stateDelta)
 {
     if (LOOKUP_NODE_MODE)
     {
@@ -221,22 +218,7 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
         return true;
     }
 
-    // 4-byte shard ID
-    // uint32_t shardId = Serializable::GetNumber<uint32_t>(message, curr_offset,
-    //                                                      sizeof(uint32_t));
-    // curr_offset += sizeof(uint32_t);
-    // LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-    //           "shard_id " << shardId);
-
-    // Tx microblock
-    // MicroBlock microBlock(message, curr_offset);
-    MicroBlock microBlock;
-    if (microBlock.DeserializeCore(message, curr_offset) != 0)
-    {
-        LOG_GENERAL(WARNING, "We failed to deserialize MicroBlock.");
-        return false;
-    }
-    curr_offset += microBlock.GetSerializedCoreSize();
+    const MicroBlock& microBlock = microBlocks.at(0);
 
     uint32_t shardId = microBlock.GetHeader().GetShardID();
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -292,17 +274,16 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
         return false;
     }
 
-    auto& microBlocks = m_microBlocks[m_mediator.m_currentEpochNum];
-    microBlocks.emplace(microBlock);
+    auto& microBlocksAtEpoch = m_microBlocks[m_mediator.m_currentEpochNum];
+    microBlocksAtEpoch.emplace(microBlock);
 
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              microBlocks.size()
+              microBlocksAtEpoch.size()
                   << " of " << m_shards.size() << " microblocks received");
 
-    ProcessStateDelta(message, curr_offset,
-                      microBlock.GetHeader().GetStateDeltaHash());
+    ProcessStateDelta(stateDelta, microBlock.GetHeader().GetStateDeltaHash());
 
-    if (microBlocks.size() == m_shards.size())
+    if (microBlocksAtEpoch.size() == m_shards.size())
     {
         if (m_mode == PRIMARY_DS)
         {
@@ -315,12 +296,11 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
                           + 1
                       << "] LAST");
         }
-        for (auto& microBlock : microBlocks)
+        for (auto& mb : microBlocksAtEpoch)
         {
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Timestamp: "
-                          << microBlock.GetHeader().GetTimestamp()
-                          << microBlock.GetHeader().GetStateDeltaHash());
+                      "Timestamp: " << mb.GetHeader().GetTimestamp()
+                                    << mb.GetHeader().GetStateDeltaHash());
         }
 
         // m_mediator.m_node->RunConsensusOnMicroBlock();
@@ -387,12 +367,10 @@ void DirectoryService::CommitMBSubmissionMsgBuffer()
                         .GetHeader()
                         .GetBlockNum())
         {
-            for (const auto& msg : it->second)
+            for (const auto& entry : it->second)
             {
-                ProcessMicroblockSubmissionFromShardCore(
-                    msg,
-                    MessageOffset::BODY + sizeof(unsigned char) //mbtype
-                        + sizeof(uint64_t));
+                ProcessMicroblockSubmissionFromShardCore(entry.m_microBlocks,
+                                                         entry.m_stateDelta);
             }
             m_MBSubmissionBuffer.erase(it);
             break;
@@ -405,11 +383,9 @@ void DirectoryService::CommitMBSubmissionMsgBuffer()
 }
 
 bool DirectoryService::ProcessMicroblockSubmissionFromShard(
-    [[gnu::unused]] const vector<unsigned char>& message,
-    [[gnu::unused]] unsigned int offset, [[gnu::unused]] const Peer& from)
+    const uint64_t blockNumber, const vector<MicroBlock>& microBlocks,
+    const vector<unsigned char>& stateDelta)
 {
-    // Message = [8-byte Tx blocknum] /*[4-byte shard ID]*/ [Tx microblock] [State delta]
-
     LOG_MARKER();
 
     // if (!CheckState(PROCESS_MICROBLOCKSUBMISSION))
@@ -419,43 +395,31 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShard(
     //     return false;
     // }
 
-    if (IsMessageSizeInappropriate(message.size(), offset,
-                                   sizeof(uint64_t) + MicroBlock::GetMinSize()))
-    {
-        return false;
-    }
-
-    unsigned int curr_offset = offset;
-
-    // 8-byte Tx block number
-    uint64_t latestSubmitTxBlockNum = Serializable::GetNumber<uint64_t>(
-        message, curr_offset, sizeof(uint64_t));
-    curr_offset += sizeof(uint64_t);
-
     LOG_GENERAL(INFO,
                 "Received microblock submission for block number "
-                    << latestSubmitTxBlockNum);
+                    << blockNumber);
 
     if (m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum()
-        < latestSubmitTxBlockNum)
+        < blockNumber)
     {
         lock_guard<mutex> g(m_mutexMBSubmissionBuffer);
-        m_MBSubmissionBuffer[latestSubmitTxBlockNum].push_back(message);
+        m_MBSubmissionBuffer[blockNumber].emplace_back(microBlocks, stateDelta);
 
         return true;
     }
     else if (m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum()
-             == latestSubmitTxBlockNum)
+             == blockNumber)
     {
         if (CheckState(PROCESS_MICROBLOCKSUBMISSION))
         {
-            return ProcessMicroblockSubmissionFromShardCore(message,
-                                                            curr_offset);
+            return ProcessMicroblockSubmissionFromShardCore(microBlocks,
+                                                            stateDelta);
         }
         else
         {
             lock_guard<mutex> g(m_mutexMBSubmissionBuffer);
-            m_MBSubmissionBuffer[latestSubmitTxBlockNum].push_back(message);
+            m_MBSubmissionBuffer[blockNumber].emplace_back(microBlocks,
+                                                           stateDelta);
 
             return true;
         }
@@ -475,6 +439,8 @@ bool DirectoryService::ProcessMicroblockSubmission(
     [[gnu::unused]] const vector<unsigned char>& message,
     [[gnu::unused]] unsigned int offset, [[gnu::unused]] const Peer& from)
 {
+    LOG_MARKER();
+
     if (LOOKUP_NODE_MODE)
     {
         LOG_GENERAL(WARNING,
@@ -483,20 +449,29 @@ bool DirectoryService::ProcessMicroblockSubmission(
         return true;
     }
 
-    LOG_MARKER();
+    unsigned char submitMBType = 0;
+    uint64_t blockNumber = 0;
+    vector<MicroBlock> microBlocks;
+    vector<unsigned char> stateDelta;
 
-    unsigned int cur_offset = offset;
-
-    unsigned char submitMBType = message[cur_offset];
-    cur_offset += sizeof(unsigned char);
+    if (!Messenger::GetDSMicroBlockSubmission(message, offset, submitMBType,
+                                              blockNumber, microBlocks,
+                                              stateDelta))
+    {
+        LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Messenger::GetDSMicroBlockSubmission failed.");
+        return false;
+    }
 
     if (submitMBType == SUBMITMICROBLOCKTYPE::SHARDMICROBLOCK)
     {
-        return ProcessMicroblockSubmissionFromShard(message, cur_offset, from);
+        return ProcessMicroblockSubmissionFromShard(blockNumber, microBlocks,
+                                                    stateDelta);
     }
     else if (submitMBType == SUBMITMICROBLOCKTYPE::MISSINGMICROBLOCK)
     {
-        return ProcessMissingMicroblockSubmission(message, cur_offset, from);
+        return ProcessMissingMicroblockSubmission(blockNumber, microBlocks,
+                                                  stateDelta);
     }
     else
     {
@@ -507,44 +482,23 @@ bool DirectoryService::ProcessMicroblockSubmission(
 }
 
 bool DirectoryService::ProcessMissingMicroblockSubmission(
-    [[gnu::unused]] const vector<unsigned char>& message,
-    [[gnu::unused]] unsigned int offset, [[gnu::unused]] const Peer&)
+    const uint64_t blockNumber, const vector<MicroBlock>& microBlocks,
+    const vector<unsigned char>& stateDelta)
 {
-    unsigned int cur_offset = offset;
-
-    auto blockNum = Serializable::GetNumber<uint64_t>(message, cur_offset,
-                                                      sizeof(uint64_t));
-    cur_offset += sizeof(uint64_t);
-
-    if (blockNum != m_mediator.m_currentEpochNum)
+    if (blockNumber != m_mediator.m_currentEpochNum)
     {
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "untimely delivery of "
-                      << "missing microblocks. received: " << blockNum
+                      << "missing microblocks. received: " << blockNumber
                       << " , local: " << m_mediator.m_currentEpochNum);
     }
 
-    auto microblocksNum = Serializable::GetNumber<uint32_t>(message, cur_offset,
-                                                            sizeof(uint32_t));
-    cur_offset += sizeof(uint32_t);
-
     {
         lock_guard<mutex> g(m_mutexMicroBlocks);
-        auto& microBlocks = m_microBlocks[blockNum];
+        auto& microBlocksAtEpoch = m_microBlocks[blockNumber];
 
-        for (uint32_t i = 0; i < microblocksNum; i++)
+        for (const auto& microBlock : microBlocks)
         {
-            MicroBlock microBlock;
-            if (microBlock.DeserializeCore(message, cur_offset) != 0)
-            {
-                LOG_GENERAL(
-                    WARNING,
-                    "Deserialize microblock failed, stop at the previous "
-                    "successful one");
-                return false;
-            }
-            cur_offset += microBlock.GetSerializedCoreSize();
-
             uint32_t shardId = microBlock.GetHeader().GetShardID();
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "shard_id " << shardId);
@@ -618,12 +572,13 @@ bool DirectoryService::ProcessMissingMicroblockSubmission(
                 continue;
             }
 
-            microBlocks.emplace(microBlock);
+            microBlocksAtEpoch.emplace(microBlock);
 
             LOG_GENERAL(INFO,
-                        microBlocks.size()
+                        microBlocksAtEpoch.size()
                             << " of " << m_shards.size() + 1
-                            << " microblocks received for Epoch " << blockNum);
+                            << " microblocks received for Epoch "
+                            << blockNumber);
         }
     }
 
@@ -646,18 +601,14 @@ bool DirectoryService::ProcessMissingMicroblockSubmission(
 
     if (m_finalBlock->GetHeader().GetStateDeltaHash() != StateHash())
     {
-        vector<unsigned char> stateDeltaBytes;
-        copy(message.begin() + cur_offset, message.end(),
-             back_inserter(stateDeltaBytes));
-
-        if (stateDeltaBytes.empty())
+        if (stateDelta.empty())
         {
             LOG_GENERAL(WARNING, "Cannot get state delta from message");
             return false;
         }
 
         SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
-        sha2.Update(stateDeltaBytes);
+        sha2.Update(stateDelta);
         StateHash stateDeltaHash(sha2.Finalize());
 
         LOG_GENERAL(INFO, "Calculated StateHash: " << stateDeltaHash);
@@ -670,7 +621,7 @@ bool DirectoryService::ProcessMissingMicroblockSubmission(
             return false;
         }
 
-        if (AccountStore::GetInstance().DeserializeDeltaTemp(stateDeltaBytes, 0)
+        if (AccountStore::GetInstance().DeserializeDeltaTemp(stateDelta, 0)
             != 0)
         {
             LOG_GENERAL(WARNING,

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -613,7 +613,7 @@ bool Messenger::GetDSMicroBlockSubmission(const vector<unsigned char>& src,
 
     result.ParseFromArray(src.data() + offset, src.size() - offset);
 
-    if (result.IsInitialized())
+    if (!result.IsInitialized())
     {
         LOG_GENERAL(WARNING, "DSMicroBlockSubmission initialization failed.");
         return false;

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -46,6 +46,17 @@ public:
                                    uint64_t& nonce, std::string& resultingHash,
                                    std::string& mixHash, Signature& signature);
 
+    static bool SetDSMicroBlockSubmission(
+        std::vector<unsigned char>& dst, const unsigned int offset,
+        const unsigned char microBlockType, const uint64_t blockNumber,
+        const std::vector<MicroBlock>& microBlocks,
+        const std::vector<unsigned char>& stateDelta);
+    static bool GetDSMicroBlockSubmission(
+        const std::vector<unsigned char>& src, const unsigned int offset,
+        unsigned char& microBlockType, uint64_t& blockNumber,
+        std::vector<MicroBlock>& microBlocks,
+        std::vector<unsigned char>& stateDelta);
+
     static bool SetDSDSBlockAnnouncement(
         std::vector<unsigned char>& dst, const unsigned int offset,
         const uint32_t consensusID, const std::vector<unsigned char>& blockHash,

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -106,6 +106,14 @@ message DSPoWSubmission
     required ByteArray signature           = 2;
 }
 
+message DSMicroBlockSubmission
+{
+    required uint32 microblocktype = 1; // only LSB used
+    required uint64 blocknumber    = 2;
+    repeated ByteArray microblocks = 3;
+    optional bytes statedelta      = 4;
+}
+
 message DSDSBlockAnnouncement
 {
     required ProtoDSBlock dsblock             = 1;

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -580,6 +580,8 @@ void Node::BeginNextConsensusRound()
 void Node::GetMyShardsMicroBlock(const uint64_t& blocknum, uint8_t sharing_mode,
                                  vector<TransactionWithReceipt>& txns_to_send)
 {
+    LOG_MARKER();
+
     if (LOOKUP_NODE_MODE)
     {
         LOG_GENERAL(WARNING,
@@ -588,26 +590,28 @@ void Node::GetMyShardsMicroBlock(const uint64_t& blocknum, uint8_t sharing_mode,
         return;
     }
 
-    LOG_MARKER();
-
-    const vector<TxnHash>& tx_hashes = m_microblock->GetTranHashes();
-    for (const auto& tx_hash : tx_hashes)
+    if (m_microblock != nullptr)
     {
-        if (!FindTxnInProcessedTxnsList(blocknum, sharing_mode, txns_to_send,
-                                        tx_hash))
+        const vector<TxnHash>& tx_hashes = m_microblock->GetTranHashes();
+        for (const auto& tx_hash : tx_hashes)
         {
-            LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                      "Failed trying to find txn in processed txn list");
+            if (!FindTxnInProcessedTxnsList(blocknum, sharing_mode,
+                                            txns_to_send, tx_hash))
+            {
+                LOG_EPOCH(WARNING,
+                          to_string(m_mediator.m_currentEpochNum).c_str(),
+                          "Failed trying to find txn in processed txn list");
+            }
         }
-    }
 
-    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Number of transactions to broadcast for block "
-                  << blocknum << " = " << txns_to_send.size());
+        LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Number of transactions to broadcast for block "
+                      << blocknum << " = " << txns_to_send.size());
 
-    {
-        lock_guard<mutex> g(m_mutexProcessedTransactions);
-        m_processedTransactions.erase(blocknum);
+        {
+            lock_guard<mutex> g(m_mutexProcessedTransactions);
+            m_processedTransactions.erase(blocknum);
+        }
     }
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In this PR `DSInstructionType::MICROBLOCKSUBMISSION` has been protobuf-ed.
This message is sent by Node to DS (type `SHARDMICROBLOCK`) and by DS to DS (type `MISSINGMICROBLOCK`).

This PR also fixes an issue with forwarding transactions, found during testing.
If a node had to fetch missing microblocks, `Node::GetMyShardsMicroBlock` can crash because `m_microblock` was set to null inside `Node::MicroBlockValidator`.
The fix is to just not let this node forward transactions if its microblock reference is null.

Tested by avoiding sending the microblock to one backup DS in `Node::SubmitMicroblockToDSCommittee`.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Note that `m_MBSubmissionBuffer` type has been changed.
Previously we buffered the raw message.
This time the buffer already contains the deserialized components.
This is to avoid re-deserializing again, because `DirectoryService::ProcessMicroblockSubmission` initially needs the submit type part of the message before either processing the message or buffering it for later.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
