### PR TITLE
Temporarily disable heartbeat check

### DIFF
--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -145,8 +145,10 @@ void Mediator::HeartBeatLaunch()
     auto func = [this]() -> void {
 
         // Set base timeout to roughly around one DS epoch (doesn't have to be very accurate)
-        const unsigned int heartBeatTimeoutInSeconds = POW_WINDOW_IN_SECONDS
-            + (TX_DISTRIBUTE_TIME_IN_MS / 1000) * NUM_FINAL_BLOCK_PER_POW;
+        const unsigned int heartBeatTimeoutInSeconds = NEW_NODE_SYNC_INTERVAL
+            + POW_WINDOW_IN_SECONDS
+            + ((TX_DISTRIBUTE_TIME_IN_MS + FINALBLOCK_DELAY_IN_MS) / 1000)
+                * NUM_FINAL_BLOCK_PER_POW;
 
         if (heartBeatTimeoutInSeconds <= HEARTBEAT_INTERVAL_IN_SECONDS)
         {

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -174,7 +174,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
     {
         LOG_GENERAL(INFO, "I am a normal node.");
 
-        m_mediator.HeartBeatLaunch();
+        //m_mediator.HeartBeatLaunch();
     }
     else
     {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Heartbeat is currently interfering with DS committee progress during the period between PoW submissions and the end of DSBlock consensus.

This PR temporarily disables the heartbeat thread and it also increases the estimated duration of one DS epoch.

The heartbeat should be re-enabled after we implement the prioritization between viewchange, heartbeat, and fallback (ideally only one should be triggered at a time).

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
