### PR TITLE
Added DSBlockHeader hashes verification

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -186,11 +186,13 @@ class DirectoryService : public Executable, public Broadcastable {
   void SendEntireShardingStructureToShardNodes(unsigned int my_shards_lo,
                                                unsigned int my_shards_hi);
 
-  unsigned int ComposeDSBlock(
+  unsigned int ComputeDSBlockParameters(
       const std::vector<std::pair<std::array<unsigned char, 32>, PubKey>>&
           sortedDSPoWSolns,
       std::vector<std::pair<std::array<unsigned char, 32>, PubKey>>&
-          sortedPoWSolns);
+          sortedPoWSolns,
+      std::map<PubKey, Peer>& powDSWinners, uint8_t& dsDifficulty,
+      uint8_t& difficulty, uint64_t& blockNum, BlockHash& prevHash);
   void ComputeSharding(
       const std::vector<std::pair<std::array<unsigned char, 32>, PubKey>>&
           sortedPoWSolns);

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -454,6 +454,56 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
     return false;
   }
 
+  // Verify the DSBlockHashSet member of the DSBlockHeader
+  ShardingHash shardingHash;
+  if (!Messenger::GetShardingStructureHash(m_mediator.m_ds->m_shards,
+                                           shardingHash)) {
+    LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+              "Messenger::GetShardingStructureHash failed.");
+    return false;
+  }
+  if (shardingHash != dsblock.GetHeader().GetShardingHash()) {
+    LOG_GENERAL(WARNING,
+                "Sharding structure hash in newly received DS Block doesn't "
+                "match. Calculated: "
+                    << shardingHash
+                    << " Received: " << dsblock.GetHeader().GetShardingHash());
+    return false;
+  }
+  TxSharingHash txSharingHash;
+  if (!Messenger::GetTxSharingAssignmentsHash(
+          m_mediator.m_ds->m_DSReceivers, m_mediator.m_ds->m_shardReceivers,
+          m_mediator.m_ds->m_shardSenders, txSharingHash)) {
+    LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+              "Messenger::GetTxSharingAssignmentsHash failed.");
+    return false;
+  }
+  if (txSharingHash != dsblock.GetHeader().GetTxSharingHash()) {
+    LOG_GENERAL(WARNING,
+                "Tx sharing structure hash in newly received DS Block doesn't "
+                "match. Calculated: "
+                    << txSharingHash
+                    << " Received: " << dsblock.GetHeader().GetTxSharingHash());
+    return false;
+  }
+
+  // Verify the CommitteeHash member of the BlockHeaderBase
+  CommitteeHash committeeHash;
+  if (!Messenger::GetDSCommitteeHash(*m_mediator.m_DSCommittee,
+                                     committeeHash)) {
+    LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
+              "Messenger::GetDSCommitteeHash failed.");
+    return false;
+  }
+  if (committeeHash != dsblock.GetHeader().GetCommitteeHash()) {
+    LOG_GENERAL(WARNING,
+                "DS committee hash in newly received DS Block doesn't match. "
+                "Calculated: "
+                    << committeeHash
+                    << " Received: " << dsblock.GetHeader().GetCommitteeHash());
+    return false;
+  }
+
   m_myshardId = shardId;
 
   LogReceivedDSBlockDetails(dsblock);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR starts to use the DSBlockHeader hashes added in #671, #677, and #679.

Specifically, the sharding structure hash, tx sharing assignment hash, and the DS committee hash are now checked in both DSBlock consensus and when the shard nodes receive the DSBlock.

Tested locally for both instances, and works OK.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
The tricky part in this review should just be in the change to the `RunConsensusOnDSBlockWhenDSPrimary` function.  Note how the previously named `ComposeDSBlock` has been renamed to `ComputeDSBlockParameters`, because now the actual creating of the DSBlock has to be done only after computing both the DS block parameters and the new sharding structure/tx sharing assignments.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
