### PR TITLE
Enable SHA-256 verification for upgrading protocol

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -113,7 +113,7 @@ echo -e "Making SHA-256 & multi-signature..."
 privKeyFile="$(realpath $1)"
 pubKeyFile="$(realpath $2)"
 cd ${releaseDir}
-sha="$(sha256sum ${debFile}|cut -d ' ' -f1)"
+sha="$(sha256sum ${debFile}|cut -d ' ' -f1|tr 'a-z' 'A-Z')"
 sed -i "${shaLine}s/.*/${sha}/" ${versionFile}
 signature="$(./bin/signmultisig ${sha} ${privKeyFile} ${pubKeyFile})"
 sed -i "${sigLine}s/.*/${signature}/" ${versionFile}
@@ -147,32 +147,17 @@ curl -v -s \
   -H "Authorization: token ${GitHubToken}" \
   -H "Content-Type:application/json" \
   --data-binary @${pubKeyFile} \
-  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=$(basename {pubKeyFile})" \
-  -d '{
-  "Content-Type": "application/octet-stream",
-  "name": "'"$(basename ${pubKeyFile})"'",
-  "label": "'"${newVer}"'"
-}'
+  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=$(basename {pubKeyFile})"
 curl -v -s \
   -H "Authorization: token ${GitHubToken}" \
   -H "Content-Type:application/json" \
   --data-binary @${releaseDir}/${debFile} \
-  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=${debFile}" \
-  -d '{
-  "Content-Type": "application/vnd.debian.binary-package",
-  "name": "'"${debFile}"'",
-  "label": "'"${newVer}"'"
-}'
+  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=${debFile}"
 curl -v -s \
   -H "Authorization: token ${GitHubToken}" \
   -H "Content-Type:application/json" \
   --data-binary @${releaseDir}/${versionFile} \
-  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=${versionFile}" \
-  -d '{
-  "Content-Type": "application/octet-stream",
-  "name": "'"${versionFile}"'",
-  "label": "'"${newVer}"'"
-}'
+  "https://uploads.github.com/repos/${ownerName}/${repoName}/releases/${releaseId}/assets?name=${versionFile}"
 rm ${releaseLog}
 echo -e "\nA new draft release with package is created on Github sucessfully, please proceed to publishing the draft release on Github webpage.\n"
 

--- a/src/libUtils/UpgradeManager.cpp
+++ b/src/libUtils/UpgradeManager.cpp
@@ -376,15 +376,13 @@ bool UpgradeManager::DownloadSW()
         downloadSha = DataConversion::Uint8VecToHexStr(output);
     }
 
-    /*
-    /// Temporarily comment out, cause GitHub would attach extra information in the tail of every file.
-    /// (https://github.com/Zilliqa/Issues/issues/185)
     if (sha != downloadSha)
     {
-        LOG_GENERAL(WARNING, "SHA-256 checksum of .deb file does not match!");
+        LOG_GENERAL(WARNING,
+                    "SHA-256 checksum of .deb file does not match, expected: "
+                        << sha << ", real: " << downloadSha);
         return false;
     }
-*/
 
     m_latestSWInfo = make_shared<SWInfo>(major, minor, fix, upgradeDS, commit);
     m_latestSHA = DataConversion::HexStrToUint8Vec(sha);


### PR DESCRIPTION


## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In upgrading protocol, released package would be uploaded onto GitHub, and then be downloaded to each node.
Bunch of verification would be applied on the downloaded files including SHA-256 checksum, before really upgrading the nodes.

Previously, some extra information would be appended in the tail of uploaded files, to result in SHA-256 checksum failed.
This PR is to fix this bug, and enable SHA-256 checksum for downloaded files.
https://github.com/Zilliqa/Issues/issues/185

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (20 nodes, commit: 78b960e)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
- [x] large-scale cloud test (200 nodes, commit: 78b960e)
