### PR TITLE
Change tx receipt success filed to boolean instead of string

### DIFF
--- a/src/libData/AccountData/TransactionReceipt.cpp
+++ b/src/libData/AccountData/TransactionReceipt.cpp
@@ -77,9 +77,9 @@ int TransactionReceipt::Deserialize(const std::vector<unsigned char>& src,
 
 void TransactionReceipt::SetResult(const bool& result) {
   if (result) {
-    m_tranReceiptObj["success"] = "true";
+    m_tranReceiptObj["success"] = true;
   } else {
-    m_tranReceiptObj["success"] = "false";
+    m_tranReceiptObj["success"] = false;
   }
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
This changes the type of the `success` property on `m_tranReceiptObj` to `boolean`.

<!-- What is the context of your pull request? -->
It is preferable to use  an actual `boolean` value instead of `"true"` and `"false"`.
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
