### PR TITLE
Added CommitteeHash to BlockHeaderBase and Messenger

### DIFF
--- a/src/libData/BlockData/BlockHeader/BlockHashSet.h
+++ b/src/libData/BlockData/BlockHeader/BlockHashSet.h
@@ -24,26 +24,22 @@
 #include "libData/AccountData/Transaction.h"
 
 // Hashes for DSBlockHashSet
-using DSCommHash = dev::h256;
 using ShardingHash = dev::h256;
 using TxSharingHash = dev::h256;
 
 struct DSBlockHashSet {
-  DSCommHash m_dsCommHash;        // Hash of DS committee composition
   ShardingHash m_shardingHash;    // Hash of sharding structure
   TxSharingHash m_txSharingHash;  // Hash of transaction sharing assignments
   std::array<unsigned char, RESERVED_FIELD_SIZE>
       m_reservedField;  // Reserved storage for extra hashes
 
   bool operator==(const DSBlockHashSet& hashSet) const {
-    return std::tie(m_dsCommHash, m_shardingHash, m_txSharingHash) ==
-           std::tie(hashSet.m_dsCommHash, hashSet.m_shardingHash,
-                    hashSet.m_txSharingHash);
+    return std::tie(m_shardingHash, m_txSharingHash) ==
+           std::tie(hashSet.m_shardingHash, hashSet.m_txSharingHash);
   }
   bool operator<(const DSBlockHashSet& hashSet) const {
-    return std::tie(m_dsCommHash, m_shardingHash, m_txSharingHash) >
-           std::tie(hashSet.m_dsCommHash, hashSet.m_shardingHash,
-                    hashSet.m_txSharingHash);
+    return std::tie(m_shardingHash, m_txSharingHash) >
+           std::tie(hashSet.m_shardingHash, hashSet.m_txSharingHash);
   }
   bool operator>(const DSBlockHashSet& hashSet) const {
     return !((*this == hashSet) || (*this < hashSet));
@@ -54,7 +50,6 @@ struct DSBlockHashSet {
 
 inline std::ostream& operator<<(std::ostream& os, const DSBlockHashSet& t) {
   os << "<DSBlockHashSet>" << std::endl
-     << "m_dsCommHash : " << t.m_dsCommHash.hex() << std::endl
      << "m_shardingHash : " << t.m_shardingHash.hex() << std::endl
      << "m_txSharingHash : " << t.m_txSharingHash.hex() << std::endl
      << "m_reservedField : "
@@ -68,7 +63,6 @@ template <>
 struct hash<DSBlockHashSet> {
   size_t operator()(DSBlockHashSet const& hashSet) const noexcept {
     std::size_t seed = 0;
-    boost::hash_combine(seed, hashSet.m_dsCommHash.hex());
     boost::hash_combine(seed, hashSet.m_shardingHash.hex());
     boost::hash_combine(seed, hashSet.m_txSharingHash.hex());
     boost::hash_combine(

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.cpp
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.cpp
@@ -26,6 +26,9 @@ using namespace boost::multiprecision;
 
 BlockHeaderBase::BlockHeaderBase() {}
 
+BlockHeaderBase::BlockHeaderBase(const CommitteeHash& committeeHash)
+    : m_committeeHash(committeeHash) {}
+
 BlockHash BlockHeaderBase::GetMyHash() const {
   SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
   std::vector<unsigned char> vec;
@@ -35,4 +38,8 @@ BlockHash BlockHeaderBase::GetMyHash() const {
   BlockHash blockHash;
   std::copy(resVec.begin(), resVec.end(), blockHash.asArray().begin());
   return blockHash;
+}
+
+const CommitteeHash& BlockHeaderBase::GetCommitteeHash() const {
+  return m_committeeHash;
 }

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
@@ -23,23 +23,29 @@
 #include <array>
 #include <boost/multiprecision/cpp_int.hpp>
 
-#include "BlockHeaderBase.h"
 #include "common/Constants.h"
 #include "common/Serializable.h"
 #include "libCrypto/Schnorr.h"
 #include "libData/AccountData/Transaction.h"
 
+// Hash for the committee that generated the block
+using CommitteeHash = dev::h256;
+
 /// [TODO] Base class for all supported block header types
 class BlockHeaderBase : public SerializableDataBlock {
  protected:
   // TODO: pull out all common code from ds, micro and tx block header
+  CommitteeHash m_committeeHash;
 
  public:
   // Constructors
   BlockHeaderBase();
+  BlockHeaderBase(const CommitteeHash& committeeHash);
 
   /// Calculate my hash
   BlockHash GetMyHash() const;
+
+  const CommitteeHash& GetCommitteeHash() const;
 };
 
 #endif  // __BLOCKHEADERBASE_H__

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -37,8 +37,10 @@ DSBlockHeader::DSBlockHeader(
     const uint8_t dsDifficulty, const uint8_t difficulty,
     const BlockHash& prevHash, const PubKey& leaderPubKey,
     const uint64_t& blockNum, const uint256_t& timestamp, const SWInfo& swInfo,
-    const map<PubKey, Peer>& powDSWinners, const DSBlockHashSet& hash)
-    : m_dsDifficulty(dsDifficulty),
+    const map<PubKey, Peer>& powDSWinners, const DSBlockHashSet& hash,
+    const CommitteeHash& committeeHash)
+    : BlockHeaderBase(committeeHash),
+      m_dsDifficulty(dsDifficulty),
       m_difficulty(difficulty),
       m_prevHash(prevHash),
       m_leaderPubKey(leaderPubKey),
@@ -84,10 +86,6 @@ const SWInfo& DSBlockHeader::GetSWInfo() const { return m_swInfo; }
 
 const map<PubKey, Peer>& DSBlockHeader::GetDSPoWWinners() const {
   return m_PoWDSWinners;
-}
-
-const DSCommHash& DSBlockHeader::GetDSCommHash() const {
-  return m_hash.m_dsCommHash;
 }
 
 const ShardingHash& DSBlockHeader::GetShardingHash() const {

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -59,7 +59,7 @@ class DSBlockHeader : public BlockHeaderBase {
                 const boost::multiprecision::uint256_t& timestamp,
                 const SWInfo& swInfo,
                 const std::map<PubKey, Peer>& powDSWinners,
-                const DSBlockHashSet& hash);
+                const DSBlockHashSet& hash, const CommitteeHash& committeeHash);
 
   /// Implements the Serialize function inherited from Serializable.
   bool Serialize(std::vector<unsigned char>& dst,
@@ -93,10 +93,6 @@ class DSBlockHeader : public BlockHeaderBase {
   const SWInfo& GetSWInfo() const;
 
   const std::map<PubKey, Peer>& GetDSPoWWinners() const;
-
-  /// Returns the digest that represents the hash of the DS committee
-  /// composition
-  const DSCommHash& GetDSCommHash() const;
 
   /// Returns the digest that represents the hash of the sharding structure
   const ShardingHash& GetShardingHash() const;

--- a/src/libData/BlockData/BlockHeader/FallbackBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/FallbackBlockHeader.cpp
@@ -38,8 +38,10 @@ FallbackBlockHeader::FallbackBlockHeader(
     const unsigned char fallbackState, const StateHash& stateRootHash,
     const uint32_t leaderConsensusId, const Peer& leaderNetworkInfo,
     const PubKey& leaderPubKey, const uint32_t shardId,
-    const boost::multiprecision::uint256_t& timestamp)
-    : m_fallbackDSEpochNo(fallbackDSEpochNo),
+    const boost::multiprecision::uint256_t& timestamp,
+    const CommitteeHash& committeeHash)
+    : BlockHeaderBase(committeeHash),
+      m_fallbackDSEpochNo(fallbackDSEpochNo),
       m_fallbackEpochNo(fallbackEpochNo),
       m_fallbackState(fallbackState),
       m_hash{stateRootHash},

--- a/src/libData/BlockData/BlockHeader/FallbackBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/FallbackBlockHeader.h
@@ -58,7 +58,8 @@ class FallbackBlockHeader : public BlockHeaderBase {
                       const uint32_t leaderConsensusId,
                       const Peer& leaderNetworkInfo, const PubKey& leaderPubKey,
                       const uint32_t shardId,
-                      const boost::multiprecision::uint256_t& timestamp);
+                      const boost::multiprecision::uint256_t& timestamp,
+                      const CommitteeHash& committeeHash);
 
   /// Implements the Serialize function inherited from Serializable.
   bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
@@ -39,8 +39,10 @@ MicroBlockHeader::MicroBlockHeader(
     const uint64_t& blockNum, const uint256_t& timestamp,
     const TxnHash& txRootHash, uint32_t numTxs, const PubKey& minerPubKey,
     const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader,
-    const StateHash& stateDeltaHash, const TxnHash& tranReceiptHash)
-    : m_type(type),
+    const StateHash& stateDeltaHash, const TxnHash& tranReceiptHash,
+    const CommitteeHash& committeeHash)
+    : BlockHeaderBase(committeeHash),
+      m_type(type),
       m_version(version),
       m_shardId(shardId),
       m_gasLimit(gasLimit),

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
@@ -66,7 +66,8 @@ class MicroBlockHeader : public BlockHeaderBase {
                    const PubKey& minerPubKey, const uint64_t& dsBlockNum,
                    const BlockHash& dsBlockHeader,
                    const StateHash& stateDeltaHash,
-                   const TxnHash& tranReceiptHash);
+                   const TxnHash& tranReceiptHash,
+                   const CommitteeHash& committeeHash);
 
   /// Implements the Serialize function inherited from Serializable.
   bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -41,8 +41,10 @@ TxBlockHeader::TxBlockHeader(
     const StateHash& deltaRootHash, const StateHash& stateDeltaHash,
     const TxnHash& tranReceiptRootHash, uint32_t numTxs,
     uint32_t numMicroBlockHashes, const PubKey& minerPubKey,
-    const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader)
-    : m_type(type),
+    const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader,
+    const CommitteeHash& committeeHash)
+    : BlockHeaderBase(committeeHash),
+      m_type(type),
       m_version(version),
       m_gasLimit(gasLimit),
       m_gasUsed(gasUsed),

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.h
@@ -64,7 +64,8 @@ class TxBlockHeader : public BlockHeaderBase {
                 const StateHash& deltaRootHash, const StateHash& stateDeltaHash,
                 const TxnHash& tranReceiptRootHash, const uint32_t numTxs,
                 const uint32_t numMicroBlockHashes, const PubKey& minerPubKey,
-                const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader);
+                const uint64_t& dsBlockNum, const BlockHash& dsBlockHeader,
+                const CommitteeHash& committeeHash);
 
   /// Implements the Serialize function inherited from Serializable.
   bool Serialize(std::vector<unsigned char>& dst,

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.cpp
@@ -40,8 +40,10 @@ VCBlockHeader::VCBlockHeader(const uint64_t& vieWChangeDSEpochNo,
                              const Peer& candidateLeaderNetworkInfo,
                              const PubKey& candidateLeaderPubKey,
                              const uint32_t vcCounter,
-                             const boost::multiprecision::uint256_t& timestamp)
-    : m_VieWChangeDSEpochNo(vieWChangeDSEpochNo),
+                             const boost::multiprecision::uint256_t& timestamp,
+                             const CommitteeHash& committeeHash)
+    : BlockHeaderBase(committeeHash),
+      m_VieWChangeDSEpochNo(vieWChangeDSEpochNo),
       m_VieWChangeEpochNo(viewChangeEpochNo),
       m_ViewChangeState(viewChangeState),
       m_CandidateLeaderIndex(expectedCandidateLeaderIndex),

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.h
@@ -56,7 +56,8 @@ class VCBlockHeader : public BlockHeaderBase {
                 const uint32_t expectedCandidateLeaderIndex,
                 const Peer& candidateLeaderNetworkInfo,
                 const PubKey& candidateLeaderPubKey, const uint32_t vcCounter,
-                const boost::multiprecision::uint256_t& timestamp);
+                const boost::multiprecision::uint256_t& timestamp,
+                const CommitteeHash& committeeHash);
 
   /// Implements the Serialize function inherited from Serializable.
   bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -122,11 +122,12 @@ unsigned int DirectoryService::ComposeDSBlock(
   // TODO: Revise DS block structure
   {
     lock_guard<mutex> g(m_mediator.m_mutexCurSWInfo);
-    m_pendingDSBlock.reset(new DSBlock(
-        DSBlockHeader(dsDifficulty, difficulty, prevHash,
-                      m_mediator.m_selfKey.second, blockNum, get_time_as_int(),
-                      SWInfo(), powDSWinners, DSBlockHashSet()),
-        CoSignatures(m_mediator.m_DSCommittee->size())));
+    m_pendingDSBlock.reset(
+        new DSBlock(DSBlockHeader(dsDifficulty, difficulty, prevHash,
+                                  m_mediator.m_selfKey.second, blockNum,
+                                  get_time_as_int(), SWInfo(), powDSWinners,
+                                  DSBlockHashSet(), CommitteeHash()),
+                    CoSignatures(m_mediator.m_DSCommittee->size())));
     m_pendingDSBlock->SetBlockHash(m_pendingDSBlock->GetHeader().GetMyHash());
   }
   LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -169,7 +169,8 @@ void DirectoryService::ComposeFinalBlock() {
                     timestamp, microblockTxnTrieRoot, stateRoot,
                     microblockDeltaTrieRoot, stateDeltaHash,
                     microblockTranReceiptRoot, numTxs, numMicroBlocks,
-                    m_mediator.m_selfKey.second, lastDSBlockNum, dsBlockHeader),
+                    m_mediator.m_selfKey.second, lastDSBlockNum, dsBlockHeader,
+                    CommitteeHash()),
       isMicroBlockEmpty, microBlockHashes, shardIds,
       CoSignatures(m_mediator.m_DSCommittee->size())));
   m_finalBlock->SetBlockHash(m_finalBlock->GetHeader().GetMyHash());

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -271,7 +271,7 @@ void DirectoryService::ComputeNewCandidateLeader() {
             m_mediator.m_currentEpochNum, m_viewChangestate,
             m_viewChangeCounter, newLeaderNetworkInfo,
             m_mediator.m_DSCommittee->at(m_viewChangeCounter).first,
-            m_viewChangeCounter, get_time_as_int()),
+            m_viewChangeCounter, get_time_as_int(), CommitteeHash()),
         CoSignatures()));
     m_pendingVCBlock->SetBlockHash(m_pendingVCBlock->GetHeader().GetMyHash());
   }

--- a/src/libLookup/Synchronizer.cpp
+++ b/src/libLookup/Synchronizer.cpp
@@ -54,7 +54,7 @@ DSBlock Synchronizer::ConstructGenesisDSBlock() {
   DSBlock dsBlock(
       DSBlockHeader(DS_POW_DIFFICULTY, POW_DIFFICULTY, prevHash, keypair.second,
                     genesisBlockNumer, genesisTimestamp, SWInfo(), powDSWinners,
-                    DSBlockHashSet()),
+                    DSBlockHashSet(), CommitteeHash()),
       CoSignatures());
   dsBlock.SetBlockHash(dsBlock.GetHeader().GetMyHash());
   return dsBlock;
@@ -95,7 +95,7 @@ TxBlock Synchronizer::ConstructGenesisTxBlock() {
       TxBlockHeader(TXBLOCKTYPE::FINAL, BLOCKVERSION::VERSION1, 1, 1,
                     BlockHash(), 0, 151384616955606, TxnHash(), StateHash(),
                     StateHash(), StateHash(), TxnHash(), 0, 5, keypair.second,
-                    0, BlockHash()),
+                    0, BlockHash(), CommitteeHash()),
       vector<bool>(1), vector<MicroBlockHashSet>(5), vector<uint32_t>(5),
       CoSignatures());
   txBlock.SetBlockHash(txBlock.GetHeader().GetMyHash());

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -98,6 +98,20 @@ void ProtobufToDSCommittee(const ProtoDSCommittee& protoDSCommittee,
   }
 }
 
+void DSCommitteeToProtoCommittee(const deque<pair<PubKey, Peer>>& dsCommittee,
+                                 ProtoCommittee& protoCommittee) {
+  for (const auto& node : dsCommittee) {
+    SerializableToProtobufByteArray(node.first, *protoCommittee.add_members());
+  }
+}
+
+void ShardToProtoCommittee(const Shard& shard, ProtoCommittee& protoCommittee) {
+  for (const auto& node : shard) {
+    SerializableToProtobufByteArray(std::get<SHARD_NODE_PUBKEY>(node),
+                                    *protoCommittee.add_members());
+  }
+}
+
 void ShardingStructureToProtobuf(
     const DequeOfShard& shards,
     ProtoShardingStructure& protoShardingStructure) {
@@ -211,8 +225,6 @@ void DSBlockHeaderToProtobuf(const DSBlockHeader& dsBlockHeader,
 
   ZilliqaMessage::ProtoDSBlock::DSBlockHashSet* protoHeaderHash =
       protoDSBlockHeader.mutable_hash();
-  protoHeaderHash->set_dscommhash(dsBlockHeader.GetDSCommHash().data(),
-                                  dsBlockHeader.GetDSCommHash().size);
   protoHeaderHash->set_shardinghash(dsBlockHeader.GetShardingHash().data(),
                                     dsBlockHeader.GetShardingHash().size);
   protoHeaderHash->set_txsharinghash(dsBlockHeader.GetTxSharingHash().data(),
@@ -220,6 +232,9 @@ void DSBlockHeaderToProtobuf(const DSBlockHeader& dsBlockHeader,
   protoHeaderHash->set_reservedfield(
       dsBlockHeader.GetHashSetReservedField().data(),
       dsBlockHeader.GetHashSetReservedField().size());
+
+  protoDSBlockHeader.set_committeehash(dsBlockHeader.GetCommitteeHash().data(),
+                                       dsBlockHeader.GetCommitteeHash().size);
 }
 
 void DSBlockToProtobuf(const DSBlock& dsBlock, ProtoDSBlock& protoDSBlock) {
@@ -259,6 +274,7 @@ void ProtobufToDSBlockHeader(
   PubKey leaderPubKey;
   uint256_t timestamp;
   SWInfo swInfo;
+  CommitteeHash committeeHash;
 
   copy(protoDSBlockHeader.prevhash().begin(),
        protoDSBlockHeader.prevhash().begin() +
@@ -285,11 +301,6 @@ void ProtobufToDSBlockHeader(
   DSBlockHashSet hash;
   const ZilliqaMessage::ProtoDSBlock::DSBlockHashSet& protoDSBlockHeaderHash =
       protoDSBlockHeader.hash();
-  copy(protoDSBlockHeaderHash.dscommhash().begin(),
-       protoDSBlockHeaderHash.dscommhash().begin() +
-           min((unsigned int)protoDSBlockHeaderHash.dscommhash().size(),
-               (unsigned int)hash.m_dsCommHash.size),
-       hash.m_dsCommHash.asArray().begin());
   copy(protoDSBlockHeaderHash.shardinghash().begin(),
        protoDSBlockHeaderHash.shardinghash().begin() +
            min((unsigned int)protoDSBlockHeaderHash.shardinghash().size(),
@@ -306,12 +317,18 @@ void ProtobufToDSBlockHeader(
                (unsigned int)hash.m_reservedField.size()),
        hash.m_reservedField.begin());
 
+  copy(protoDSBlockHeader.committeehash().begin(),
+       protoDSBlockHeader.committeehash().begin() +
+           min((unsigned int)protoDSBlockHeader.committeehash().size(),
+               (unsigned int)committeeHash.size),
+       committeeHash.asArray().begin());
+
   // Generate the new DSBlock
 
-  dsBlockHeader = DSBlockHeader(protoDSBlockHeader.dsdifficulty(),
-                                protoDSBlockHeader.difficulty(), prevHash,
-                                leaderPubKey, protoDSBlockHeader.blocknum(),
-                                timestamp, swInfo, powDSWinners, hash);
+  dsBlockHeader = DSBlockHeader(
+      protoDSBlockHeader.dsdifficulty(), protoDSBlockHeader.difficulty(),
+      prevHash, leaderPubKey, protoDSBlockHeader.blocknum(), timestamp, swInfo,
+      powDSWinners, hash, committeeHash);
 }
 
 void ProtobufToDSBlock(const ProtoDSBlock& protoDSBlock, DSBlock& dsBlock) {
@@ -383,6 +400,10 @@ void MicroBlockHeaderToProtobuf(
   protoMicroBlockHeader.set_tranreceipthash(
       microBlockHeader.GetTranReceiptHash().data(),
       microBlockHeader.GetTranReceiptHash().size);
+
+  protoMicroBlockHeader.set_committeehash(
+      microBlockHeader.GetCommitteeHash().data(),
+      microBlockHeader.GetCommitteeHash().size);
 }
 
 void MicroBlockToProtobuf(const MicroBlock& microBlock,
@@ -429,6 +450,7 @@ void ProtobufToMicroBlockHeader(
   BlockHash dsBlockHeader;
   StateHash stateDeltaHash;
   TxnHash tranReceiptHash;
+  CommitteeHash committeeHash;
 
   ProtobufByteArrayToNumber<uint256_t, UINT256_SIZE>(
       protoMicroBlockHeader.gaslimit(), gasLimit);
@@ -464,13 +486,19 @@ void ProtobufToMicroBlockHeader(
                (unsigned int)tranReceiptHash.size),
        tranReceiptHash.asArray().begin());
 
+  copy(protoMicroBlockHeader.committeehash().begin(),
+       protoMicroBlockHeader.committeehash().begin() +
+           min((unsigned int)protoMicroBlockHeader.committeehash().size(),
+               (unsigned int)committeeHash.size),
+       committeeHash.asArray().begin());
+
   microBlockHeader = MicroBlockHeader(
       protoMicroBlockHeader.type(), protoMicroBlockHeader.version(),
       protoMicroBlockHeader.shardid(), gasLimit, gasUsed, prevHash,
       protoMicroBlockHeader.blocknum(), timestamp, txRootHash,
       protoMicroBlockHeader.numtxs(), minerPubKey,
       protoMicroBlockHeader.dsblocknum(), dsBlockHeader, stateDeltaHash,
-      tranReceiptHash);
+      tranReceiptHash, committeeHash);
 }
 
 void ProtobufToMicroBlock(const ProtoMicroBlock& protoMicroBlock,
@@ -549,6 +577,9 @@ void TxBlockHeaderToProtobuf(const TxBlockHeader& txBlockHeader,
   protoTxBlockHeader.set_dsblocknum(txBlockHeader.GetDSBlockNum());
   protoTxBlockHeader.set_dsblockheader(txBlockHeader.GetDSBlockHeader().data(),
                                        txBlockHeader.GetDSBlockHeader().size);
+
+  protoTxBlockHeader.set_committeehash(txBlockHeader.GetCommitteeHash().data(),
+                                       txBlockHeader.GetCommitteeHash().size);
 }
 
 void TxBlockToProtobuf(const TxBlock& txBlock, ProtoTxBlock& protoTxBlock) {
@@ -611,6 +642,7 @@ void ProtobufToTxBlockHeader(
   TxBlockHashSet hash;
   PubKey minerPubKey;
   BlockHash dsBlockHeader;
+  CommitteeHash committeeHash;
 
   ProtobufByteArrayToNumber<uint256_t, UINT256_SIZE>(
       protoTxBlockHeader.gaslimit(), gasLimit);
@@ -661,13 +693,20 @@ void ProtobufToTxBlockHeader(
                (unsigned int)dsBlockHeader.size),
        dsBlockHeader.asArray().begin());
 
+  copy(protoTxBlockHeader.committeehash().begin(),
+       protoTxBlockHeader.committeehash().begin() +
+           min((unsigned int)protoTxBlockHeader.committeehash().size(),
+               (unsigned int)committeeHash.size),
+       committeeHash.asArray().begin());
+
   txBlockHeader = TxBlockHeader(
       protoTxBlockHeader.type(), protoTxBlockHeader.version(), gasLimit,
       gasUsed, prevHash, protoTxBlockHeader.blocknum(), timestamp,
       hash.m_txRootHash, hash.m_stateRootHash, hash.m_deltaRootHash,
       hash.m_stateDeltaHash, hash.m_tranReceiptRootHash,
       protoTxBlockHeader.numtxs(), protoTxBlockHeader.nummicroblockhashes(),
-      minerPubKey, protoTxBlockHeader.dsblocknum(), dsBlockHeader);
+      minerPubKey, protoTxBlockHeader.dsblocknum(), dsBlockHeader,
+      committeeHash);
 }
 
 void ProtobufToTxBlock(const ProtoTxBlock& protoTxBlock, TxBlock& txBlock) {
@@ -761,6 +800,9 @@ void VCBlockHeaderToProtobuf(const VCBlockHeader& vcBlockHeader,
   protoVCBlockHeader.set_vccounter(vcBlockHeader.GetViewChangeCounter());
   NumberToProtobufByteArray<uint256_t, UINT256_SIZE>(
       vcBlockHeader.GetTimeStamp(), *protoVCBlockHeader.mutable_timestamp());
+
+  protoVCBlockHeader.set_committeehash(vcBlockHeader.GetCommitteeHash().data(),
+                                       vcBlockHeader.GetCommitteeHash().size);
 }
 
 void VCBlockToProtobuf(const VCBlock& vcBlock, ProtoVCBlock& protoVCBlock) {
@@ -799,6 +841,7 @@ void ProtobufToVCBlockHeader(
   Peer candidateLeaderNetworkInfo;
   PubKey candidateLeaderPubKey;
   uint256_t timestamp;
+  CommitteeHash committeeHash;
 
   ProtobufByteArrayToSerializable(
       protoVCBlockHeader.candidateleadernetworkinfo(),
@@ -808,12 +851,19 @@ void ProtobufToVCBlockHeader(
   ProtobufByteArrayToNumber<uint256_t, UINT256_SIZE>(
       protoVCBlockHeader.timestamp(), timestamp);
 
-  vcBlockHeader = VCBlockHeader(
-      protoVCBlockHeader.viewchangedsepochno(),
-      protoVCBlockHeader.viewchangeepochno(),
-      protoVCBlockHeader.viewchangestate(),
-      protoVCBlockHeader.candidateleaderindex(), candidateLeaderNetworkInfo,
-      candidateLeaderPubKey, protoVCBlockHeader.vccounter(), timestamp);
+  copy(protoVCBlockHeader.committeehash().begin(),
+       protoVCBlockHeader.committeehash().begin() +
+           min((unsigned int)protoVCBlockHeader.committeehash().size(),
+               (unsigned int)committeeHash.size),
+       committeeHash.asArray().begin());
+
+  vcBlockHeader =
+      VCBlockHeader(protoVCBlockHeader.viewchangedsepochno(),
+                    protoVCBlockHeader.viewchangeepochno(),
+                    protoVCBlockHeader.viewchangestate(),
+                    protoVCBlockHeader.candidateleaderindex(),
+                    candidateLeaderNetworkInfo, candidateLeaderPubKey,
+                    protoVCBlockHeader.vccounter(), timestamp, committeeHash);
 }
 
 void ProtobufToVCBlock(const ProtoVCBlock& protoVCBlock, VCBlock& vcBlock) {
@@ -879,6 +929,10 @@ void FallbackBlockHeaderToProtobuf(
   NumberToProtobufByteArray<uint256_t, UINT256_SIZE>(
       fallbackBlockHeader.GetTimeStamp(),
       *protoFallbackBlockHeader.mutable_timestamp());
+
+  protoFallbackBlockHeader.set_committeehash(
+      fallbackBlockHeader.GetCommitteeHash().data(),
+      fallbackBlockHeader.GetCommitteeHash().size);
 }
 
 void FallbackBlockToProtobuf(const FallbackBlock& fallbackBlock,
@@ -921,6 +975,7 @@ void ProtobufToFallbackBlockHeader(
   PubKey leaderPubKey;
   uint256_t timestamp;
   StateHash stateRootHash;
+  CommitteeHash committeeHash;
 
   ProtobufByteArrayToSerializable(protoFallbackBlockHeader.leadernetworkinfo(),
                                   leaderNetworkInfo);
@@ -935,12 +990,19 @@ void ProtobufToFallbackBlockHeader(
                (unsigned int)stateRootHash.size),
        stateRootHash.asArray().begin());
 
+  copy(protoFallbackBlockHeader.committeehash().begin(),
+       protoFallbackBlockHeader.committeehash().begin() +
+           min((unsigned int)protoFallbackBlockHeader.committeehash().size(),
+               (unsigned int)committeeHash.size),
+       committeeHash.asArray().begin());
+
   fallbackBlockHeader = FallbackBlockHeader(
       protoFallbackBlockHeader.fallbackdsepochno(),
       protoFallbackBlockHeader.fallbackepochno(),
       protoFallbackBlockHeader.fallbackstate(), stateRootHash,
       protoFallbackBlockHeader.leaderconsensusid(), leaderNetworkInfo,
-      leaderPubKey, protoFallbackBlockHeader.shardid(), timestamp);
+      leaderPubKey, protoFallbackBlockHeader.shardid(), timestamp,
+      committeeHash);
 }
 
 void ProtobufToFallbackBlock(const ProtoFallbackBlock& protoFallbackBlock,
@@ -1228,20 +1290,46 @@ bool GetConsensusAnnouncementCore(
 // ============================================================================
 
 bool Messenger::GetDSCommitteeHash(const deque<pair<PubKey, Peer>>& dsCommittee,
-                                   DSCommHash& dst) {
-  ProtoDSCommittee protoDSCommittee;
+                                   CommitteeHash& dst) {
+  ProtoCommittee protoCommittee;
 
-  DSCommitteeToProtobuf(dsCommittee, protoDSCommittee);
+  DSCommitteeToProtoCommittee(dsCommittee, protoCommittee);
 
-  if (!protoDSCommittee.IsInitialized()) {
-    LOG_GENERAL(WARNING, "ProtoDSCommittee initialization failed.");
+  if (!protoCommittee.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoCommittee initialization failed.");
     return false;
   }
 
   vector<unsigned char> tmp;
 
-  if (!SerializeToArray(protoDSCommittee, tmp, 0)) {
-    LOG_GENERAL(WARNING, "ProtoDSCommittee serialization failed.");
+  if (!SerializeToArray(protoCommittee, tmp, 0)) {
+    LOG_GENERAL(WARNING, "ProtoCommittee serialization failed.");
+    return false;
+  }
+
+  SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
+  sha2.Update(tmp);
+  tmp = sha2.Finalize();
+
+  copy(tmp.begin(), tmp.end(), dst.asArray().begin());
+
+  return true;
+}
+
+bool Messenger::GetShardHash(const Shard& shard, CommitteeHash& dst) {
+  ProtoCommittee protoCommittee;
+
+  ShardToProtoCommittee(shard, protoCommittee);
+
+  if (!protoCommittee.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoCommittee initialization failed.");
+    return false;
+  }
+
+  vector<unsigned char> tmp;
+
+  if (!SerializeToArray(protoCommittee, tmp, 0)) {
+    LOG_GENERAL(WARNING, "ProtoCommittee serialization failed.");
     return false;
   }
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -34,7 +34,9 @@ class Messenger {
   // ============================================================================
 
   static bool GetDSCommitteeHash(
-      const std::deque<std::pair<PubKey, Peer>>& dsCommittee, DSCommHash& dst);
+      const std::deque<std::pair<PubKey, Peer>>& dsCommittee,
+      CommitteeHash& dst);
+  static bool GetShardHash(const Shard& shard, CommitteeHash& dst);
 
   static bool GetShardingStructureHash(const DequeOfShard& shards,
                                        ShardingHash& dst);

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -22,6 +22,11 @@ message ProtoDSCommittee
     repeated ProtoDSNode dsnodes = 1;
 }
 
+message ProtoCommittee
+{
+    repeated ByteArray members = 1;
+}
+
 message ProtoShardingStructure
 {
     message Member
@@ -52,10 +57,9 @@ message ProtoDSBlock
 {
     message DSBlockHashSet
     {
-        required bytes dscommhash       = 1;
-        required bytes shardinghash     = 2;
-        required bytes txsharinghash    = 3;
-        required bytes reservedfield    = 4;
+        required bytes shardinghash     = 1;
+        required bytes txsharinghash    = 2;
+        required bytes reservedfield    = 3;
     }
     message DSBlockHeader
     {
@@ -68,11 +72,12 @@ message ProtoDSBlock
         required ByteArray swinfo       = 7;
         message PowDSWinners
         {
-            required ByteArray key = 1;
-            required ByteArray val = 2;
+            required ByteArray key      = 1;
+            required ByteArray val      = 2;
         }
         repeated PowDSWinners dswinners = 8;
         required DSBlockHashSet hash    = 9;
+        required bytes committeehash    = 10;
     }
     message CoSignatures
     {
@@ -105,6 +110,7 @@ message ProtoMicroBlock
         required bytes dsblockheader   = 13;
         required bytes statedeltahash  = 14;
         required bytes tranreceipthash = 15;
+        required bytes committeehash   = 16;
     }
     message CoSignatures
     {
@@ -143,6 +149,7 @@ message ProtoTxBlock
         required ByteArray minerpubkey          = 11;
         required uint64 dsblocknum              = 12;
         required bytes dsblockheader            = 13;
+        required bytes committeehash            = 14;
     }
     message MicroBlockHashSet
     {
@@ -177,6 +184,7 @@ message ProtoVCBlock
         required ByteArray candidateleaderpubkey      = 6;
         required uint32 vccounter                     = 7;
         required ByteArray timestamp                  = 8;
+        required bytes committeehash                  = 9;
     }
     message CoSignatures
     {
@@ -194,26 +202,27 @@ message ProtoFallbackBlock
 {
     message FallbackBlockHeader
     {
-        required uint64 fallbackdsepochno           = 1;
-        required uint64 fallbackepochno             = 2;
-        required uint32 fallbackstate               = 3; // only LSB used
-        required bytes stateroothash                = 4;
-        required uint32 leaderconsensusid          = 5;
+        required uint64 fallbackdsepochno    = 1;
+        required uint64 fallbackepochno      = 2;
+        required uint32 fallbackstate        = 3; // only LSB used
+        required bytes stateroothash         = 4;
+        required uint32 leaderconsensusid    = 5;
         required ByteArray leadernetworkinfo = 6;
         required ByteArray leaderpubkey      = 7;
-        required uint32 shardid                     = 8;
-        required ByteArray timestamp                  = 9;
+        required uint32 shardid              = 8;
+        required ByteArray timestamp         = 9;
+        required bytes committeehash         = 10;
     }
     message CoSignatures
     {
-        required ByteArray cs1                        = 1;
-        repeated bool b1                              = 2 [packed=true];
-        required ByteArray cs2                        = 3;
-        repeated bool b2                              = 4 [packed=true];
+        required ByteArray cs1               = 1;
+        repeated bool b1                     = 2 [packed=true];
+        required ByteArray cs2               = 3;
+        repeated bool b2                     = 4 [packed=true];
     }
-    required FallbackBlockHeader header               = 1;
-    required CoSignatures cosigs                      = 2;
-    required bytes blockhash                          = 3;
+    required FallbackBlockHeader header      = 1;
+    required CoSignatures cosigs             = 2;
+    required bytes blockhash                 = 3;
 }
 
 // ============================================================================

--- a/src/libNode/FallbackPreProcessing.cpp
+++ b/src/libNode/FallbackPreProcessing.cpp
@@ -380,7 +380,7 @@ void Node::ComposeFallbackBlock() {
             m_mediator.m_currentEpochNum, m_fallbackState,
             AccountStore::GetInstance().GetStateRootHash(), m_consensusLeaderID,
             leaderNetworkInfo, m_myShardMembers->at(m_consensusLeaderID).first,
-            m_myshardId, get_time_as_int()),
+            m_myshardId, get_time_as_int(), CommitteeHash()),
         CoSignatures()));
     m_pendingFallbackBlock->SetBlockHash(
         m_pendingFallbackBlock->GetHeader().GetMyHash());

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -113,8 +113,8 @@ bool Node::ComposeMicroBlock() {
   m_microblock.reset(new MicroBlock(
       MicroBlockHeader(type, version, shardId, gasLimit, gasUsed, prevHash,
                        blockNum, timestamp, txRootHash, numTxs, minerPubKey,
-                       dsBlockNum, dsBlockHeader, stateDeltaHash,
-                       txReceiptHash),
+                       dsBlockNum, dsBlockHeader, stateDeltaHash, txReceiptHash,
+                       CommitteeHash()),
       tranHashes, CoSignatures()));
 
   LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/tests/Lookup/Test_LookupNodeForDSBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForDSBlock.cpp
@@ -68,9 +68,10 @@ BOOST_AUTO_TEST_CASE(testDSBlockStoring) {
   std::pair<PrivKey, PubKey> pubKey1 = Schnorr::GetInstance().GenKeyPair();
 
   std::map<PubKey, Peer> powDSWinners;
-  DSBlock dsblock(DSBlockHeader(50, 20, prevHash1, pubKey1.second, 0, 0,
-                                SWInfo(), powDSWinners, DSBlockHashSet()),
-                  CoSignatures());
+  DSBlock dsblock(
+      DSBlockHeader(50, 20, prevHash1, pubKey1.second, 0, 0, SWInfo(),
+                    powDSWinners, DSBlockHashSet(), CommitteeHash()),
+      CoSignatures());
 
   curr_offset += dsblock.Serialize(dsblockmsg, curr_offset);
 

--- a/tests/Lookup/Test_LookupNodeForTxBlock.cpp
+++ b/tests/Lookup/Test_LookupNodeForTxBlock.cpp
@@ -60,9 +60,10 @@ void SendDSBlockFirstToMatchDSBlockNum(Peer& lookup_node) {
 
   std::pair<PrivKey, PubKey> pubKey1 = Schnorr::GetInstance().GenKeyPair();
   std::map<PubKey, Peer> powDSWinners;
-  DSBlock dsblock(DSBlockHeader(50, 20, prevHash1, pubKey1.second, 0, 0,
-                                SWInfo(), powDSWinners, DSBlockHashSet()),
-                  CoSignatures());
+  DSBlock dsblock(
+      DSBlockHeader(50, 20, prevHash1, pubKey1.second, 0, 0, SWInfo(),
+                    powDSWinners, DSBlockHashSet(), CommitteeHash()),
+      CoSignatures());
 
   curr_offset += dsblock.Serialize(dsblockmsg, curr_offset);
 
@@ -124,7 +125,7 @@ BOOST_AUTO_TEST_CASE(testTxBlockStoring) {
       TxBlockHeader(TXBLOCKTYPE::FINAL, BLOCKVERSION::VERSION1, 1, 1,
                     BlockHash(), 0, get_time_as_int(), TxnHash(), StateHash(),
                     StateHash(), StateHash(), TxnHash(), 0, 5, pubKey1.second,
-                    0, BlockHash()),
+                    0, BlockHash(), CommitteeHash()),
       vector<bool>(1), vector<MicroBlockHashSet>(5), vector<uint32_t>(5),
       CoSignatures());
 

--- a/tests/Persistence/Test_DSPersistence.cpp
+++ b/tests/Persistence/Test_DSPersistence.cpp
@@ -66,9 +66,10 @@ DSBlock constructDummyDSBlock(uint64_t blocknum) {
     powDSWinners[Schnorr::GetInstance().GenKeyPair().second] = Peer();
   }
 
-  return DSBlock(DSBlockHeader(50, 20, prevHash1, pubKey1.second, blocknum, 789,
-                               SWInfo(), powDSWinners, DSBlockHashSet()),
-                 CoSignatures());
+  return DSBlock(
+      DSBlockHeader(50, 20, prevHash1, pubKey1.second, blocknum, 789, SWInfo(),
+                    powDSWinners, DSBlockHashSet(), CommitteeHash()),
+      CoSignatures());
 }
 
 BOOST_AUTO_TEST_CASE(testSerializationDeserialization) {

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -60,7 +60,7 @@ TxBlock constructDummyTxBlock(int instanceNum) {
       TxBlockHeader(TXBLOCKTYPE::FINAL, BLOCKVERSION::VERSION1, 1, 1,
                     BlockHash(), instanceNum, get_time_as_int(), TxnHash(),
                     StateHash(), StateHash(), StateHash(), TxnHash(), 5, 6,
-                    pubKey1.second, instanceNum, BlockHash()),
+                    pubKey1.second, instanceNum, BlockHash(), CommitteeHash()),
       vector<bool>(), vector<MicroBlockHashSet>(6), vector<uint32_t>(6),
       CoSignatures());
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR moves out the previously named `DSCommHash` from `DSBlockHashSet` into `BlockHeaderBase` as a new type `CommitteeHash`.

Now all data blocks will have this `CommitteeHash`, which will be generated from either the DS committee or the shard that created the block. Messenger functions `GetDSCommitteeHash` and `GetShardHash` have been created for this purpose.

Locally tested, the data blocks still serialize and deserialize okay with the added member. The exception again is `VCBlock` and `FallbackBlock` which we can test again separately.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
