### PR TITLE
DS to send vcds message instead of vc block (before ds block consensus) to shard nodes

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -628,6 +628,7 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
       << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
       << "] AFTER SENDING DSBLOCK");
 
+  ClearVCBlockVector();
   UpdateDSCommiteeComposition();
   UpdateMyDSModeAndConsensusId();
 

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -92,8 +92,9 @@ void DirectoryService::SendDSBlockToLookupNodes() {
   vector<unsigned char> dsblock_message = {MessageType::NODE,
                                            NodeInstructionType::DSBLOCK};
   if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY, 0,
-                                 *m_pendingDSBlock, m_shards, m_DSReceivers,
-                                 m_shardReceivers, m_shardSenders)) {
+                                 *m_pendingDSBlock, m_VCBlockVector, m_shards,
+                                 m_DSReceivers, m_shardReceivers,
+                                 m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Messenger::SetNodeDSBlock failed.");
     return;
@@ -116,8 +117,9 @@ void DirectoryService::SendDSBlockToNewDSLeader() {
   vector<unsigned char> dsblock_message = {MessageType::NODE,
                                            NodeInstructionType::DSBLOCK};
   if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY, 0,
-                                 *m_pendingDSBlock, m_shards, m_DSReceivers,
-                                 m_shardReceivers, m_shardSenders)) {
+                                 *m_pendingDSBlock, m_VCBlockVector, m_shards,
+                                 m_DSReceivers, m_shardReceivers,
+                                 m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Messenger::SetNodeDSBlock failed.");
     return;
@@ -201,9 +203,10 @@ void DirectoryService::SendDSBlockToShardNodes(
     // Generate the message
     vector<unsigned char> dsblock_message = {MessageType::NODE,
                                              NodeInstructionType::DSBLOCK};
-    if (!Messenger::SetNodeDSBlock(
-            dsblock_message, MessageOffset::BODY, shardId, *m_pendingDSBlock,
-            m_shards, m_DSReceivers, m_shardReceivers, m_shardSenders)) {
+    if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY,
+                                   shardId, *m_pendingDSBlock, m_VCBlockVector,
+                                   m_shards, m_DSReceivers, m_shardReceivers,
+                                   m_shardSenders)) {
       LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
                 "Messenger::SetNodeDSBlock failed.");
       return;

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -91,12 +91,12 @@ void DirectoryService::SendDSBlockToLookupNodes() {
 
   vector<unsigned char> dsblock_message = {MessageType::NODE,
                                            NodeInstructionType::DSBLOCK};
-  if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY, 0,
-                                 *m_pendingDSBlock, m_VCBlockVector, m_shards,
-                                 m_DSReceivers, m_shardReceivers,
-                                 m_shardSenders)) {
+  if (!Messenger::SetNodeVCDSBlocksMessage(
+          dsblock_message, MessageOffset::BODY, 0, *m_pendingDSBlock,
+          m_VCBlockVector, m_shards, m_DSReceivers, m_shardReceivers,
+          m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Messenger::SetNodeDSBlock failed.");
+              "Messenger::SetNodeVCDSBlocksMessage failed.");
     return;
   }
 
@@ -116,12 +116,12 @@ void DirectoryService::SendDSBlockToNewDSLeader() {
 
   vector<unsigned char> dsblock_message = {MessageType::NODE,
                                            NodeInstructionType::DSBLOCK};
-  if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY, 0,
-                                 *m_pendingDSBlock, m_VCBlockVector, m_shards,
-                                 m_DSReceivers, m_shardReceivers,
-                                 m_shardSenders)) {
+  if (!Messenger::SetNodeVCDSBlocksMessage(
+          dsblock_message, MessageOffset::BODY, 0, *m_pendingDSBlock,
+          m_VCBlockVector, m_shards, m_DSReceivers, m_shardReceivers,
+          m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Messenger::SetNodeDSBlock failed.");
+              "Messenger::SetNodeVCDSBlocksMessage failed.");
     return;
   }
 
@@ -203,12 +203,12 @@ void DirectoryService::SendDSBlockToShardNodes(
     // Generate the message
     vector<unsigned char> dsblock_message = {MessageType::NODE,
                                              NodeInstructionType::DSBLOCK};
-    if (!Messenger::SetNodeDSBlock(dsblock_message, MessageOffset::BODY,
-                                   shardId, *m_pendingDSBlock, m_VCBlockVector,
-                                   m_shards, m_DSReceivers, m_shardReceivers,
-                                   m_shardSenders)) {
+    if (!Messenger::SetNodeVCDSBlocksMessage(
+            dsblock_message, MessageOffset::BODY, shardId, *m_pendingDSBlock,
+            m_VCBlockVector, m_shards, m_DSReceivers, m_shardReceivers,
+            m_shardSenders)) {
       LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-                "Messenger::SetNodeDSBlock failed.");
+                "Messenger::SetNodeVCDSBlocksMessage failed.");
       return;
     }
 

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -530,14 +530,13 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
 
   // kill first ds leader (used for view change testing)
   // Either do killing of ds leader or make ds leader do nothing.
-  /**
-  if (m_consensusMyID == 0 && m_viewChangeCounter < 1)
-  {
-      LOG_GENERAL(INFO, "I am killing/suspending myself to test view change");
-      // throw exception();
-      return false;
-  }
-  **/
+  // if (m_consensusMyID == 0 && m_viewChangeCounter < 1)
+  // {
+  //     LOG_GENERAL(INFO, "I am killing/suspending myself to test view
+  //     change");
+  //     // throw exception();
+  //     return false;
+  // }
 
   m_consensusObject.reset(new ConsensusLeader(
       consensusID, m_mediator.m_currentEpochNum, m_consensusBlockHash,

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -125,6 +125,10 @@ class DirectoryService : public Executable, public Broadcastable {
   std::condition_variable cv_ViewChangeVCBlock;
   std::mutex m_MutexCVViewChangeVCBlock;
 
+  // To be used to store vc block (ds block consensus) for "normal nodes"
+  std::mutex m_mutexVCBlockVector;
+  std::vector<VCBlock> m_VCBlockVector;
+
   // Consensus and consensus object
   std::condition_variable cv_DSBlockConsensus;
   std::mutex m_MutexCVDSBlockConsensus;
@@ -501,6 +505,7 @@ class DirectoryService : public Executable, public Broadcastable {
 
   /// PoW (DS block) consensus functions
   void RunConsensusOnDSBlock(bool isRejoin = false);
+  bool IsDSBlockVCState(unsigned char vcBlockState);
 
  private:
   static std::map<DirState, std::string> DirStateStrings;
@@ -515,6 +520,7 @@ class DirectoryService : public Executable, public Broadcastable {
   std::array<unsigned char, 32> GetDSPoWSoln(PubKey Pubk);
   bool IsNodeSubmittedDSPoWSoln(PubKey Pubk);
   uint32_t GetNumberOfDSPoWSolns();
+  void ClearVCBlockVector();
 };
 
 #endif  // __DIRECTORYSERVICE_H__

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -206,7 +206,7 @@ class DirectoryService : public Executable, public Broadcastable {
   // internal calls from ProcessDSBlockConsensus
   void StoreDSBlockToStorage();  // To further refactor
   void SendDSBlockToLookupNodes();
-  void SendDSBlockToNewDSLeader();
+  void SendDSBlockToNewDSMembers();
   void SetupMulticastConfigForDSBlock(unsigned int& my_DS_cluster_num,
                                       unsigned int& my_shards_lo,
                                       unsigned int& my_shards_hi) const;

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -204,14 +204,12 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary() {
   ComposeFinalBlock();  // stores it in m_finalBlock
 
   // kill first ds leader (used for view change testing)
-  /**
-  if (m_consensusMyID == 0 && m_viewChangeCounter < 1)
-  {
-      LOG_GENERAL(INFO, "I am killing/suspending myself to test view change");
-      // throw exception();
-      return false;
-  }
-  **/
+
+  // if (m_consensusMyID == 0 && m_viewChangeCounter < 1) {
+  //   LOG_GENERAL(INFO, "I am killing/suspending myself to test view change");
+  //   // throw exception();
+  //   return false;
+  // }
 
   // Create new consensus object
   m_consensusBlockHash =

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -252,6 +252,9 @@ void DirectoryService::ProcessViewChangeConsensusWhenDone() {
   switch (viewChangeState) {
     case DSBLOCK_CONSENSUS:
     case DSBLOCK_CONSENSUS_PREP: {
+      // Do not send to shard node as sharding structure is not yet formed.
+      // VC block(s) will concat with ds block and sharding structure to form
+      // vcdsmessage, which then will be send to shard node for processing.
       lock_guard<mutex> g(m_mutexVCBlockVector);
       m_VCBlockVector.emplace_back(*m_pendingVCBlock.get());
       break;

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -413,11 +413,8 @@ bool DirectoryService::ProcessViewChangeConsensus(
 
 // Exposing this function so that libNode can use it to check state
 bool DirectoryService::IsDSBlockVCState(unsigned char vcBlockState) {
-  if ((DirState)vcBlockState == DSBLOCK_CONSENSUS_PREP ||
-      (DirState)vcBlockState == DSBLOCK_CONSENSUS) {
-    return true;
-  }
-  return false;
+  return ((DirState)vcBlockState == DSBLOCK_CONSENSUS_PREP ||
+          (DirState)vcBlockState == DSBLOCK_CONSENSUS);
 }
 
 void DirectoryService::ClearVCBlockVector() {

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -229,8 +229,8 @@ void DirectoryService::ProcessViewChangeConsensusWhenDone() {
   // Broadcasting vcblock to lookup nodes iff view change do not occur before ds
   // block consensus. This is to be consistent with how normal node process the
   // vc block (before ds block).
-  if (viewChangeState == DSBLOCK_CONSENSUS ||
-      viewChangeState == DSBLOCK_CONSENSUS_PREP) {
+  if (viewChangeState != DSBLOCK_CONSENSUS &&
+      viewChangeState != DSBLOCK_CONSENSUS_PREP) {
     unsigned int nodeToSendToLookUpLo = m_mediator.GetShardSize(true) / 4;
     unsigned int nodeToSendToLookUpHi =
         nodeToSendToLookUpLo + TX_SHARING_CLUSTER_SIZE;

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -2085,7 +2085,7 @@ bool Messenger::SetNodeVCDSBlocksMessage(
 
   result.set_shardid(shardId);
   DSBlockToProtobuf(dsBlock, *result.mutable_dsblock());
-  
+
   for (const auto& vcblock : vcBlocks) {
     VCBlockToProtobuf(vcblock, *result.add_vcblocks());
   }
@@ -2121,40 +2121,13 @@ bool Messenger::GetNodeVCDSBlocksMessage(
   shardId = result.shardid();
   ProtobufToDSBlock(result.dsblock(), dsBlock);
 
-<<<<<<< 56cb7559f329f57d04455e798dd7af6b57e7de1c
-  ProtobufToShardingStructure(result.sharding(), shards);
-=======
   for (const auto& proto_vcblock : result.vcblocks()) {
     VCBlock vcblock;
     ProtobufToVCBlock(proto_vcblock, vcblock);
     vcBlocks.emplace_back(move(vcblock));
   }
 
-  for (const auto& proto_shard : result.sharding().shards()) {
-    shards.emplace_back();
-
-    for (const auto& proto_member : proto_shard.members()) {
-      PubKey key;
-      Peer peer;
-
-      ProtobufByteArrayToSerializable(proto_member.pubkey(), key);
-      ProtobufByteArrayToSerializable(proto_member.peerinfo(), peer);
-
-      shards.back().emplace_back(key, peer, proto_member.reputation());
-    }
-  }
-
-  const TxSharingAssignments& proto_assignments = result.assignments();
-
-  for (const auto& dsnode : proto_assignments.dsnodes()) {
-    Peer peer;
-    ProtobufByteArrayToSerializable(dsnode, peer);
-    dsReceivers.emplace_back(peer);
-  }
-
-  for (const auto& proto_shard : proto_assignments.shardnodes()) {
-    shardReceivers.emplace_back();
->>>>>>> Update dsblock protobuf to dsvcmessage
+  ProtobufToShardingStructure(result.sharding(), shards);
 
   ProtobufToTxSharingAssignments(result.assignments(), dsReceivers,
                                  shardReceivers, shardSenders);

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -2073,14 +2073,12 @@ bool Messenger::GetDSVCBlockAnnouncement(
 // Node messages
 // ============================================================================
 
-bool Messenger::SetNodeDSBlock(vector<unsigned char>& dst,
-                               const unsigned int offset,
-                               const uint32_t shardId, const DSBlock& dsBlock,
-                               const std::vector<VCBlock>& vcBlocks,
-                               const DequeOfShard& shards,
-                               const vector<Peer>& dsReceivers,
-                               const vector<vector<Peer>>& shardReceivers,
-                               const vector<vector<Peer>>& shardSenders) {
+bool Messenger::SetNodeVCDSBlocksMessage(
+    vector<unsigned char>& dst, const unsigned int offset,
+    const uint32_t shardId, const DSBlock& dsBlock,
+    const std::vector<VCBlock>& vcBlocks, const DequeOfShard& shards,
+    const vector<Peer>& dsReceivers, const vector<vector<Peer>>& shardReceivers,
+    const vector<vector<Peer>>& shardSenders) {
   LOG_MARKER();
 
   NodeDSBlock result;
@@ -2104,12 +2102,11 @@ bool Messenger::SetNodeDSBlock(vector<unsigned char>& dst,
   return SerializeToArray(result, dst, offset);
 }
 
-bool Messenger::GetNodeDSBlock(const vector<unsigned char>& src,
-                               const unsigned int offset, uint32_t& shardId,
-                               DSBlock& dsBlock, std::vector<VCBlock>& vcBlocks,
-                               DequeOfShard& shards, vector<Peer>& dsReceivers,
-                               vector<vector<Peer>>& shardReceivers,
-                               vector<vector<Peer>>& shardSenders) {
+bool Messenger::GetNodeVCDSBlocksMessage(
+    const vector<unsigned char>& src, const unsigned int offset,
+    uint32_t& shardId, DSBlock& dsBlock, std::vector<VCBlock>& vcBlocks,
+    DequeOfShard& shards, vector<Peer>& dsReceivers,
+    vector<vector<Peer>>& shardReceivers, vector<vector<Peer>>& shardSenders) {
   LOG_MARKER();
 
   NodeDSBlock result;

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -184,14 +184,7 @@ class Messenger {
   // Node messages
   // ============================================================================
 
-  //   static bool SetNodeDSBlock(
-  //       std::vector<unsigned char>& dst, const unsigned int offset,
-  //       const uint32_t shardId, const DSBlock& dsBlock,
-  //       const DequeOfShard& shards, const std::vector<Peer>& dsReceivers,
-  //       const std::vector<std::vector<Peer>>& shardReceivers,
-  //       const std::vector<std::vector<Peer>>& shardSenders);
-
-  static bool SetNodeDSBlock(
+  static bool SetNodeVCDSBlocksMessage(
       std::vector<unsigned char>& dst, const unsigned int offset,
       const uint32_t shardId, const DSBlock& dsBlock,
       const std::vector<VCBlock>& vcBlocks, const DequeOfShard& shards,
@@ -199,21 +192,12 @@ class Messenger {
       const std::vector<std::vector<Peer>>& shardReceivers,
       const std::vector<std::vector<Peer>>& shardSenders);
 
-  //   static bool GetNodeDSBlock(const std::vector<unsigned char>& src,
-  //                              const unsigned int offset, uint32_t& shardId,
-  //                              DSBlock& dsBlock, DequeOfShard& shards,
-  //                              std::vector<Peer>& dsReceivers,
-  //                              std::vector<std::vector<Peer>>&
-  //                              shardReceivers,
-  //                              std::vector<std::vector<Peer>>& shardSenders);
-
-  static bool GetNodeDSBlock(const std::vector<unsigned char>& src,
-                             const unsigned int offset, uint32_t& shardId,
-                             DSBlock& dsBlock, std::vector<VCBlock>& vcBlocks,
-                             DequeOfShard& shards,
-                             std::vector<Peer>& dsReceivers,
-                             std::vector<std::vector<Peer>>& shardReceivers,
-                             std::vector<std::vector<Peer>>& shardSenders);
+  static bool GetNodeVCDSBlocksMessage(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      uint32_t& shardId, DSBlock& dsBlock, std::vector<VCBlock>& vcBlocks,
+      DequeOfShard& shards, std::vector<Peer>& dsReceivers,
+      std::vector<std::vector<Peer>>& shardReceivers,
+      std::vector<std::vector<Peer>>& shardSenders);
 
   static bool SetNodeFinalBlock(std::vector<unsigned char>& dst,
                                 const unsigned int offset,

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -184,16 +184,33 @@ class Messenger {
   // Node messages
   // ============================================================================
 
+  //   static bool SetNodeDSBlock(
+  //       std::vector<unsigned char>& dst, const unsigned int offset,
+  //       const uint32_t shardId, const DSBlock& dsBlock,
+  //       const DequeOfShard& shards, const std::vector<Peer>& dsReceivers,
+  //       const std::vector<std::vector<Peer>>& shardReceivers,
+  //       const std::vector<std::vector<Peer>>& shardSenders);
+
   static bool SetNodeDSBlock(
       std::vector<unsigned char>& dst, const unsigned int offset,
       const uint32_t shardId, const DSBlock& dsBlock,
-      const DequeOfShard& shards, const std::vector<Peer>& dsReceivers,
+      const std::vector<VCBlock>& vcBlocks, const DequeOfShard& shards,
+      const std::vector<Peer>& dsReceivers,
       const std::vector<std::vector<Peer>>& shardReceivers,
       const std::vector<std::vector<Peer>>& shardSenders);
 
+  //   static bool GetNodeDSBlock(const std::vector<unsigned char>& src,
+  //                              const unsigned int offset, uint32_t& shardId,
+  //                              DSBlock& dsBlock, DequeOfShard& shards,
+  //                              std::vector<Peer>& dsReceivers,
+  //                              std::vector<std::vector<Peer>>&
+  //                              shardReceivers,
+  //                              std::vector<std::vector<Peer>>& shardSenders);
+
   static bool GetNodeDSBlock(const std::vector<unsigned char>& src,
                              const unsigned int offset, uint32_t& shardId,
-                             DSBlock& dsBlock, DequeOfShard& shards,
+                             DSBlock& dsBlock, std::vector<VCBlock>& vcBlocks,
+                             DequeOfShard& shards,
                              std::vector<Peer>& dsReceivers,
                              std::vector<std::vector<Peer>>& shardReceivers,
                              std::vector<std::vector<Peer>>& shardSenders);

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -265,14 +265,6 @@ message DSVCBlockAnnouncement
 // Node messages
 // ============================================================================
 
-// message NodeDSBlock
-// {
-//    required uint32 shardid                   = 1;
-//    required ProtoDSBlock dsblock             = 2;
-//    required ShardingStructure sharding       = 3;
-//    required TxSharingAssignments assignments = 4;
-// }
-
 message NodeDSBlock
 {
     required uint32 shardid                        = 1;

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -265,12 +265,21 @@ message DSVCBlockAnnouncement
 // Node messages
 // ============================================================================
 
+// message NodeDSBlock
+// {
+//    required uint32 shardid                   = 1;
+//    required ProtoDSBlock dsblock             = 2;
+//    required ShardingStructure sharding       = 3;
+//    required TxSharingAssignments assignments = 4;
+// }
+
 message NodeDSBlock
 {
     required uint32 shardid                        = 1;
     required ProtoDSBlock dsblock                  = 2;
-    required ProtoShardingStructure sharding       = 3;
-    required ProtoTxSharingAssignments assignments = 4;
+    repeated ProtoVCBlock vcblocks                 = 3;
+    required ProtoShardingStructure sharding       = 4;
+    required ProtoTxSharingAssignments assignments = 5;
 }
 
 message NodeFinalBlock

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -467,12 +467,6 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
     return false;
   }
 
-  // Check the signature of this DS block
-  if (!VerifyDSBlockCoSignature(dsblock)) {
-    LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "DSBlock co-sig verification failed");
-    return false;
-  }
 
   uint32_t expectedViewChangeCounter = 1;
   for (const auto& vcBlock : vcBlocks) {
@@ -493,6 +487,14 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
                           << vcBlock.GetHeader().GetViewChangeCounter());
     expectedViewChangeCounter++;
   }
+
+  // Check the signature of this DS block
+  if (!VerifyDSBlockCoSignature(dsblock)) {
+    LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+              "DSBlock co-sig verification failed");
+    return false;
+  }
+
 
   auto func = [this, dsblock]() mutable -> void {
     lock_guard<mutex> g(m_mediator.m_mutexCurSWInfo);

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -403,8 +403,8 @@ void Node::ResetConsensusId() {
 }
 
 bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
-                          unsigned int cur_offset,
-                          [[gnu::unused]] const Peer& from) {
+                                    unsigned int cur_offset,
+                                    [[gnu::unused]] const Peer& from) {
   LOG_MARKER();
   lock_guard<mutex> g(m_mutexDSBlock);
 
@@ -439,12 +439,12 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
   m_mediator.m_ds->m_shardReceivers.clear();
   m_mediator.m_ds->m_shardSenders.clear();
 
-  if (!Messenger::GetNodeDSBlock(
+  if (!Messenger::GetNodeVCDSBlocksMessage(
           message, cur_offset, shardId, dsblock, vcBlocks,
           m_mediator.m_ds->m_shards, m_mediator.m_ds->m_DSReceivers,
           m_mediator.m_ds->m_shardReceivers, m_mediator.m_ds->m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Messenger::GetNodeDSBlock failed.");
+              "Messenger::GetNodeVCDSBlocksMessage failed.");
     return false;
   }
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -467,7 +467,6 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
     return false;
   }
 
-
   uint32_t expectedViewChangeCounter = 1;
   for (const auto& vcBlock : vcBlocks) {
     if (vcBlock.GetHeader().GetViewChangeCounter() !=
@@ -494,7 +493,6 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
               "DSBlock co-sig verification failed");
     return false;
   }
-
 
   auto func = [this, dsblock]() mutable -> void {
     lock_guard<mutex> g(m_mediator.m_mutexCurSWInfo);

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -474,6 +474,18 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
     return false;
   }
 
+  uint32_t expectedViewChangeCounter = 1;
+  for (const auto& vcBlock : vcBlocks) {
+    if (vcBlock.GetHeader().GetViewChangeCounter() !=
+        expectedViewChangeCounter) {
+      LOG_GENERAL(WARNING, "Unexpected VC block counter. Expected: "
+                               << expectedViewChangeCounter << " Received: "
+                               << vcBlock.GetHeader().GetViewChangeCounter());
+    }
+    ProcessVCBlockCore(vcBlock);
+    expectedViewChangeCounter++;
+  }
+
   auto func = [this, dsblock]() mutable -> void {
     lock_guard<mutex> g(m_mediator.m_mutexCurSWInfo);
     if (m_mediator.m_curSWInfo != dsblock.GetHeader().GetSWInfo()) {

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -430,6 +430,7 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
   }
 
   DSBlock dsblock;
+  vector<VCBlock> vcBlocks;
   uint32_t shardId;
   Peer newleaderIP;
 
@@ -439,9 +440,9 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
   m_mediator.m_ds->m_shardSenders.clear();
 
   if (!Messenger::GetNodeDSBlock(
-          message, cur_offset, shardId, dsblock, m_mediator.m_ds->m_shards,
-          m_mediator.m_ds->m_DSReceivers, m_mediator.m_ds->m_shardReceivers,
-          m_mediator.m_ds->m_shardSenders)) {
+          message, cur_offset, shardId, dsblock, vcBlocks,
+          m_mediator.m_ds->m_shards, m_mediator.m_ds->m_DSReceivers,
+          m_mediator.m_ds->m_shardReceivers, m_mediator.m_ds->m_shardSenders)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Messenger::GetNodeDSBlock failed.");
     return false;

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -482,7 +482,15 @@ bool Node::ProcessDSBlock(const vector<unsigned char>& message,
                                << expectedViewChangeCounter << " Received: "
                                << vcBlock.GetHeader().GetViewChangeCounter());
     }
-    ProcessVCBlockCore(vcBlock);
+
+    if (!ProcessVCBlockCore(vcBlock)) {
+      LOG_GENERAL(WARNING, "Checking for error when processing vc blocknum "
+                               << vcBlock.GetHeader().GetViewChangeCounter());
+      return false;
+    }
+
+    LOG_GENERAL(INFO, "view change completed for vc blocknum "
+                          << vcBlock.GetHeader().GetViewChangeCounter());
     expectedViewChangeCounter++;
   }
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -402,7 +402,7 @@ void Node::ResetConsensusId() {
   m_consensusLeaderID = m_mediator.m_currentEpochNum == 1 ? 1 : 0;
 }
 
-bool Node::ProcessDSBlock(const vector<unsigned char>& message,
+bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
                           unsigned int cur_offset,
                           [[gnu::unused]] const Peer& from) {
   LOG_MARKER();

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1170,7 +1170,7 @@ bool Node::Execute(const vector<unsigned char>& message, unsigned int offset,
 
   InstructionHandler ins_handlers[] = {
       &Node::ProcessStartPoW,
-      &Node::ProcessDSBlock,
+      &Node::ProcessVCDSBlocksMessage,
       &Node::ProcessSubmitTransaction,
       &Node::ProcessMicroblockConsensus,
       &Node::ProcessFinalBlock,

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -228,7 +228,7 @@ class Node : public Executable, public Broadcastable {
       const uint64_t& blocknum);
   void LogReceivedFinalBlockDetails(const TxBlock& txblock);
 
-  // internal calls from ProcessDSBlock
+  // internal calls from ProcessVCDSBlocksMessage
   void LogReceivedDSBlockDetails(const DSBlock& dsblock);
   void StoreDSBlockToDisk(const DSBlock& dsblock);
   void UpdateDSCommiteeComposition();
@@ -265,7 +265,7 @@ class Node : public Executable, public Broadcastable {
 
   // bool ProcessCreateAccounts(const std::vector<unsigned char> & message,
   // unsigned int offset, const Peer & from);
-  bool ProcessDSBlock(const std::vector<unsigned char>& message,
+  bool ProcessVCDSBlocksMessage(const std::vector<unsigned char>& message,
                       unsigned int cur_offset, const Peer& from);
   bool ProcessDoRejoin(const std::vector<unsigned char>& message,
                        unsigned int offset, const Peer& from);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -280,7 +280,7 @@ class Node : public Executable, public Broadcastable {
   bool VerifyVCBlockCoSignature(const VCBlock& vcblock);
   bool ProcessVCBlock(const std::vector<unsigned char>& message,
                       unsigned int cur_offset, const Peer& from);
-
+  bool ProcessVCBlockCore(const VCBlock& vcblock);
   // Transaction functions
   bool OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
                          const Peer& from);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -266,7 +266,7 @@ class Node : public Executable, public Broadcastable {
   // bool ProcessCreateAccounts(const std::vector<unsigned char> & message,
   // unsigned int offset, const Peer & from);
   bool ProcessVCDSBlocksMessage(const std::vector<unsigned char>& message,
-                      unsigned int cur_offset, const Peer& from);
+                                unsigned int cur_offset, const Peer& from);
   bool ProcessDoRejoin(const std::vector<unsigned char>& message,
                        unsigned int offset, const Peer& from);
 

--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -152,7 +152,7 @@ bool Node::ProcessVCBlock(const vector<unsigned char>& message,
   return true;
 }
 
-// VC Core function to process 1 vc block
+// VC Core function to process one vc block
 bool Node::ProcessVCBlockCore(const VCBlock& vcblock) {
   LOG_MARKER();
 

--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -110,36 +110,6 @@ bool Node::VerifyVCBlockCoSignature(const VCBlock& vcblock) {
   return true;
 }
 
-/**  TODO
-void Node::LogReceivedDSBlockDetails(const DSBlock& dsblock)
-{
-#ifdef IS_LOOKUP_NODE
-        LOG_GENERAL(
-            INFO,
-            "m_VieWChangeDSEpochNo "
-                << to_string(vcblock.GetHeader().GetVieWChangeDSEpochNo())
-                       .c_str()
-                << "\n"
-                << "m_VieWChangeEpochNo: "
-                << to_string(vcblock.GetHeader().GetViewChangeEpochNo()).c_str()
-                << "\n"
-                << "m_ViewChangeState: "
-                << vcblock.GetHeader().GetViewChangeState() << "\n"
-                << "m_CandidateLeaderIndex: "
-                << to_string(vcblock.GetHeader().GetCandidateLeaderIndex())
-                << "\n"
-                << "m_CandidateLeaderNetworkInfo: "
-                << vcblock.GetHeader().GetCandidateLeaderNetworkInfo() << "\n"
-                << "m_CandidateLeaderPubKey: "
-                << vcblock.GetHeader().GetCandidateLeaderPubKey() << "\n"
-                << "m_VCCounter: "
-                << to_string(vcblock.GetHeader().GetViewChangeCounter()).c_str()
-                << "\n"
-                << "m_Timestamp: " << vcblock.GetHeader().GetTimeStamp());
-#endif // IS_LOOKUP_NODE
-}
-**/
-
 bool Node::ProcessVCBlock(const vector<unsigned char>& message,
                           unsigned int cur_offset,
                           [[gnu::unused]] const Peer& from) {
@@ -155,6 +125,13 @@ bool Node::ProcessVCBlock(const vector<unsigned char>& message,
 
   if (vcblock.GetHeader().GetViewChangeEpochNo() !=
       m_mediator.m_currentEpochNum) {
+    LOG_GENERAL(WARNING,
+                "Node should received individual vc block for ds block ");
+    return false;
+  }
+
+  if (m_mediator.m_ds->IsDSBlockVCState(
+          vcblock.GetHeader().GetViewChangeState())) {
     LOG_GENERAL(WARNING, "Received wrong vcblock. cur epoch: "
                              << m_mediator.m_currentEpochNum << "vc epoch: "
                              << vcblock.GetHeader().GetViewChangeEpochNo());
@@ -186,8 +163,6 @@ bool Node::ProcessVCBlock(const vector<unsigned char>& message,
                     << vcblock.GetHeader().GetCandidateLeaderNetworkInfo());
     return false;
   }
-  // TODO
-  // LogReceivedVSBlockDetails(vcblock);
 
   // Check the signature of this VC block
   if (!VerifyVCBlockCoSignature(vcblock)) {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR delays the sending of VC blocks (for ds block consensus)  to shard nodes. The sending of the vcblocks have been postponed and combined with the sending of DS Blocks. The benefit of such delays is that the DS Committee will have the sharding structure before transmission of the blocks. 

This will allows for the implementation for efficient broadcasting (tree based) of vc block(s). 

Known issue that hinder testing of this PR
- Lookup consuming too much cpu utilization on startup (https://github.com/Zilliqa/Issues/issues/224)
- https://github.com/Zilliqa/Issues/issues/225

With this issue, it is hard to observe lookup performing changing its view. However, it used the same function as the same as shard nodes. Changing of view is tested to be successful on DS Committee and Shard nodes. 

TODO (refactors):
- [x] Rename SetNodeDSBock to SetNodeVCDSBlocksMessage
- [x] Rename GetNodeDSBock to GetNodeVCDSBlocksMessage
- [x] Rename ProcessDSblock to ProcessVCDSBlocksMessage

**Message visualization for - DS -> node : 
Before:** 
- DS -> node DS Block
`[DSBlock][Sharding structure][misc info]
`
- All VC 
`[VC Block]
`

**After:**
- (Renamed) VCDSMBlocksMessage to node 
`[DSBlock][Vector of VCBlocks][Sharding structure][misc info]
`
- VC after DS Block: 
`[VC Block]
`
## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Note: A revisit and follow PR for view change is required. Follow up is for various scenario of view change. 

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review** 
- [x] Retest rebase

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
**Local test**
- [x] No view change standard test (commit: e750a27cdc1ba64c65507b1055b1a248ec9ddd78)
- [x] 1x view change before ds block (commit: f152a042bd199511663d9322b99a4ada24567899)
- [ ] 3x view change before ds block (commit: f152a042bd199511663d9322b99a4ada24567899)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
**Medium scale test**
- [x] medium-scale cloud test (No view change) (commit: f152a042bd199511663d9322b99a4ada24567899) - 15 DS Epoch
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
