### PR TITLE
Added hashing functions to Messenger for the DSBlockHashSet

### DIFF
--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -1247,7 +1247,7 @@ bool Messenger::GetDSCommitteeHash(const deque<pair<PubKey, Peer>>& dsCommittee,
 
   SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
   sha2.Update(tmp);
-  tmp = move(sha2.Finalize());
+  tmp = sha2.Finalize();
 
   copy(tmp.begin(), tmp.end(), dst.asArray().begin());
 
@@ -1274,7 +1274,7 @@ bool Messenger::GetShardingStructureHash(const DequeOfShard& shards,
 
   SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
   sha2.Update(tmp);
-  tmp = move(sha2.Finalize());
+  tmp = sha2.Finalize();
 
   copy(tmp.begin(), tmp.end(), dst.asArray().begin());
 
@@ -1303,7 +1303,7 @@ bool Messenger::GetTxSharingAssignmentsHash(
 
   SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
   sha2.Update(tmp);
-  tmp = move(sha2.Finalize());
+  tmp = sha2.Finalize();
 
   copy(tmp.begin(), tmp.end(), dst.asArray().begin());
 

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -77,6 +77,115 @@ void ProtobufByteArrayToNumber(const ByteArray& byteArray, T& number) {
   number = Serializable::GetNumber<T>(tmp, 0, S);
 }
 
+void DSCommitteeToProtobuf(const deque<pair<PubKey, Peer>>& dsCommittee,
+                           ProtoDSCommittee& protoDSCommittee) {
+  for (const auto& node : dsCommittee) {
+    ProtoDSNode* protodsnode = protoDSCommittee.add_dsnodes();
+    SerializableToProtobufByteArray(node.first, *protodsnode->mutable_pubkey());
+    SerializableToProtobufByteArray(node.second, *protodsnode->mutable_peer());
+  }
+}
+
+void ProtobufToDSCommittee(const ProtoDSCommittee& protoDSCommittee,
+                           deque<pair<PubKey, Peer>>& dsCommittee) {
+  for (const auto& dsnode : protoDSCommittee.dsnodes()) {
+    PubKey pubkey;
+    Peer peer;
+
+    ProtobufByteArrayToSerializable(dsnode.pubkey(), pubkey);
+    ProtobufByteArrayToSerializable(dsnode.peer(), peer);
+    dsCommittee.emplace_back(pubkey, peer);
+  }
+}
+
+void ShardingStructureToProtobuf(
+    const DequeOfShard& shards,
+    ProtoShardingStructure& protoShardingStructure) {
+  for (const auto& shard : shards) {
+    ProtoShardingStructure::Shard* proto_shard =
+        protoShardingStructure.add_shards();
+
+    for (const auto& node : shard) {
+      ProtoShardingStructure::Member* proto_member = proto_shard->add_members();
+
+      SerializableToProtobufByteArray(std::get<SHARD_NODE_PUBKEY>(node),
+                                      *proto_member->mutable_pubkey());
+      SerializableToProtobufByteArray(std::get<SHARD_NODE_PEER>(node),
+                                      *proto_member->mutable_peerinfo());
+      proto_member->set_reputation(std::get<SHARD_NODE_REP>(node));
+    }
+  }
+}
+
+void ProtobufToShardingStructure(
+    const ProtoShardingStructure& protoShardingStructure,
+    DequeOfShard& shards) {
+  for (const auto& proto_shard : protoShardingStructure.shards()) {
+    shards.emplace_back();
+
+    for (const auto& proto_member : proto_shard.members()) {
+      PubKey key;
+      Peer peer;
+
+      ProtobufByteArrayToSerializable(proto_member.pubkey(), key);
+      ProtobufByteArrayToSerializable(proto_member.peerinfo(), peer);
+
+      shards.back().emplace_back(key, peer, proto_member.reputation());
+    }
+  }
+}
+
+void TxSharingAssignmentsToProtobuf(
+    const vector<Peer>& dsReceivers, const vector<vector<Peer>>& shardReceivers,
+    const vector<vector<Peer>>& shardSenders,
+    ProtoTxSharingAssignments& protoTxSharingAssignments) {
+  for (const auto& dsnode : dsReceivers) {
+    SerializableToProtobufByteArray(dsnode,
+                                    *protoTxSharingAssignments.add_dsnodes());
+  }
+
+  for (unsigned int i = 0; i < shardReceivers.size(); i++) {
+    ProtoTxSharingAssignments::AssignedNodes* proto_shard =
+        protoTxSharingAssignments.add_shardnodes();
+
+    for (const auto& receiver : shardReceivers.at(i)) {
+      SerializableToProtobufByteArray(receiver, *proto_shard->add_receivers());
+    }
+    for (const auto& sender : shardSenders.at(i)) {
+      SerializableToProtobufByteArray(sender, *proto_shard->add_senders());
+    }
+  }
+}
+
+void ProtobufToTxSharingAssignments(
+    const ProtoTxSharingAssignments& protoTxSharingAssignments,
+    vector<Peer>& dsReceivers, vector<vector<Peer>>& shardReceivers,
+    vector<vector<Peer>>& shardSenders) {
+  for (const auto& dsnode : protoTxSharingAssignments.dsnodes()) {
+    Peer peer;
+    ProtobufByteArrayToSerializable(dsnode, peer);
+    dsReceivers.emplace_back(peer);
+  }
+
+  for (const auto& proto_shard : protoTxSharingAssignments.shardnodes()) {
+    shardReceivers.emplace_back();
+
+    for (const auto& receiver : proto_shard.receivers()) {
+      Peer peer;
+      ProtobufByteArrayToSerializable(receiver, peer);
+      shardReceivers.back().emplace_back(peer);
+    }
+
+    shardSenders.emplace_back();
+
+    for (const auto& sender : proto_shard.senders()) {
+      Peer peer;
+      ProtobufByteArrayToSerializable(sender, peer);
+      shardSenders.back().emplace_back(peer);
+    }
+  }
+}
+
 void DSBlockHeaderToProtobuf(const DSBlockHeader& dsBlockHeader,
                              ProtoDSBlock::DSBlockHeader& protoDSBlockHeader) {
   protoDSBlockHeader.set_dsdifficulty(dsBlockHeader.GetDSDifficulty());
@@ -1118,6 +1227,89 @@ bool GetConsensusAnnouncementCore(
 // Primitives
 // ============================================================================
 
+bool Messenger::GetDSCommitteeHash(const deque<pair<PubKey, Peer>>& dsCommittee,
+                                   DSCommHash& dst) {
+  ProtoDSCommittee protoDSCommittee;
+
+  DSCommitteeToProtobuf(dsCommittee, protoDSCommittee);
+
+  if (!protoDSCommittee.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoDSCommittee initialization failed.");
+    return false;
+  }
+
+  vector<unsigned char> tmp;
+
+  if (!SerializeToArray(protoDSCommittee, tmp, 0)) {
+    LOG_GENERAL(WARNING, "ProtoDSCommittee serialization failed.");
+    return false;
+  }
+
+  SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
+  sha2.Update(tmp);
+  tmp = move(sha2.Finalize());
+
+  copy(tmp.begin(), tmp.end(), dst.asArray().begin());
+
+  return true;
+}
+
+bool Messenger::GetShardingStructureHash(const DequeOfShard& shards,
+                                         ShardingHash& dst) {
+  ProtoShardingStructure protoShardingStructure;
+
+  ShardingStructureToProtobuf(shards, protoShardingStructure);
+
+  if (!protoShardingStructure.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoShardingStructure initialization failed.");
+    return false;
+  }
+
+  vector<unsigned char> tmp;
+
+  if (!SerializeToArray(protoShardingStructure, tmp, 0)) {
+    LOG_GENERAL(WARNING, "ProtoShardingStructure serialization failed.");
+    return false;
+  }
+
+  SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
+  sha2.Update(tmp);
+  tmp = move(sha2.Finalize());
+
+  copy(tmp.begin(), tmp.end(), dst.asArray().begin());
+
+  return true;
+}
+
+bool Messenger::GetTxSharingAssignmentsHash(
+    const vector<Peer>& dsReceivers, const vector<vector<Peer>>& shardReceivers,
+    const vector<vector<Peer>>& shardSenders, TxSharingHash& dst) {
+  ProtoTxSharingAssignments protoTxSharingAssignments;
+
+  TxSharingAssignmentsToProtobuf(dsReceivers, shardReceivers, shardSenders,
+                                 protoTxSharingAssignments);
+
+  if (!protoTxSharingAssignments.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTxSharingAssignments initialization failed.");
+    return false;
+  }
+
+  vector<unsigned char> tmp;
+
+  if (!SerializeToArray(protoTxSharingAssignments, tmp, 0)) {
+    LOG_GENERAL(WARNING, "ProtoTxSharingAssignments serialization failed.");
+    return false;
+  }
+
+  SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
+  sha2.Update(tmp);
+  tmp = move(sha2.Finalize());
+
+  copy(tmp.begin(), tmp.end(), dst.asArray().begin());
+
+  return true;
+}
+
 bool Messenger::SetDSBlockHeader(vector<unsigned char>& dst,
                                  const unsigned int offset,
                                  const DSBlockHeader& dsBlockHeader) {
@@ -1606,38 +1798,10 @@ bool Messenger::SetDSDSBlockAnnouncement(
 
   DSBlockToProtobuf(dsBlock, *dsblock->mutable_dsblock());
 
-  for (const auto& shard : shards) {
-    ShardingStructure::Shard* proto_shard =
-        dsblock->mutable_sharding()->add_shards();
+  ShardingStructureToProtobuf(shards, *dsblock->mutable_sharding());
 
-    for (const auto& node : shard) {
-      ShardingStructure::Member* proto_member = proto_shard->add_members();
-
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PUBKEY>(node),
-                                      *proto_member->mutable_pubkey());
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PEER>(node),
-                                      *proto_member->mutable_peerinfo());
-      proto_member->set_reputation(std::get<SHARD_NODE_REP>(node));
-    }
-  }
-
-  TxSharingAssignments* proto_assignments = dsblock->mutable_assignments();
-
-  for (const auto& dsnode : dsReceivers) {
-    SerializableToProtobufByteArray(dsnode, *proto_assignments->add_dsnodes());
-  }
-
-  for (unsigned int i = 0; i < shardReceivers.size(); i++) {
-    TxSharingAssignments::AssignedNodes* proto_shard =
-        proto_assignments->add_shardnodes();
-
-    for (const auto& receiver : shardReceivers.at(i)) {
-      SerializableToProtobufByteArray(receiver, *proto_shard->add_receivers());
-    }
-    for (const auto& sender : shardSenders.at(i)) {
-      SerializableToProtobufByteArray(sender, *proto_shard->add_senders());
-    }
-  }
+  TxSharingAssignmentsToProtobuf(dsReceivers, shardReceivers, shardSenders,
+                                 *dsblock->mutable_assignments());
 
   if (!dsblock->IsInitialized()) {
     LOG_GENERAL(WARNING, "DSDSBlockAnnouncement initialization failed. Debug: "
@@ -1710,45 +1874,10 @@ bool Messenger::GetDSDSBlockAnnouncement(
 
   ProtobufToDSBlock(dsblock.dsblock(), dsBlock);
 
-  for (const auto& proto_shard : dsblock.sharding().shards()) {
-    shards.emplace_back();
+  ProtobufToShardingStructure(dsblock.sharding(), shards);
 
-    for (const auto& proto_member : proto_shard.members()) {
-      PubKey key;
-      Peer peer;
-
-      ProtobufByteArrayToSerializable(proto_member.pubkey(), key);
-      ProtobufByteArrayToSerializable(proto_member.peerinfo(), peer);
-
-      shards.back().emplace_back(key, peer, proto_member.reputation());
-    }
-  }
-
-  const TxSharingAssignments& proto_assignments = dsblock.assignments();
-
-  for (const auto& dsnode : proto_assignments.dsnodes()) {
-    Peer peer;
-    ProtobufByteArrayToSerializable(dsnode, peer);
-    dsReceivers.emplace_back(peer);
-  }
-
-  for (const auto& proto_shard : proto_assignments.shardnodes()) {
-    shardReceivers.emplace_back();
-
-    for (const auto& receiver : proto_shard.receivers()) {
-      Peer peer;
-      ProtobufByteArrayToSerializable(receiver, peer);
-      shardReceivers.back().emplace_back(peer);
-    }
-
-    shardSenders.emplace_back();
-
-    for (const auto& sender : proto_shard.senders()) {
-      Peer peer;
-      ProtobufByteArrayToSerializable(sender, peer);
-      shardSenders.back().emplace_back(peer);
-    }
-  }
+  ProtobufToTxSharingAssignments(dsblock.assignments(), dsReceivers,
+                                 shardReceivers, shardSenders);
 
   // Get the part of the announcement that should be co-signed during the first
   // round of consensus
@@ -1958,38 +2087,10 @@ bool Messenger::SetNodeDSBlock(vector<unsigned char>& dst,
   result.set_shardid(shardId);
   DSBlockToProtobuf(dsBlock, *result.mutable_dsblock());
 
-  for (const auto& shard : shards) {
-    ShardingStructure::Shard* proto_shard =
-        result.mutable_sharding()->add_shards();
+  ShardingStructureToProtobuf(shards, *result.mutable_sharding());
 
-    for (const auto& node : shard) {
-      ShardingStructure::Member* proto_member = proto_shard->add_members();
-
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PUBKEY>(node),
-                                      *proto_member->mutable_pubkey());
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PEER>(node),
-                                      *proto_member->mutable_peerinfo());
-      proto_member->set_reputation(std::get<SHARD_NODE_REP>(node));
-    }
-  }
-
-  TxSharingAssignments* proto_assignments = result.mutable_assignments();
-
-  for (const auto& dsnode : dsReceivers) {
-    SerializableToProtobufByteArray(dsnode, *proto_assignments->add_dsnodes());
-  }
-
-  for (unsigned int i = 0; i < shardReceivers.size(); i++) {
-    TxSharingAssignments::AssignedNodes* proto_shard =
-        proto_assignments->add_shardnodes();
-
-    for (const auto& receiver : shardReceivers.at(i)) {
-      SerializableToProtobufByteArray(receiver, *proto_shard->add_receivers());
-    }
-    for (const auto& sender : shardSenders.at(i)) {
-      SerializableToProtobufByteArray(sender, *proto_shard->add_senders());
-    }
-  }
+  TxSharingAssignmentsToProtobuf(dsReceivers, shardReceivers, shardSenders,
+                                 *result.mutable_assignments());
 
   if (!result.IsInitialized()) {
     LOG_GENERAL(WARNING, "NodeDSBlock initialization failed.");
@@ -2019,45 +2120,10 @@ bool Messenger::GetNodeDSBlock(const vector<unsigned char>& src,
   shardId = result.shardid();
   ProtobufToDSBlock(result.dsblock(), dsBlock);
 
-  for (const auto& proto_shard : result.sharding().shards()) {
-    shards.emplace_back();
+  ProtobufToShardingStructure(result.sharding(), shards);
 
-    for (const auto& proto_member : proto_shard.members()) {
-      PubKey key;
-      Peer peer;
-
-      ProtobufByteArrayToSerializable(proto_member.pubkey(), key);
-      ProtobufByteArrayToSerializable(proto_member.peerinfo(), peer);
-
-      shards.back().emplace_back(key, peer, proto_member.reputation());
-    }
-  }
-
-  const TxSharingAssignments& proto_assignments = result.assignments();
-
-  for (const auto& dsnode : proto_assignments.dsnodes()) {
-    Peer peer;
-    ProtobufByteArrayToSerializable(dsnode, peer);
-    dsReceivers.emplace_back(peer);
-  }
-
-  for (const auto& proto_shard : proto_assignments.shardnodes()) {
-    shardReceivers.emplace_back();
-
-    for (const auto& receiver : proto_shard.receivers()) {
-      Peer peer;
-      ProtobufByteArrayToSerializable(receiver, peer);
-      shardReceivers.back().emplace_back(peer);
-    }
-
-    shardSenders.emplace_back();
-
-    for (const auto& sender : proto_shard.senders()) {
-      Peer peer;
-      ProtobufByteArrayToSerializable(sender, peer);
-      shardSenders.back().emplace_back(peer);
-    }
-  }
+  ProtobufToTxSharingAssignments(result.assignments(), dsReceivers,
+                                 shardReceivers, shardSenders);
 
   return true;
 }
@@ -2663,11 +2729,7 @@ bool Messenger::SetLookupSetDSInfoFromSeed(
 
   LookupSetDSInfoFromSeed result;
 
-  for (const auto& node : dsNodes) {
-    LookupSetDSInfoFromSeed::DSNode* protodsnode = result.add_dsnodes();
-    SerializableToProtobufByteArray(node.first, *protodsnode->mutable_pubkey());
-    SerializableToProtobufByteArray(node.second, *protodsnode->mutable_peer());
-  }
+  DSCommitteeToProtobuf(dsNodes, *result.mutable_dscommittee());
 
   if (!result.IsInitialized()) {
     LOG_GENERAL(WARNING, "LookupSetDSInfoFromSeed initialization failed.");
@@ -2691,14 +2753,7 @@ bool Messenger::GetLookupSetDSInfoFromSeed(const vector<unsigned char>& src,
     return false;
   }
 
-  for (const auto& dsnode : result.dsnodes()) {
-    PubKey pubkey;
-    Peer peer;
-
-    ProtobufByteArrayToSerializable(dsnode.pubkey(), pubkey);
-    ProtobufByteArrayToSerializable(dsnode.peer(), peer);
-    dsNodes.emplace_back(pubkey, peer);
-  }
+  ProtobufToDSCommittee(result.dscommittee(), dsNodes);
 
   return true;
 }
@@ -3313,20 +3368,7 @@ bool Messenger::SetLookupSetShardsFromSeed(vector<unsigned char>& dst,
 
   LookupSetShardsFromSeed result;
 
-  for (const auto& shard : shards) {
-    ShardingStructure::Shard* proto_shard =
-        result.mutable_sharding()->add_shards();
-
-    for (const auto& node : shard) {
-      ShardingStructure::Member* proto_member = proto_shard->add_members();
-
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PUBKEY>(node),
-                                      *proto_member->mutable_pubkey());
-      SerializableToProtobufByteArray(std::get<SHARD_NODE_PEER>(node),
-                                      *proto_member->mutable_peerinfo());
-      proto_member->set_reputation(std::get<SHARD_NODE_REP>(node));
-    }
-  }
+  ShardingStructureToProtobuf(shards, *result.mutable_sharding());
 
   if (!result.IsInitialized()) {
     LOG_GENERAL(WARNING, "LookupSetShardsFromSeed initialization failed.");
@@ -3350,19 +3392,7 @@ bool Messenger::GetLookupSetShardsFromSeed(const vector<unsigned char>& src,
     return false;
   }
 
-  for (const auto& proto_shard : result.sharding().shards()) {
-    shards.emplace_back();
-
-    for (const auto& proto_member : proto_shard.members()) {
-      PubKey key;
-      Peer peer;
-
-      ProtobufByteArrayToSerializable(proto_member.pubkey(), key);
-      ProtobufByteArrayToSerializable(proto_member.peerinfo(), peer);
-
-      shards.back().emplace_back(key, peer, proto_member.reputation());
-    }
-  }
+  ProtobufToShardingStructure(result.sharding(), shards);
 
   return true;
 }

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -33,6 +33,16 @@ class Messenger {
   // Primitives
   // ============================================================================
 
+  static bool GetDSCommitteeHash(
+      const std::deque<std::pair<PubKey, Peer>>& dsCommittee, DSCommHash& dst);
+
+  static bool GetShardingStructureHash(const DequeOfShard& shards,
+                                       ShardingHash& dst);
+  static bool GetTxSharingAssignmentsHash(
+      const std::vector<Peer>& dsReceivers,
+      const std::vector<std::vector<Peer>>& shardReceivers,
+      const std::vector<std::vector<Peer>>& shardSenders, TxSharingHash& dst);
+
   static bool SetDSBlockHeader(std::vector<unsigned char>& dst,
                                const unsigned int offset,
                                const DSBlockHeader& dsBlockHeader);

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -11,7 +11,18 @@ message ByteArray
     required bytes data = 1;
 }
 
-message ShardingStructure
+message ProtoDSNode
+{
+    required ByteArray pubkey = 1;
+    required ByteArray peer   = 2;
+}
+
+message ProtoDSCommittee
+{
+    repeated ProtoDSNode dsnodes = 1;
+}
+
+message ProtoShardingStructure
 {
     message Member
     {
@@ -26,7 +37,7 @@ message ShardingStructure
     repeated Shard shards           = 1;
 }
 
-message TxSharingAssignments
+message ProtoTxSharingAssignments
 {
     message AssignedNodes
     {
@@ -235,9 +246,9 @@ message DSMicroBlockSubmission
 
 message DSDSBlockAnnouncement
 {
-    required ProtoDSBlock dsblock             = 1;
-    required ShardingStructure sharding       = 2;
-    required TxSharingAssignments assignments = 3;
+    required ProtoDSBlock dsblock                  = 1;
+    required ProtoShardingStructure sharding       = 2;
+    required ProtoTxSharingAssignments assignments = 3;
 }
 
 message DSFinalBlockAnnouncement
@@ -256,10 +267,10 @@ message DSVCBlockAnnouncement
 
 message NodeDSBlock
 {
-    required uint32 shardid                   = 1;
-    required ProtoDSBlock dsblock             = 2;
-    required ShardingStructure sharding       = 3;
-    required TxSharingAssignments assignments = 4;
+    required uint32 shardid                        = 1;
+    required ProtoDSBlock dsblock                  = 2;
+    required ProtoShardingStructure sharding       = 3;
+    required ProtoTxSharingAssignments assignments = 4;
 }
 
 message NodeFinalBlock
@@ -329,12 +340,7 @@ message LookupGetDSInfoFromSeed
 
 message LookupSetDSInfoFromSeed
 {
-    message DSNode
-    {
-        required ByteArray pubkey = 1;
-        required ByteArray peer   = 2;
-    }
-    repeated DSNode dsnodes       = 1;
+    required ProtoDSCommittee dscommittee = 1;
 }
 
 message LookupGetDSBlockFromSeed
@@ -439,7 +445,7 @@ message LookupGetShardsFromSeed
 
 message LookupSetShardsFromSeed
 {
-    required ShardingStructure sharding = 1;
+    required ProtoShardingStructure sharding = 1;
 }
 
 message MicroBlockInfo


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR introduces these functions to be able to set the `DSBlockHashSet`:
- `Messenger::GetDSCommitteeHash`
- `Messenger::GetShardingStructureHash`
- `Messenger::GetTxSharingAssignmentsHash`

These functions are still unused as of this PR.

Related to this, some refactoring is also done inside `ZilliqaMessage.proto` and `Messenger.cpp`.

Local test has confirmed the affected refactored messages work ok, but the refactored `LookupSetShardsFromSeed` and `LookupGetShardsFromSeed` are not tested yet. I propose we test them separately afterwards.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
