### PR TITLE
Use the Messenger functions for the remaining lookup messages

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1726,7 +1726,7 @@ bool Lookup::InitMining()
 
     if (m_mediator.m_currentEpochNum / NUM_FINAL_BLOCK_PER_POW == curDsBlockNum)
     {
-        if (true /*CheckStateRoot()*/)
+        if (CheckStateRoot())
         {
             // Attempt PoW
             m_startedPoW = true;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR uses the Messenger protobuf functions pushed in #580 for the remaining lookup messages.
It covers messages starting from `GETSTATEFROMSEED` (0x0A).

Here is the breakdown of changed messages:
- `GETNETWORKIDFROMSEED` - not changed (seems like this isn't called anywhere)
- `SETNETWORKIDFROMSEED` - not changed (seems like this isn't called anywhere)
- `GETSTATEFROMSEED` - changed to use Messenger
- `SETSTATEFROMSEED` - changed to use Messenger
- `SETLOOKUPOFFLINE` - changed to use Messenger
- `SETLOOKUPONLINE` - changed to use Messenger
- `GETOFFLINELOOKUPS` - changed to use Messenger
- `SETOFFLINELOOKUPS` - changed to use Messenger
- `RAISESTARTPOW` - not changed (empty message)
- `GETSTARTPOWFROMSEED` - changed to use Messenger
- `SETSTARTPOWFROMSEED` - not changed (empty message)
- Remaining messages already use Messenger

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Local testing steps done:
1. Disable `CheckStateRoot` in `InitMining`
2. test_gentxn
3. test_node_lookup
4. test_node_simple
5. test_node_late

Functions that were called and tested ok:
- `SetLookupGetStateFromSeed`
- `GetLookupGetStateFromSeed`
- `SetLookupSetStateFromSeed`
- `GetLookupSetStateFromSeed`
- `SetLookupGetOfflineLookups`
- `GetLookupGetOfflineLookups`
- `SetLookupSetOfflineLookups`
- `GetLookupSetOfflineLookups`
- `SetLookupGetStartPoWFromSeed`
- `GetLookupGetStartPoWFromSeed`

These functions weren't called because they require lookup node rejoining (#631):
- `SetLookupSetLookupOffline`
- `GetLookupSetLookupOffline`
- `SetLookupSetLookupOnline`
- `GetLookupSetLookupOnline`

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
