### PR TITLE
Hotfix of g3log installation failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 #
 find_package(PkgConfig REQUIRED)
 
-find_package(g3logger QUIET)
-if(NOT "${g3logger_FOUND}")
-    include(InstallG3log)
-    find_package(g3logger REQUIRED)
-endif()
+include(InstallG3log)
+find_package(g3logger CONFIG REQUIRED)
 
 find_package(libmongocxx QUIET)
 if (NOT ${libmongocxx_FOUND})


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Since 8f3c6626c4b61a5731b5083edc7a42831914f2ea, build failed happened in cmake 3.10.2, ubuntu 18.04.1 LTS.
This hotfix just roll-back g3log-related installation process to clean the roadblock.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
