### PR TITLE
Changed data block types serialization to completely use Messenger

### DIFF
--- a/src/common/Serializable.h
+++ b/src/common/Serializable.h
@@ -77,4 +77,59 @@ class Serializable {
   }
 };
 
+// This is a temporary class for use with data blocks
+class Serializable2 {
+ public:
+  /// Serializes internal state to destination byte stream.
+  virtual bool Serialize(std::vector<unsigned char>& dst,
+                         unsigned int offset) const = 0;
+
+  /// Deserializes source byte stream into internal state.
+  virtual bool Deserialize(const std::vector<unsigned char>& src,
+                           unsigned int offset) = 0;
+
+  /// Virtual destructor.
+  virtual ~Serializable2() {}
+
+  /// Template function for extracting a number from the source byte stream at
+  /// the specified offset. Returns 0 if there are not enough bytes to read from
+  /// the stream.
+  template <class numerictype>
+  static numerictype GetNumber(const std::vector<unsigned char>& src,
+                               unsigned int offset,
+                               unsigned int numerictype_len) {
+    numerictype result = 0;
+
+    if (offset + numerictype_len <= src.size()) {
+      unsigned int left_shift = (numerictype_len - 1) * 8;
+      for (unsigned int i = 0; i < numerictype_len; i++) {
+        numerictype tmp = src.at(offset + i);
+        result += (tmp << left_shift);
+        left_shift -= 8;
+      }
+    }
+
+    return result;
+  }
+
+  /// Template function for placing a number into the destination byte stream at
+  /// the specified offset. Destination is resized if necessary.
+  template <class numerictype>
+  static void SetNumber(std::vector<unsigned char>& dst, unsigned int offset,
+                        numerictype value, unsigned int numerictype_len) {
+    const unsigned int length_available = dst.size() - offset;
+
+    if (length_available < numerictype_len) {
+      dst.resize(dst.size() + numerictype_len - length_available);
+    }
+
+    unsigned int right_shift = (numerictype_len - 1) * 8;
+    for (unsigned int i = 0; i < numerictype_len; i++) {
+      dst.at(offset + i) =
+          static_cast<unsigned char>((value >> right_shift) & 0xFF);
+      right_shift -= 8;
+    }
+  }
+};
+
 #endif  // __SERIALIZABLE_H__

--- a/src/common/Serializable.h
+++ b/src/common/Serializable.h
@@ -78,7 +78,7 @@ class Serializable {
 };
 
 // This is a temporary class for use with data blocks
-class Serializable2 {
+class SerializableDataBlock {
  public:
   /// Serializes internal state to destination byte stream.
   virtual bool Serialize(std::vector<unsigned char>& dst,
@@ -89,7 +89,7 @@ class Serializable2 {
                            unsigned int offset) = 0;
 
   /// Virtual destructor.
-  virtual ~Serializable2() {}
+  virtual ~SerializableDataBlock() {}
 
   /// Template function for extracting a number from the source byte stream at
   /// the specified offset. Returns 0 if there are not enough bytes to read from

--- a/src/libDB/ArchiveDB.cpp
+++ b/src/libDB/ArchiveDB.cpp
@@ -85,7 +85,8 @@ bool ArchiveDB::InsertSerializable(const Serializable& sz, const string& index,
 }
 
 // Temporary function for use by data blocks
-bool ArchiveDB::InsertSerializable(const Serializable2& sz, const string& index,
+bool ArchiveDB::InsertSerializable(const SerializableDataBlock& sz,
+                                   const string& index,
                                    const string& collectionName) {
   if (!m_isInitialized) {
     return false;

--- a/src/libDB/ArchiveDB.h
+++ b/src/libDB/ArchiveDB.h
@@ -31,6 +31,9 @@ class ArchiveDB : public BaseDB {
   bool InsertDSBlock(const DSBlock& dsblock);
   bool InsertSerializable(const Serializable& sz, const std::string& index,
                           const std::string& collectionName);
+  // Temporary function for use by data blocks
+  bool InsertSerializable(const Serializable2& sz, const std::string& index,
+                          const std::string& collectionName);
   bool InsertAccount(const Address& addr, const Account& acc);
   bool GetSerializable(std::vector<unsigned char>& retVec,
                        const std::string& index,

--- a/src/libDB/ArchiveDB.h
+++ b/src/libDB/ArchiveDB.h
@@ -32,7 +32,8 @@ class ArchiveDB : public BaseDB {
   bool InsertSerializable(const Serializable& sz, const std::string& index,
                           const std::string& collectionName);
   // Temporary function for use by data blocks
-  bool InsertSerializable(const Serializable2& sz, const std::string& index,
+  bool InsertSerializable(const SerializableDataBlock& sz,
+                          const std::string& index,
                           const std::string& collectionName);
   bool InsertAccount(const Address& addr, const Account& acc);
   bool GetSerializable(std::vector<unsigned char>& retVec,

--- a/src/libData/BlockData/Block/BlockBase.cpp
+++ b/src/libData/BlockData/Block/BlockBase.cpp
@@ -28,57 +28,6 @@ using namespace boost::multiprecision;
 
 BlockBase::BlockBase() {}
 
-unsigned int BlockBase::GetSerializedSize() const {
-  return BLOCK_SIG_SIZE +
-         BitVector::GetBitVectorSerializedSize(m_cosigs.m_B1.size()) +
-         BLOCK_SIG_SIZE +
-         BitVector::GetBitVectorSerializedSize(m_cosigs.m_B2.size());
-}
-
-unsigned int BlockBase::GetMinSize() {
-  return BLOCK_SIG_SIZE + BitVector::GetBitVectorSerializedSize(1) +
-         BLOCK_SIG_SIZE + BitVector::GetBitVectorSerializedSize(1);
-}
-
-unsigned int BlockBase::Serialize(vector<unsigned char>& dst,
-                                  unsigned int offset) const {
-  unsigned int curOffset = offset;
-
-  m_cosigs.m_CS1.Serialize(dst, curOffset);
-  curOffset += BLOCK_SIG_SIZE;
-
-  curOffset += BitVector::SetBitVector(dst, curOffset, m_cosigs.m_B1);
-
-  m_cosigs.m_CS2.Serialize(dst, curOffset);
-  curOffset += BLOCK_SIG_SIZE;
-
-  curOffset += BitVector::SetBitVector(dst, curOffset, m_cosigs.m_B2);
-
-  return curOffset - offset;
-}
-
-int BlockBase::Deserialize(const vector<unsigned char>& src,
-                           unsigned int offset) {
-  try {
-    m_cosigs.m_CS1.Deserialize(src, offset);
-    offset += BLOCK_SIG_SIZE;
-
-    m_cosigs.m_B1 = BitVector::GetBitVector(src, offset);
-    offset += BitVector::GetBitVectorSerializedSize(m_cosigs.m_B1.size());
-
-    m_cosigs.m_CS2.Deserialize(src, offset);
-    offset += BLOCK_SIG_SIZE;
-
-    m_cosigs.m_B2 = BitVector::GetBitVector(src, offset);
-    offset += BitVector::GetBitVectorSerializedSize(m_cosigs.m_B2.size());
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING,
-                "Error with BlockBase::Deserialize." << ' ' << e.what());
-    return -1;
-  }
-  return 0;
-}
-
 const Signature& BlockBase::GetCS1() const { return m_cosigs.m_CS1; }
 
 const vector<bool>& BlockBase::GetB1() const { return m_cosigs.m_B1; }

--- a/src/libData/BlockData/Block/BlockBase.h
+++ b/src/libData/BlockData/Block/BlockBase.h
@@ -44,7 +44,7 @@ struct CoSignatures {
 };
 
 /// [TODO] Base class for all supported block data types
-class BlockBase : public Serializable2 {
+class BlockBase : public SerializableDataBlock {
   // TODO: pull out all common code from ds, micro and tx block
  protected:
   CoSignatures m_cosigs;

--- a/src/libData/BlockData/Block/BlockBase.h
+++ b/src/libData/BlockData/Block/BlockBase.h
@@ -37,10 +37,14 @@ struct CoSignatures {
   std::vector<bool> m_B2;
 
   CoSignatures(unsigned int bitmaplen = 1) : m_B1(bitmaplen), m_B2(bitmaplen) {}
+  CoSignatures(const CoSignatures& src) = default;
+  CoSignatures(const Signature& CS1, const std::vector<bool>& B1,
+               const Signature& CS2, const std::vector<bool>& B2)
+      : m_CS1(CS1), m_B1(B1), m_CS2(CS2), m_B2(B2) {}
 };
 
 /// [TODO] Base class for all supported block data types
-class BlockBase : public Serializable {
+class BlockBase : public Serializable2 {
   // TODO: pull out all common code from ds, micro and tx block
  protected:
   CoSignatures m_cosigs;
@@ -48,19 +52,6 @@ class BlockBase : public Serializable {
  public:
   /// Default constructor.
   BlockBase();
-
-  /// Returns the size in bytes when serializing the block.
-  unsigned int GetSerializedSize() const;
-
-  /// Returns the minimum size required for storing a block.
-  static unsigned int GetMinSize();
-
-  /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
-
-  /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the co-sig for first round.
   const Signature& GetCS1() const;

--- a/src/libData/BlockData/Block/DSBlock.cpp
+++ b/src/libData/BlockData/Block/DSBlock.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "DSBlock.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -30,55 +31,33 @@ DSBlock::DSBlock() {}
 
 // To-do: handle exceptions. Will be deprecated.
 DSBlock::DSBlock(const vector<unsigned char>& src, unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "We failed to init DSBlock.");
   }
 }
 
-DSBlock::DSBlock(DSBlockHeader&& header, CoSignatures&& cosigs)
-    : m_header(move(header)) {
+DSBlock::DSBlock(const DSBlockHeader& header, CoSignatures&& cosigs)
+    : m_header(header) {
   m_cosigs = move(cosigs);
 }
 
-unsigned int DSBlock::Serialize(vector<unsigned char>& dst,
-                                unsigned int offset) const {
-  unsigned int size_needed = GetSerializedSize();
-  unsigned int size_remaining = dst.size() - offset;
-
-  if (size_remaining < size_needed) {
-    dst.resize(size_needed + offset);
+bool DSBlock::Serialize(vector<unsigned char>& dst, unsigned int offset) const {
+  if (!Messenger::SetDSBlock(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetDSBlock failed.");
+    return false;
   }
-  m_header.Serialize(dst, offset);
 
-  BlockBase::Serialize(dst, offset + m_header.GetSize());
-
-  return size_needed;
+  return true;
 }
 
-int DSBlock::Deserialize(const vector<unsigned char>& src,
-                         unsigned int offset) {
-  try {
-    DSBlockHeader header;
-    if (header.Deserialize(src, offset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to init DSBlockHeader.");
-      return -1;
-    }
-    m_header = move(header);
-
-    BlockBase::Deserialize(src, offset + header.GetSize());
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING, "Error with DSBlock::Deserialize." << ' ' << e.what());
-    return -1;
+bool DSBlock::Deserialize(const vector<unsigned char>& src,
+                          unsigned int offset) {
+  if (!Messenger::GetDSBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetDSBlock failed.");
+    return false;
   }
-  return 0;
-}
 
-unsigned int DSBlock::GetSerializedSize() const {
-  return m_header.GetSize() + BlockBase::GetSerializedSize();
-}
-
-unsigned int DSBlock::GetMinSize() {
-  return m_header.GetSize() + BlockBase::GetMinSize();
+  return true;
 }
 
 const DSBlockHeader& DSBlock::GetHeader() const { return m_header; }

--- a/src/libData/BlockData/Block/DSBlock.h
+++ b/src/libData/BlockData/Block/DSBlock.h
@@ -43,21 +43,13 @@ class DSBlock : public BlockBase {
   DSBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Constructor with specified DS block parameters.
-  DSBlock(DSBlockHeader&& header, CoSignatures&& cosigs);
+  DSBlock(const DSBlockHeader& header, CoSignatures&& cosigs);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
-
-  /// Returns the size in bytes when serializing the DS block.
-  unsigned int GetSerializedSize() const;
-
-  /// Returns the minimum required size in bytes for obtaining a DS block from a
-  /// byte stream.
-  unsigned int GetMinSize();
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the reference to the DSBlockHeader part of the DS block.
   const DSBlockHeader& GetHeader() const;

--- a/src/libData/BlockData/Block/FallbackBlock.h
+++ b/src/libData/BlockData/Block/FallbackBlock.h
@@ -43,21 +43,13 @@ class FallbackBlock : public BlockBase {
   FallbackBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Constructor with specified fallback block parameters.
-  FallbackBlock(FallbackBlockHeader&& header, CoSignatures&& cosigs);
+  FallbackBlock(const FallbackBlockHeader& header, CoSignatures&& cosigs);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
-
-  /// Returns the size in bytes when serializing the block.
-  unsigned int GetSerializedSize() const;
-
-  /// Returns the minimum required size in bytes for obtaining a fallback block
-  /// from a byte stream.
-  static unsigned int GetMinSize();
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the reference to the FallbackBlockHeader part of the fallback
   /// block.

--- a/src/libData/BlockData/Block/MicroBlock.h
+++ b/src/libData/BlockData/Block/MicroBlock.h
@@ -44,41 +44,15 @@ class MicroBlock : public BlockBase {
   /// Constructor for loading existing microblock from a byte stream.
   MicroBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
-  /// Constructor with predefined member values.
-  MicroBlock(MicroBlockHeader&& header, const std::vector<TxnHash>& tranHashes,
-             CoSignatures&& cosigs);
-
-  /// Constructor with predefined member values (moveable tranHashes)
-  MicroBlock(MicroBlockHeader&& header, std::vector<TxnHash>&& tranHashes,
-             CoSignatures&& cosigs);
+  /// Constructor with predefined member values
+  MicroBlock(const MicroBlockHeader& header,
+             const std::vector<TxnHash>& tranHashes, CoSignatures&& cosigs);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
-
-  /// Returns the expected size of m_header and BlockBase when serialized into a
-  /// byte stream.
-  unsigned int GetSerializedCoreSize() const;
-
-  /// Returns the expected size of m_tranHashes when serialized into a byte
-  /// stream.
-  unsigned int GetSerializedTxnHashesSize() const;
-
-  /// Serialize function used for sending MB to DS Committee where tranHashes is
-  /// not needed
-  unsigned int SerializeCore(std::vector<unsigned char>& dst,
-                             unsigned int offset) const;
-
-  /// Deserialize function used in DS Committee where tranHashes is not needed
-  int DeserializeCore(const std::vector<unsigned char>& src,
-                      unsigned int offset);
-
-  /// Returns the minimum required size in bytes for obtaining a microblock from
-  /// a byte stream.
-  static unsigned int GetMinSize();
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the header component of the microblock.
   const MicroBlockHeader& GetHeader() const;

--- a/src/libData/BlockData/Block/TxBlock.cpp
+++ b/src/libData/BlockData/Block/TxBlock.cpp
@@ -20,126 +20,61 @@
 #include <utility>
 
 #include "TxBlock.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
 using namespace boost::multiprecision;
 
-uint32_t TxBlock::SerializeIsMicroBlockEmpty() const {
-  int ret = 0;
-  for (int i = m_isMicroBlockEmpty.size() - 1; i >= 0; --i) {
-    ret = 2 * ret + m_isMicroBlockEmpty[i];
-  }
-  return ret;
-}
-
-unsigned int TxBlock::Serialize(vector<unsigned char>& dst,
-                                unsigned int offset) const {
+bool TxBlock::Serialize(vector<unsigned char>& dst, unsigned int offset) const {
   if (m_header.GetNumMicroBlockHashes() != m_microBlockHashes.size()) {
-    LOG_GENERAL(WARNING, "assertion failed (" << __FILE__ << ":" << __LINE__
-                                              << ": " << __FUNCTION__ << ")");
+    LOG_GENERAL(WARNING, "Header microblock hash count ("
+                             << m_header.GetNumMicroBlockHashes()
+                             << ") != actual count ("
+                             << m_microBlockHashes.size() << ")");
+    return false;
   }
 
-  unsigned int size_needed = GetSerializedSize();
-  unsigned int size_remaining = dst.size() - offset;
-
-  if (size_remaining < size_needed) {
-    dst.resize(size_needed + offset);
+  if (!Messenger::SetTxBlock(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetTxBlock failed.");
+    return false;
   }
 
-  m_header.Serialize(dst, offset);
-
-  unsigned int curOffset = offset + TxBlockHeader::SIZE;
-
-  SetNumber<uint32_t>(dst, curOffset, SerializeIsMicroBlockEmpty(),
-                      sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-
-  for (unsigned int i = 0; i < m_header.GetNumMicroBlockHashes(); i++) {
-    const uint32_t& shardId = m_shardIds[i];
-    SetNumber<uint32_t>(dst, curOffset, shardId, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-
-    curOffset = m_microBlockHashes.at(i).Serialize(dst, curOffset);
-  }
-
-  BlockBase::Serialize(dst, curOffset);
-
-  return size_needed;
+  return true;
 }
 
-vector<bool> TxBlock::DeserializeIsMicroBlockEmpty(uint32_t arg) {
-  vector<bool> ret;
-  for (uint i = 0; i < m_header.GetNumMicroBlockHashes(); ++i) {
-    ret.push_back(arg % 2);
-    arg /= 2;
+bool TxBlock::Deserialize(const vector<unsigned char>& src,
+                          unsigned int offset) {
+  if (!Messenger::GetTxBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTxBlock failed.");
+    return false;
   }
-  return ret;
-}
 
-int TxBlock::Deserialize(const vector<unsigned char>& src,
-                         unsigned int offset) {
-  try {
-    TxBlockHeader header;
-    if (header.Deserialize(src, offset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to deserialize header.");
-      return -1;
-    }
-    m_header = header;
-
-    unsigned int curOffset = offset + TxBlockHeader::SIZE;
-
-    m_isMicroBlockEmpty = DeserializeIsMicroBlockEmpty(
-        GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t)));
-    curOffset += sizeof(uint32_t);
-
-    for (unsigned int i = 0; i < m_header.GetNumMicroBlockHashes(); i++) {
-      uint32_t shardId = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-      curOffset += sizeof(uint32_t);
-
-      m_shardIds.push_back(shardId);
-
-      MicroBlockHashSet microBlockHash;
-      microBlockHash.Deserialize(src, curOffset);
-      curOffset += microBlockHash.size();
-
-      m_microBlockHashes.emplace_back(microBlockHash);
-    }
-    if (m_header.GetNumMicroBlockHashes() != m_microBlockHashes.size()) {
-      LOG_GENERAL(WARNING, "assertion failed (" << __FILE__ << ":" << __LINE__
-                                                << ": " << __FUNCTION__ << ")");
-    }
-
-    BlockBase::Deserialize(src, curOffset);
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING, "Error with TxBlock::Deserialize." << ' ' << e.what());
-    return -1;
+  if (m_header.GetNumMicroBlockHashes() != m_microBlockHashes.size()) {
+    LOG_GENERAL(WARNING, "Header microblock hash count ("
+                             << m_header.GetNumMicroBlockHashes()
+                             << ") != actual count ("
+                             << m_microBlockHashes.size() << ")");
+    return false;
   }
-  return 0;
-}
 
-unsigned int TxBlock::GetSerializedSize() const {
-  return TxBlockHeader::SIZE + sizeof(uint32_t) +
-         (m_microBlockHashes.size() *
-          (MicroBlockHashSet::size() + sizeof(uint32_t))) +
-         BlockBase::GetSerializedSize();
+  return true;
 }
-
-unsigned int TxBlock::GetMinSize() { return TxBlockHeader::SIZE; }
 
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
 TxBlock::TxBlock() {}
 
 TxBlock::TxBlock(const vector<unsigned char>& src, unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "We failed to init TxBlock.");
   }
 }
 
-TxBlock::TxBlock(TxBlockHeader&& header, const vector<bool>& isMicroBlockEmpty,
+TxBlock::TxBlock(const TxBlockHeader& header,
+                 const vector<bool>& isMicroBlockEmpty,
                  const vector<MicroBlockHashSet>& microBlockHashes,
                  const vector<uint32_t>& shardIds, CoSignatures&& cosigs)
-    : m_header(move(header)),
+    : m_header(header),
       m_isMicroBlockEmpty(isMicroBlockEmpty),
       m_microBlockHashes(microBlockHashes),
       m_shardIds(shardIds) {

--- a/src/libData/BlockData/Block/TxBlock.h
+++ b/src/libData/BlockData/Block/TxBlock.h
@@ -49,26 +49,16 @@ class TxBlock : public BlockBase {
   TxBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Constructor with specified Tx block parameters.
-  TxBlock(TxBlockHeader&& header, const std::vector<bool>& isMicroBlockEmpty,
+  TxBlock(const TxBlockHeader& header,
+          const std::vector<bool>& isMicroBlockEmpty,
           const std::vector<MicroBlockHashSet>& microBlockHashes,
           const std::vector<uint32_t>& shardIds, CoSignatures&& cosigs);
 
-  uint32_t SerializeIsMicroBlockEmpty() const;
-
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
-
-  std::vector<bool> DeserializeIsMicroBlockEmpty(uint32_t arg);
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
-
-  /// Returns the size in bytes when serializing the block.
-  unsigned int GetSerializedSize() const;
-
-  /// Returns the minimum size required for storing a block.
-  static unsigned int GetMinSize();
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the reference to the TxBlockHeader part of the Tx block.
   const TxBlockHeader& GetHeader() const;

--- a/src/libData/BlockData/Block/VCBlock.cpp
+++ b/src/libData/BlockData/Block/VCBlock.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "VCBlock.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -28,58 +29,33 @@ VCBlock::VCBlock() {}
 
 // To-do: handle exceptions. Will be deprecated.
 VCBlock::VCBlock(const vector<unsigned char>& src, unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "Error. We failed to initialize VCBlock.");
   }
 }
 
-VCBlock::VCBlock(VCBlockHeader&& header, CoSignatures&& cosigs)
-    : m_header(move(header)) {
+VCBlock::VCBlock(const VCBlockHeader& header, CoSignatures&& cosigs)
+    : m_header(header) {
   m_cosigs = move(cosigs);
 }
 
-unsigned int VCBlock::Serialize(vector<unsigned char>& dst,
-                                unsigned int offset) const {
-  unsigned int size_needed = GetSerializedSize();
-  unsigned int size_remaining = dst.size() - offset;
-
-  if (size_remaining < size_needed) {
-    dst.resize(size_needed + offset);
+bool VCBlock::Serialize(vector<unsigned char>& dst, unsigned int offset) const {
+  if (!Messenger::SetVCBlock(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetVCBlock failed.");
+    return false;
   }
 
-  m_header.Serialize(dst, offset);
-
-  BlockBase::Serialize(dst, offset + VCBlockHeader::SIZE);
-
-  return size_needed;
+  return true;
 }
 
-int VCBlock::Deserialize(const vector<unsigned char>& src,
-                         unsigned int offset) {
-  LOG_MARKER();
-  try {
-    VCBlockHeader header;
-    if (header.Deserialize(src, offset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to init DSBlockHeader.");
-      return -1;
-    }
-    m_header = move(header);
-
-    BlockBase::Deserialize(src, offset + VCBlockHeader::SIZE);
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING,
-                "ERROR: Error with VCBlock::Deserialize." << ' ' << e.what());
-    return -1;
+bool VCBlock::Deserialize(const vector<unsigned char>& src,
+                          unsigned int offset) {
+  if (!Messenger::GetVCBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetVCBlock failed.");
+    return false;
   }
-  return 0;
-}
 
-unsigned int VCBlock::GetSerializedSize() const {
-  return VCBlockHeader::SIZE + BlockBase::GetSerializedSize();
-}
-
-unsigned int VCBlock::GetMinSize() {
-  return VCBlockHeader::SIZE + BlockBase::GetMinSize();
+  return true;
 }
 
 const VCBlockHeader& VCBlock::GetHeader() const { return m_header; }

--- a/src/libData/BlockData/Block/VCBlock.h
+++ b/src/libData/BlockData/Block/VCBlock.h
@@ -42,23 +42,15 @@ class VCBlock : public BlockBase {
   VCBlock(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Constructor with specified VC block parameters.
-  VCBlock(VCBlockHeader&& header, CoSignatures&& cosigs);
+  VCBlock(const VCBlockHeader& header, CoSignatures&& cosigs);
 
   /// Implements the Serialize function inherited from Serializable.
   /// Return size of serialized structure
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
   /// Return 0 if successed, -1 if failed
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
-
-  /// Returns the size in bytes when serializing the VC block.
-  unsigned int GetSerializedSize() const;
-
-  /// Returns the minimum required size in bytes for obtaining a VC block from a
-  /// byte stream.
-  static unsigned int GetMinSize();
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the reference to the VCBlockHeader part of the VC block.
   const VCBlockHeader& GetHeader() const;

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
@@ -30,7 +30,7 @@
 #include "libData/AccountData/Transaction.h"
 
 /// [TODO] Base class for all supported block header types
-class BlockHeaderBase : public Serializable {
+class BlockHeaderBase : public Serializable2 {
  protected:
   // TODO: pull out all common code from ds, micro and tx block header
 

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
@@ -30,7 +30,7 @@
 #include "libData/AccountData/Transaction.h"
 
 /// [TODO] Base class for all supported block header types
-class BlockHeaderBase : public Serializable2 {
+class BlockHeaderBase : public SerializableDataBlock {
  protected:
   // TODO: pull out all common code from ds, micro and tx block header
 

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "DSBlockHeader.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -27,7 +28,7 @@ DSBlockHeader::DSBlockHeader() { m_blockNum = (uint64_t)-1; }
 
 DSBlockHeader::DSBlockHeader(const vector<unsigned char>& src,
                              unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "We failed to init DSBlockHeader.");
   }
 }
@@ -48,109 +49,24 @@ DSBlockHeader::DSBlockHeader(const uint8_t dsDifficulty,
       m_swInfo(swInfo),
       m_PoWDSWinners(powDSWinners) {}
 
-unsigned int DSBlockHeader::Serialize(vector<unsigned char>& dst,
-                                      unsigned int offset) const {
-  LOG_MARKER();
-
-  unsigned int size_remaining = dst.size() - offset;
-  if (size_remaining < GetSize()) {
-    dst.resize(GetSize() + offset);
+bool DSBlockHeader::Serialize(vector<unsigned char>& dst,
+                              unsigned int offset) const {
+  if (!Messenger::SetDSBlockHeader(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetDSBlockHeader failed.");
+    return false;
   }
 
-  unsigned int curOffset = offset;
-
-  SetNumber<uint8_t>(dst, curOffset, m_dsDifficulty, sizeof(uint8_t));
-  curOffset += sizeof(uint8_t);
-  SetNumber<uint8_t>(dst, curOffset, m_difficulty, sizeof(uint8_t));
-  curOffset += sizeof(uint8_t);
-  copy(m_prevHash.asArray().begin(), m_prevHash.asArray().end(),
-       dst.begin() + curOffset);
-  curOffset += BLOCK_HASH_SIZE;
-  m_leaderPubKey.Serialize(dst, curOffset);
-  curOffset += PUB_KEY_SIZE;
-  SetNumber<uint64_t>(dst, curOffset, m_blockNum, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  SetNumber<uint256_t>(dst, curOffset, m_timestamp, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  curOffset += m_swInfo.Serialize(dst, curOffset);
-  SetNumber<uint32_t>(dst, curOffset, m_PoWDSWinners.size(), sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-
-  for (const auto& DSWinner : m_PoWDSWinners) {
-    // Pubkey
-    DSWinner.first.Serialize(dst, curOffset);
-    curOffset += PUB_KEY_SIZE;
-    // IP address
-    Serializable::SetNumber<uint128_t>(
-        dst, curOffset, DSWinner.second.m_ipAddress, UINT128_SIZE);
-    curOffset += UINT128_SIZE;
-    // Port
-    Serializable::SetNumber<uint32_t>(
-        dst, curOffset, DSWinner.second.m_listenPortHost, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-  }
-  return GetSize();
+  return true;
 }
 
-int DSBlockHeader::Deserialize(const vector<unsigned char>& src,
-                               unsigned int offset) {
-  LOG_MARKER();
-  PubKey deserializedPubKey;
-  Peer deserializedPeer;
-  uint128_t deserializedIP;
-  uint32_t deserializedPort;
-  unsigned int curOffset = offset;
-  try {
-    m_dsDifficulty = GetNumber<uint8_t>(src, curOffset, sizeof(uint8_t));
-    curOffset += sizeof(uint8_t);
-    m_difficulty = GetNumber<uint8_t>(src, curOffset, sizeof(uint8_t));
-    curOffset += sizeof(uint8_t);
-    copy(src.begin() + curOffset, src.begin() + curOffset + BLOCK_HASH_SIZE,
-         m_prevHash.asArray().begin());
-    curOffset += BLOCK_HASH_SIZE;
-    if (m_leaderPubKey.Deserialize(src, curOffset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to init m_leaderPubKey.");
-      return -1;
-    }
-    curOffset += PUB_KEY_SIZE;
-    m_blockNum = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    m_timestamp = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    if (m_swInfo.Deserialize(src, curOffset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to init m_swInfo.");
-      return -1;
-    }
-    curOffset += SWInfo::SIZE;
-    uint32_t numOfIncomingDSMem =
-        GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    uint32_t expectedSizeOffset =
-        curOffset + (numOfIncomingDSMem * (PUB_KEY_SIZE + IP_SIZE + PORT_SIZE));
-    if (expectedSizeOffset >= src.size()) {
-      LOG_GENERAL(WARNING,
-                  "payload size is too small to deserialize all incoming "
-                  "ds members"
-                      << expectedSizeOffset << " " << src.size());
-      return -1;
-    }
-
-    for (uint32_t i = 0; i < numOfIncomingDSMem; i++) {
-      deserializedPubKey.Deserialize(src, curOffset);
-      curOffset += PUB_KEY_SIZE;
-      deserializedIP = GetNumber<uint128_t>(src, curOffset, IP_SIZE);
-      curOffset += IP_SIZE;
-      deserializedPort = GetNumber<uint32_t>(src, curOffset, PORT_SIZE);
-      curOffset += PORT_SIZE;
-      m_PoWDSWinners[deserializedPubKey] =
-          Peer(deserializedIP, deserializedPort);
-    }
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING,
-                "Error with DSBlockHeader::Deserialize." << ' ' << e.what());
-    return -1;
+bool DSBlockHeader::Deserialize(const vector<unsigned char>& src,
+                                unsigned int offset) {
+  if (!Messenger::GetDSBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetDSBlockHeader failed.");
+    return false;
   }
-  return 0;
+
+  return true;
 }
 
 const uint8_t& DSBlockHeader::GetDSDifficulty() const { return m_dsDifficulty; }
@@ -162,15 +78,6 @@ const BlockHash& DSBlockHeader::GetPrevHash() const { return m_prevHash; }
 const PubKey& DSBlockHeader::GetLeaderPubKey() const { return m_leaderPubKey; }
 
 const uint64_t& DSBlockHeader::GetBlockNum() const { return m_blockNum; }
-
-uint32_t DSBlockHeader::GetSize() const {
-  uint32_t dsBlockSize1 = sizeof(uint8_t) + sizeof(uint8_t) + BLOCK_HASH_SIZE +
-                          PUB_KEY_SIZE + sizeof(uint64_t) + UINT256_SIZE +
-                          SWInfo::SIZE + sizeof(uint32_t);
-
-  dsBlockSize1 += m_PoWDSWinners.size() * (PUB_KEY_SIZE + IP_SIZE + PORT_SIZE);
-  return dsBlockSize1;
-}
 
 const uint256_t& DSBlockHeader::GetTimestamp() const { return m_timestamp; }
 

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -59,12 +59,12 @@ class DSBlockHeader : public BlockHeaderBase {
                 const std::map<PubKey, Peer>& powDSWinners);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const override;
+  bool Serialize(std::vector<unsigned char>& dst,
+                 unsigned int offset) const override;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src,
-                  unsigned int offset) override;
+  bool Deserialize(const std::vector<unsigned char>& src,
+                   unsigned int offset) override;
 
   /// Returns the difficulty of the PoW puzzle.
   const uint8_t& GetDSDifficulty() const;
@@ -81,9 +81,6 @@ class DSBlockHeader : public BlockHeaderBase {
 
   /// Returns the number of ancestor blocks.
   const uint64_t& GetBlockNum() const;
-
-  /// Return size of this DS block
-  uint32_t GetSize() const;
 
   /// Returns the Unix time at the time of creation of this block.
   const boost::multiprecision::uint256_t& GetTimestamp() const;

--- a/src/libData/BlockData/BlockHeader/FallbackBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/FallbackBlockHeader.h
@@ -42,11 +42,6 @@ class FallbackBlockHeader : public BlockHeaderBase {
   boost::multiprecision::uint256_t m_timestamp;
 
  public:
-  static const unsigned int SIZE =
-      sizeof(uint64_t) + sizeof(uint64_t) + sizeof(unsigned char) +
-      FallbackBlockHashSet::size() + sizeof(uint32_t) + IP_SIZE + PORT_SIZE +
-      PUB_KEY_SIZE + sizeof(uint32_t) + UINT256_SIZE;
-
   /// Default constructor.
   FallbackBlockHeader();  // creates a dummy invalid placeholder BlockHeader
 
@@ -66,11 +61,10 @@ class FallbackBlockHeader : public BlockHeaderBase {
                       const boost::multiprecision::uint256_t& timestamp);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the DS Epoch number where view change happen
   const uint64_t& GetFallbackDSEpochNo() const;

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "MicroBlockHeader.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -27,7 +28,7 @@ MicroBlockHeader::MicroBlockHeader() { m_blockNum = (uint64_t)-1; }
 
 MicroBlockHeader::MicroBlockHeader(const vector<unsigned char>& src,
                                    unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "We failed to init MicroBlockHeader.");
   }
 }
@@ -53,95 +54,24 @@ MicroBlockHeader::MicroBlockHeader(
       m_dsBlockNum(dsBlockNum),
       m_dsBlockHeader(dsBlockHeader) {}
 
-unsigned int MicroBlockHeader::Serialize(vector<unsigned char>& dst,
-                                         unsigned int offset) const {
-  // LOG_MARKER();
-
-  unsigned int size_remaining = dst.size() - offset;
-
-  if (size_remaining < SIZE) {
-    dst.resize(SIZE + offset);
+bool MicroBlockHeader::Serialize(vector<unsigned char>& dst,
+                                 unsigned int offset) const {
+  if (!Messenger::SetMicroBlockHeader(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetMicroBlockHeader failed.");
+    return false;
   }
 
-  unsigned int curOffset = offset;
-
-  SetNumber<uint8_t>(dst, curOffset, m_type, sizeof(uint8_t));
-  curOffset += sizeof(uint8_t);
-  SetNumber<uint32_t>(dst, curOffset, m_version, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_shardId, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint256_t>(dst, curOffset, m_gasLimit, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  SetNumber<uint256_t>(dst, curOffset, m_gasUsed, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  copy(m_prevHash.asArray().begin(), m_prevHash.asArray().end(),
-       dst.begin() + curOffset);
-  curOffset += BLOCK_HASH_SIZE;
-  SetNumber<uint64_t>(dst, curOffset, m_blockNum, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  SetNumber<uint256_t>(dst, curOffset, m_timestamp, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  curOffset = m_hash.Serialize(dst, curOffset);
-  SetNumber<uint32_t>(dst, curOffset, m_numTxs, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  m_minerPubKey.Serialize(dst, curOffset);
-  curOffset += PUB_KEY_SIZE;
-  SetNumber<uint64_t>(dst, curOffset, m_dsBlockNum, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  copy(m_dsBlockHeader.asArray().begin(), m_dsBlockHeader.asArray().end(),
-       dst.begin() + curOffset);
-
-  return SIZE;
+  return true;
 }
 
-int MicroBlockHeader::Deserialize(const vector<unsigned char>& src,
-                                  unsigned int offset) {
-  // LOG_MARKER();
-  try {
-    unsigned int curOffset = offset;
-
-    m_type = GetNumber<uint8_t>(src, curOffset, sizeof(uint8_t));
-    curOffset += sizeof(uint8_t);
-    m_version = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_shardId = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_gasLimit = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    m_gasUsed = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    copy(src.begin() + curOffset, src.begin() + curOffset + BLOCK_HASH_SIZE,
-         m_prevHash.asArray().begin());
-    curOffset += BLOCK_HASH_SIZE;
-    m_blockNum = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    m_timestamp = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    if (m_hash.Deserialize(src, curOffset)) {
-      LOG_GENERAL(WARNING, "We failed to extract MicroBlockHeader::m_hash.");
-      return -1;
-    }
-    curOffset += m_hash.size();
-    m_numTxs = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    // m_minerPubKey.Deserialize(src, curOffset);
-    if (m_minerPubKey.Deserialize(src, curOffset) != 0) {
-      LOG_GENERAL(WARNING,
-                  "We failed to init MicroBlockHeader::m_minerPubKey.");
-      return -1;
-    }
-    curOffset += PUB_KEY_SIZE;
-    m_dsBlockNum = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    copy(src.begin() + curOffset, src.begin() + curOffset + BLOCK_HASH_SIZE,
-         m_dsBlockHeader.asArray().begin());
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING,
-                "Error with MicroBlockHeader::Deserialize." << ' ' << e.what());
-    return -1;
+bool MicroBlockHeader::Deserialize(const vector<unsigned char>& src,
+                                   unsigned int offset) {
+  if (!Messenger::GetMicroBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetMicroBlockHeader failed.");
+    return false;
   }
-  return 0;
+
+  return true;
 }
 
 const uint8_t& MicroBlockHeader::GetType() const { return m_type; }

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
@@ -49,12 +49,6 @@ class MicroBlockHeader : public BlockHeaderBase {
   BlockHash m_dsBlockHeader;  // DS Block hash
 
  public:
-  static const unsigned int SIZE =
-      sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + UINT256_SIZE +
-      UINT256_SIZE + BLOCK_HASH_SIZE + sizeof(uint64_t) + UINT256_SIZE +
-      MicroBlockHashSet::size() + sizeof(uint32_t) + PUB_KEY_SIZE +
-      sizeof(uint64_t) + BLOCK_HASH_SIZE;
-
   /// Default constructor.
   MicroBlockHeader();
 
@@ -75,11 +69,10 @@ class MicroBlockHeader : public BlockHeaderBase {
                    const TxnHash& tranReceiptHash);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   // [TODO] These methods are all supposed to be moved into BlockHeaderBase, so
   // no need to add Doxygen tags for now

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "TxBlockHeader.h"
+#include "libMessage/Messenger.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -27,7 +28,7 @@ TxBlockHeader::TxBlockHeader() : m_blockNum((uint64_t)-1) {}
 
 TxBlockHeader::TxBlockHeader(const vector<unsigned char>& src,
                              unsigned int offset) {
-  if (Deserialize(src, offset) != 0) {
+  if (!Deserialize(src, offset)) {
     LOG_GENERAL(WARNING, "We failed to init TxBlockHeader.");
   }
 }
@@ -56,96 +57,24 @@ TxBlockHeader::TxBlockHeader(
       m_dsBlockNum(dsBlockNum),
       m_dsBlockHeader(dsBlockHeader) {}
 
-unsigned int TxBlockHeader::Serialize(vector<unsigned char>& dst,
-                                      unsigned int offset) const {
-  // LOG_MARKER();
-
-  unsigned int size_needed = TxBlockHeader::SIZE;
-  unsigned int size_remaining = dst.size() - offset;
-
-  if (size_remaining < size_needed) {
-    dst.resize(size_needed + offset);
+bool TxBlockHeader::Serialize(vector<unsigned char>& dst,
+                              unsigned int offset) const {
+  if (!Messenger::SetTxBlockHeader(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetTxBlockHeader failed.");
+    return false;
   }
 
-  unsigned int curOffset = offset;
-
-  SetNumber<uint8_t>(dst, curOffset, m_type, sizeof(uint8_t));
-  curOffset += sizeof(uint8_t);
-  SetNumber<uint32_t>(dst, curOffset, m_version, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint256_t>(dst, curOffset, m_gasLimit, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  SetNumber<uint256_t>(dst, curOffset, m_gasUsed, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  copy(m_prevHash.asArray().begin(), m_prevHash.asArray().end(),
-       dst.begin() + curOffset);
-  curOffset += BLOCK_HASH_SIZE;
-  SetNumber<uint64_t>(dst, curOffset, m_blockNum, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  SetNumber<uint256_t>(dst, curOffset, m_timestamp, UINT256_SIZE);
-  curOffset += UINT256_SIZE;
-  curOffset = m_hash.Serialize(dst, curOffset);
-  SetNumber<uint32_t>(dst, curOffset, m_numTxs, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_numMicroBlockHashes, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  m_minerPubKey.Serialize(dst, curOffset);
-  curOffset += PUB_KEY_SIZE;
-  SetNumber<uint64_t>(dst, curOffset, m_dsBlockNum, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  copy(m_dsBlockHeader.asArray().begin(), m_dsBlockHeader.asArray().end(),
-       dst.begin() + curOffset);
-  curOffset += BLOCK_HASH_SIZE;
-  return size_needed;
+  return true;
 }
 
-int TxBlockHeader::Deserialize(const vector<unsigned char>& src,
-                               unsigned int offset) {
-  // LOG_MARKER();
-  try {
-    unsigned int curOffset = offset;
-    m_type = GetNumber<uint8_t>(src, curOffset, sizeof(uint8_t));
-    curOffset += sizeof(uint8_t);
-    m_version = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_gasLimit = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    m_gasUsed = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    copy(src.begin() + curOffset, src.begin() + curOffset + BLOCK_HASH_SIZE,
-         m_prevHash.asArray().begin());
-    curOffset += BLOCK_HASH_SIZE;
-    m_blockNum = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    m_timestamp = GetNumber<uint256_t>(src, curOffset, UINT256_SIZE);
-    curOffset += UINT256_SIZE;
-    if (m_hash.Deserialize(src, curOffset)) {
-      LOG_GENERAL(WARNING, "We failed to extract TxBlockHeader::m_hash.");
-      return -1;
-    }
-    curOffset += m_hash.size();
-    m_numTxs = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_numMicroBlockHashes =
-        GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    // m_minerPubKey.Deserialize(src, curOffset);
-    if (m_minerPubKey.Deserialize(src, curOffset) != 0) {
-      LOG_GENERAL(WARNING, "We failed to init TxBlockHeader::m_minerPubKey.");
-      return -1;
-    }
-    curOffset += PUB_KEY_SIZE;
-    m_dsBlockNum = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    copy(src.begin() + curOffset, src.begin() + curOffset + BLOCK_HASH_SIZE,
-         m_dsBlockHeader.asArray().begin());
-    curOffset += BLOCK_HASH_SIZE;
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING,
-                "Error with TxBlockHeader::Deserialize." << ' ' << e.what());
-    return -1;
+bool TxBlockHeader::Deserialize(const vector<unsigned char>& src,
+                                unsigned int offset) {
+  if (!Messenger::GetTxBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTxBlockHeader failed.");
+    return false;
   }
-  return 0;
+
+  return true;
 }
 
 const uint8_t& TxBlockHeader::GetType() const { return m_type; }

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.h
@@ -48,12 +48,6 @@ class TxBlockHeader : public BlockHeaderBase {
   BlockHash m_dsBlockHeader;  // DS Block hash
 
  public:
-  static const unsigned int SIZE =
-      sizeof(uint8_t) + sizeof(uint32_t) + UINT256_SIZE + UINT256_SIZE +
-      BLOCK_HASH_SIZE + sizeof(uint64_t) + UINT256_SIZE +
-      TxBlockHashSet::size() + sizeof(uint32_t) + sizeof(uint32_t) +
-      PUB_KEY_SIZE + sizeof(uint64_t) + BLOCK_HASH_SIZE;
-
   /// Default constructor.
   TxBlockHeader();
 
@@ -73,12 +67,12 @@ class TxBlockHeader : public BlockHeaderBase {
                 const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const override;
+  bool Serialize(std::vector<unsigned char>& dst,
+                 unsigned int offset) const override;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src,
-                  unsigned int offset) override;
+  bool Deserialize(const std::vector<unsigned char>& src,
+                   unsigned int offset) override;
 
   /// Returns the type of the block.
   const uint8_t& GetType() const;

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.h
@@ -42,11 +42,6 @@ class VCBlockHeader : public BlockHeaderBase {
   boost::multiprecision::uint256_t m_Timestamp;
 
  public:
-  static const unsigned int SIZE = sizeof(uint64_t) + sizeof(uint64_t) +
-                                   sizeof(unsigned char) + sizeof(uint32_t) +
-                                   IP_SIZE + PORT_SIZE + PUB_KEY_SIZE +
-                                   sizeof(uint32_t) + UINT256_SIZE;
-
   /// Default constructor.
   VCBlockHeader();  // creates a dummy invalid placeholder BlockHeader --
                     // blocknum is maxsize of uint256
@@ -64,11 +59,10 @@ class VCBlockHeader : public BlockHeaderBase {
                 const boost::multiprecision::uint256_t& timestamp);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Returns the DS Epoch number where view change happen
   const uint64_t& GetVieWChangeDSEpochNo() const;

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -106,10 +106,12 @@ bool DirectoryService::VerifyMicroBlockCoSignature(const MicroBlock& microBlock,
 
   // Verify the collective signature
   vector<unsigned char> message;
-  microBlock.GetHeader().Serialize(message, 0);
-  microBlock.GetCS1().Serialize(message, MicroBlockHeader::SIZE);
-  BitVector::SetBitVector(message, MicroBlockHeader::SIZE + BLOCK_SIG_SIZE,
-                          microBlock.GetB1());
+  if (!microBlock.GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "MicroBlockHeader serialization failed");
+    return false;
+  }
+  microBlock.GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), microBlock.GetB1());
   if (!Schnorr::GetInstance().Verify(message, 0, message.size(),
                                      microBlock.GetCS2(), *aggregatedKey)) {
     LOG_GENERAL(WARNING, "Cosig verification failed");

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -72,10 +72,12 @@ void DirectoryService::ProcessViewChangeConsensusWhenDone() {
   }
 
   vector<unsigned char> message;
-  m_pendingVCBlock->GetHeader().Serialize(message, 0);
-  m_pendingVCBlock->GetCS1().Serialize(message, VCBlockHeader::SIZE);
-  BitVector::SetBitVector(message, VCBlockHeader::SIZE + BLOCK_SIG_SIZE,
-                          m_pendingVCBlock->GetB1());
+  if (!m_pendingVCBlock->GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "VCBlockHeader serialization failed");
+    return;
+  }
+  m_pendingVCBlock->GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), m_pendingVCBlock->GetB1());
   if (not Schnorr::GetInstance().Verify(message, 0, message.size(),
                                         m_pendingVCBlock->GetCS2(),
                                         *aggregatedKey)) {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1340,8 +1340,6 @@ bool Lookup::ProcessSetMicroBlockFromSeed(const vector<unsigned char>& message,
   curr_offset += sizeof(uint64_t);
 
   MicroBlock microblock(message, curr_offset);
-  curr_offset += microblock.GetSerializedCoreSize() +
-                 microblock.GetSerializedTxnHashesSize();
 
   uint32_t id = microblock.GetHeader().GetShardId();
 

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -48,7 +48,7 @@ void ProtobufByteArrayToSerializable(const ByteArray& byteArray,
 }
 
 // Temporary function for use by data blocks
-void SerializableToProtobufByteArray(const Serializable2& serializable,
+void SerializableToProtobufByteArray(const SerializableDataBlock& serializable,
                                      ByteArray& byteArray) {
   vector<unsigned char> tmp;
   serializable.Serialize(tmp, 0);
@@ -57,7 +57,7 @@ void SerializableToProtobufByteArray(const Serializable2& serializable,
 
 // Temporary function for use by data blocks
 void ProtobufByteArrayToSerializable(const ByteArray& byteArray,
-                                     Serializable2& serializable) {
+                                     SerializableDataBlock& serializable) {
   vector<unsigned char> tmp;
   copy(byteArray.data().begin(), byteArray.data().end(), back_inserter(tmp));
   serializable.Deserialize(tmp, 0);

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -30,6 +30,68 @@
 class Messenger {
  public:
   // ============================================================================
+  // Primitives
+  // ============================================================================
+
+  static bool SetDSBlockHeader(std::vector<unsigned char>& dst,
+                               const unsigned int offset,
+                               const DSBlockHeader& dsBlockHeader);
+  static bool GetDSBlockHeader(const std::vector<unsigned char>& src,
+                               const unsigned int offset,
+                               DSBlockHeader& dsBlockHeader);
+  static bool SetDSBlock(std::vector<unsigned char>& dst,
+                         const unsigned int offset, const DSBlock& dsBlock);
+  static bool GetDSBlock(const std::vector<unsigned char>& src,
+                         const unsigned int offset, DSBlock& dsBlock);
+
+  static bool SetMicroBlockHeader(std::vector<unsigned char>& dst,
+                                  const unsigned int offset,
+                                  const MicroBlockHeader& microBlockHeader);
+  static bool GetMicroBlockHeader(const std::vector<unsigned char>& src,
+                                  const unsigned int offset,
+                                  MicroBlockHeader& microBlockHeader);
+  static bool SetMicroBlock(std::vector<unsigned char>& dst,
+                            const unsigned int offset,
+                            const MicroBlock& microBlock);
+  static bool GetMicroBlock(const std::vector<unsigned char>& src,
+                            const unsigned int offset, MicroBlock& microBlock);
+
+  static bool SetTxBlockHeader(std::vector<unsigned char>& dst,
+                               const unsigned int offset,
+                               const TxBlockHeader& txBlockHeader);
+  static bool GetTxBlockHeader(const std::vector<unsigned char>& src,
+                               const unsigned int offset,
+                               TxBlockHeader& txBlockHeader);
+  static bool SetTxBlock(std::vector<unsigned char>& dst,
+                         const unsigned int offset, const TxBlock& txBlock);
+  static bool GetTxBlock(const std::vector<unsigned char>& src,
+                         const unsigned int offset, TxBlock& txBlock);
+
+  static bool SetVCBlockHeader(std::vector<unsigned char>& dst,
+                               const unsigned int offset,
+                               const VCBlockHeader& vcBlockHeader);
+  static bool GetVCBlockHeader(const std::vector<unsigned char>& src,
+                               const unsigned int offset,
+                               VCBlockHeader& vcBlockHeader);
+  static bool SetVCBlock(std::vector<unsigned char>& dst,
+                         const unsigned int offset, const VCBlock& vcBlock);
+  static bool GetVCBlock(const std::vector<unsigned char>& src,
+                         const unsigned int offset, VCBlock& vcBlock);
+
+  static bool SetFallbackBlockHeader(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const FallbackBlockHeader& fallbackBlockHeader);
+  static bool GetFallbackBlockHeader(const std::vector<unsigned char>& src,
+                                     const unsigned int offset,
+                                     FallbackBlockHeader& fallbackBlockHeader);
+  static bool SetFallbackBlock(std::vector<unsigned char>& dst,
+                               const unsigned int offset,
+                               const FallbackBlock& fallbackBlock);
+  static bool GetFallbackBlock(const std::vector<unsigned char>& src,
+                               const unsigned int offset,
+                               FallbackBlock& fallbackBlock);
+
+  // ============================================================================
   // Directory Service messages
   // ============================================================================
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -157,10 +157,12 @@ bool Node::VerifyDSBlockCoSignature(const DSBlock& dsblock) {
 
   // Verify the collective signature
   vector<unsigned char> message;
-  dsblock.GetHeader().Serialize(message, 0);
-  dsblock.GetCS1().Serialize(message, dsblock.GetHeader().GetSize());
-  BitVector::SetBitVector(
-      message, dsblock.GetHeader().GetSize() + BLOCK_SIG_SIZE, dsblock.GetB1());
+  if (!dsblock.GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "DSBlockHeader serialization failed");
+    return false;
+  }
+  dsblock.GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), dsblock.GetB1());
   if (!Schnorr::GetInstance().Verify(message, 0, message.size(),
                                      dsblock.GetCS2(), *aggregatedKey)) {
     LOG_GENERAL(WARNING, "Cosig verification failed");

--- a/src/libNode/FallbackBlockProcessing.cpp
+++ b/src/libNode/FallbackBlockProcessing.cpp
@@ -100,10 +100,12 @@ bool Node::VerifyFallbackBlockCoSignature(const FallbackBlock& fallbackblock) {
 
   // Verify the collective signature
   vector<unsigned char> message;
-  fallbackblock.GetHeader().Serialize(message, 0);
-  fallbackblock.GetCS1().Serialize(message, FallbackBlockHeader::SIZE);
-  BitVector::SetBitVector(message, FallbackBlockHeader::SIZE + BLOCK_SIG_SIZE,
-                          fallbackblock.GetB1());
+  if (!fallbackblock.GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "FallbackBlockHeader serialization failed");
+    return false;
+  }
+  fallbackblock.GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), fallbackblock.GetB1());
   if (!Schnorr::GetInstance().Verify(message, 0, message.size(),
                                      fallbackblock.GetCS2(), *aggregatedKey)) {
     LOG_GENERAL(WARNING, "Cosig verification failed. Pubkeys");

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -258,10 +258,12 @@ bool Node::VerifyFinalBlockCoSignature(const TxBlock& txblock) {
 
   // Verify the collective signature
   vector<unsigned char> message;
-  txblock.GetHeader().Serialize(message, 0);
-  txblock.GetCS1().Serialize(message, TxBlockHeader::SIZE);
-  BitVector::SetBitVector(message, TxBlockHeader::SIZE + BLOCK_SIG_SIZE,
-                          txblock.GetB1());
+  if (!txblock.GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "TxBlockHeader serialization failed");
+    return false;
+  }
+  txblock.GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), txblock.GetB1());
   if (!Schnorr::GetInstance().Verify(message, 0, message.size(),
                                      txblock.GetCS2(), *aggregatedKey)) {
     LOG_GENERAL(WARNING, "Cosig verification failed");

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -240,7 +240,9 @@ bool Node::ProcessMicroblockConsensusCore(const vector<unsigned char>& message,
                   << "is DONE!!! (Epoch " << m_mediator.m_currentEpochNum
                   << ")");
     m_lastMicroBlockCoSig.first = m_mediator.m_currentEpochNum;
-    m_lastMicroBlockCoSig.second.SetCoSignatures(*m_consensusObject);
+    m_lastMicroBlockCoSig.second = move(
+        CoSignatures(m_consensusObject->GetCS1(), m_consensusObject->GetB1(),
+                     m_consensusObject->GetCS2(), m_consensusObject->GetB2()));
 
     SetState(WAITING_FINALBLOCK);
 

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -112,7 +112,7 @@ class Node : public Executable, public Broadcastable {
 
   std::vector<unsigned char> m_consensusBlockHash;
   std::shared_ptr<MicroBlock> m_microblock;
-  std::pair<uint64_t, BlockBase> m_lastMicroBlockCoSig;
+  std::pair<uint64_t, CoSignatures> m_lastMicroBlockCoSig;
   std::mutex m_mutexMicroBlock;
 
   const static uint32_t RECVTXNDELAY_MILLISECONDS = 3000;

--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -92,10 +92,12 @@ bool Node::VerifyVCBlockCoSignature(const VCBlock& vcblock) {
 
   // Verify the collective signature
   vector<unsigned char> message;
-  vcblock.GetHeader().Serialize(message, 0);
-  vcblock.GetCS1().Serialize(message, VCBlockHeader::SIZE);
-  BitVector::SetBitVector(message, VCBlockHeader::SIZE + BLOCK_SIG_SIZE,
-                          vcblock.GetB1());
+  if (!vcblock.GetHeader().Serialize(message, 0)) {
+    LOG_GENERAL(WARNING, "VCBlockHeader serialization failed");
+    return false;
+  }
+  vcblock.GetCS1().Serialize(message, message.size());
+  BitVector::SetBitVector(message, message.size(), vcblock.GetB1());
   if (!Schnorr::GetInstance().Verify(message, 0, message.size(),
                                      vcblock.GetCS2(), *aggregatedKey)) {
     LOG_GENERAL(WARNING, "Cosig verification failed. Pubkeys");

--- a/src/libUtils/HashUtils.h
+++ b/src/libUtils/HashUtils.h
@@ -35,7 +35,7 @@ class HashUtils {
   }
   // Temporary function for use by data blocks
   static const std::vector<unsigned char> SerializableToHash(
-      const Serializable2& sz) {
+      const SerializableDataBlock& sz) {
     std::vector<unsigned char> vec;
     sz.Serialize(vec, 0);
     return BytesToHash(vec);
@@ -57,7 +57,7 @@ class HashUtils {
     return (vec.at(lsb - 1) << 8) | vec.at(lsb);
   }
   // Temporary function for use by data blocks
-  static uint16_t SerializableToHash16Bits(const Serializable2& sz) {
+  static uint16_t SerializableToHash16Bits(const SerializableDataBlock& sz) {
     const std::vector<unsigned char>& vec = SerializableToHash(sz);
 
     uint32_t lsb = vec.size() - 1;

--- a/src/libUtils/HashUtils.h
+++ b/src/libUtils/HashUtils.h
@@ -33,7 +33,13 @@ class HashUtils {
     sz.Serialize(vec, 0);
     return BytesToHash(vec);
   }
-
+  // Temporary function for use by data blocks
+  static const std::vector<unsigned char> SerializableToHash(
+      const Serializable2& sz) {
+    std::vector<unsigned char> vec;
+    sz.Serialize(vec, 0);
+    return BytesToHash(vec);
+  }
   static const std::vector<unsigned char> BytesToHash(
       const std::vector<unsigned char>& vec) {
     SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
@@ -44,6 +50,14 @@ class HashUtils {
     return resVec;
   }
   static uint16_t SerializableToHash16Bits(const Serializable& sz) {
+    const std::vector<unsigned char>& vec = SerializableToHash(sz);
+
+    uint32_t lsb = vec.size() - 1;
+
+    return (vec.at(lsb - 1) << 8) | vec.at(lsb);
+  }
+  // Temporary function for use by data blocks
+  static uint16_t SerializableToHash16Bits(const Serializable2& sz) {
     const std::vector<unsigned char>& vec = SerializableToHash(sz);
 
     uint32_t lsb = vec.size() - 1;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Before this PR, we already had protobuf-equivalent types for each data block type (`DSBlock`, `MicroBlock`, `TxBlock`, `VCBlock`, and `FallbackBlock`).

However, we only used these protobuf-equivalent types when sending out messages (e.g., the DSBlock inside DSBlock Announcement). There are other cases (e.g., storing to persistent storage, doing header cosig verification, ...) that continued to use the `Serialize` and `Deserialize` methods inside the data blocks.

In this PR, I am keeping those methods but changing them to also use our `Messenger` to do protobuf-type serialization. A lot of other methods like `GetSerializedSize` and variables like `SIZE` are now not needed anymore as a result.

Temporarily, this PR has introduced `SerializableDataBlock` because I changed the return type of `Serialize` and `Deserialize` to `bool`. When the other primitives (e.g., `Peer`, `PubKey`, ...) are changed in a similar way, we can get rid of the old `Serializable`.

Local testing has been done to check the data block types are working correctly, but I have yet to test `VCBlock` and `FallbackBlock`. I propose a code review at this stage and we will be able to revisit later the testing for these two block types, since it is not easy to trigger the conditions for them.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
