### PR TITLE
 Fix interruption caused by late ProcessFinalBlockConsensus

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -379,6 +379,10 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
             LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                       "[PoW needed]");
 
+            m_consensusID = 0;
+            m_mediator.m_node->m_consensusID = 0;
+            m_mediator.m_node->m_consensusLeaderID = 0;
+
             CleanFinalblockConsensusBuffer();
 
             m_mediator.m_node->CleanCreatedTransaction();
@@ -393,9 +397,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone()
                     .GetHeader()
                     .GetBlockNum()
                 + 1);
-            m_consensusID = 0;
-            m_mediator.m_node->m_consensusID = 0;
-            m_mediator.m_node->m_consensusLeaderID = 0;
             if (m_mode == PRIMARY_DS)
             {
                 LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
@@ -534,6 +535,8 @@ bool DirectoryService::ProcessFinalBlockConsensus(
 
         LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                   "Process final block arrived early, saved to buffer");
+
+        lock_guard<mutex> g(m_mutexConsensus);
 
         if (consensus_id == m_consensusID)
         {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -743,6 +743,8 @@ bool Node::ProcessTxnPacketFromLookupCore(
                 LOG_GENERAL(WARNING, "Txn is not valid.");
             }
 
+            processed_count++;
+
             if (processed_count % 100 == 0)
             {
                 LOG_GENERAL(INFO,

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -735,8 +735,8 @@ bool Node::ProcessTxnPacketFromLookupCore(
                 else
                 {
                     compIdx.insert(tx);
-                    txn_sent_count++;
                 }
+                txn_sent_count++;
             }
             else
             {
@@ -752,7 +752,7 @@ bool Node::ProcessTxnPacketFromLookupCore(
             }
         }
     }
-    LOG_GENERAL(INFO, "TXN COUNT" << txn_sent_count);
+    LOG_GENERAL(INFO, "INSERTED TXN COUNT" << txn_sent_count);
 
     return true;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Previously in `ProcessFinalBlockConsensusWhenDone()`, when the vacuous epoch comes, the `m_consensusID` is updated after ethash was set up, which may be quite late, but the state was already changed to `POW_SUBMISSION`.
However under current design, when a ds receive finalblock consensus message, it will check whether it's under the correct state, otherwise it will force it to be changed to the right state for processing finalblock, and triggers `RunConsensusOnFinalBlock`.
In this case, if a node happens to send the consensus message slightly late, it will interrupt the normal procedure of the protocol.

The fix here is to solve this issue.

And there is also a minor fix on the logging of processed_count, as it's tiny, was also included here.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [X] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
