### PR TITLE
Made protobuf-equivalent  message for transaction (still unused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The current release has the following features implemented:
 * Network sharding
 * Transaction sharding
 * Directory Service
-* Consensus for DS block (with sharding structure), Shard microblock and Final block 
+* Consensus for DS block (with sharding structure), Shard microblock, DS microblock, and Final block 
 * [EC-Schnorr signature](https://en.wikipedia.org/wiki/Schnorr_signature)
 * Data layer and accounts store 
 * Looking up nodes to allow new nodes to join 
@@ -42,10 +42,10 @@ The current release has the following features implemented:
 * [Zilliqa Wallet](https://github.com/Zilliqa/Zilliqa-Wallet)
 * [Smart contract design and implementation](https://scilla.readthedocs.io)
 * [GPU (OpenCL and CUDA) support](https://github.com/Zilliqa/Zilliqa/wiki/GPU-mining) for PoW
+* Gossip protocol for network message broadcasting
 
 In the coming months, we plan to have the following features:
 
-* Gossip protocol for network message broadcasting
 * Incentive structure
 * Further unit and integration tests
 * Enhancement of existing features

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -57,7 +57,7 @@ class Transaction : public Serializable {
   Transaction(const Transaction& src);
 
   /// Constructor with specified transaction fields.
-  Transaction(boost::multiprecision::uint256_t version,
+  Transaction(const boost::multiprecision::uint256_t& version,
               const boost::multiprecision::uint256_t& nonce,
               const Address& toAddr, const KeyPair& senderKeyPair,
               const boost::multiprecision::uint256_t& amount,
@@ -67,7 +67,19 @@ class Transaction : public Serializable {
               const std::vector<unsigned char>& data = {});
 
   /// Constructor with specified transaction fields.
-  Transaction(boost::multiprecision::uint256_t version,
+  Transaction(const TxnHash& tranID,
+              const boost::multiprecision::uint256_t& version,
+              const boost::multiprecision::uint256_t& nonce,
+              const Address& toAddr, const PubKey& senderPubKey,
+              const boost::multiprecision::uint256_t& amount,
+              const boost::multiprecision::uint256_t& gasPrice,
+              const boost::multiprecision::uint256_t& gasLimit,
+              const std::vector<unsigned char>& code,
+              const std::vector<unsigned char>& data,
+              const Signature& signature);
+
+  /// Constructor with specified transaction fields.
+  Transaction(const boost::multiprecision::uint256_t& version,
               const boost::multiprecision::uint256_t& nonce,
               const Address& toAddr, const PubKey& senderPubKey,
               const boost::multiprecision::uint256_t& amount,
@@ -153,63 +165,3 @@ class Transaction : public Serializable {
 };
 
 #endif  // __TRANSACTION_H__
-
-#if 0
-
-// ========================================================
-// The Predicate class facilitates conditional transactions
-// ========================================================
-
-// Each Predicate can specify a condition on the balance of 
-//   an account, or a condition on the existence of a prior
-//   transaction (A->B, amount), or both
-
-class Predicate: public Serializable
-{
-    uint8_t m_type; // 6 high bits reserved; bit0 (lowest): account condition active; bit1: transaction condition active
-    std::array<unsigned char, ACC_ADDR_SIZE> m_accConAddr; // for account condition: account address
-    uint8_t m_ops; // 4 high bits for account condition: account balance comparison operator: 
-                         //   000: ==, 001: !=, 010: >, 011: >=, 100: <, 101: <=
-                         // 4 low bits for tx cnodition:
-                         //   comparison operator. 0: on blockchain, 1: not on blockchain
-    boost::multiprecision::uint256_t m_accConBalance; // for account condition: balance specified
-    std::array<unsigned char, ACC_ADDR_SIZE> m_txConToAddr; // for transaction condition: to account address
-    std::array<unsigned char, ACC_ADDR_SIZE> m_txConFromAddr; // for transaction condition: from account address
-    boost::multiprecision::uint256_t m_txConAmount; // for transaction condition: the amount
-
-public:
-    unsigned int Serialize(std::vector<unsigned char> & dst, unsigned int offset) const;
-    void Deserialize(const std::vector<unsigned char> & src, unsigned int offset);
-
-    Predicate();
-
-    Predicate(const std::vector<unsigned char> & src, unsigned int offset);
-
-    Predicate(uint8_t type, const std::array<unsigned char, ACC_ADDR_SIZE> & accConAddr, unsigned char ops, boost::multiprecision::uint256_t accConBalance, const std::array<unsigned char, ACC_ADDR_SIZE> & txConToAddr, const std::array<unsigned char, ACC_ADDR_SIZE> & txConFromAddr, boost::multiprecision::uint256_t txConAmount);
-
-    Predicate(uint8_t type, const std::array<unsigned char, ACC_ADDR_SIZE> & accConAddr, unsigned char accConOp, boost::multiprecision::uint256_t accConBalance, const std::array<unsigned char, ACC_ADDR_SIZE> & txConToAddr, const std::array<unsigned char, ACC_ADDR_SIZE> & txConFromAddr, boost::multiprecision::uint256_t txConAmount, unsigned char txConOp);
-
-    uint8_t GetType() const;
-
-    const std::array<unsigned char, ACC_ADDR_SIZE> & GetAccConAddr() const;
-
-    uint8_t GetAccConOp() const;
-
-    boost::multiprecision::uint256_t GetAccConBalance() const;
-
-    const std::array<unsigned char, ACC_ADDR_SIZE> & GetTxConToAddr() const;
-
-    const std::array<unsigned char, ACC_ADDR_SIZE> & GetTxConFromAddr() const;
-
-    boost::multiprecision::uint256_t GetTxConAmount() const;
-
-    unsigned char GetTxConOp() const;
-
-    bool operator==(const Predicate & pred) const;
-
-    bool operator<(const Predicate & pred) const;
-
-    bool operator>(const Predicate & pred) const;
-};
-
-#endif

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -53,6 +53,25 @@ message ProtoTxSharingAssignments
     repeated AssignedNodes shardnodes = 2;
 }
 
+message ProtoTransaction
+{
+    message CoreTransactionInfo
+    {
+        required ByteArray version      = 1;
+        required ByteArray nonce        = 2;
+        required bytes toaddr           = 3;
+        required ByteArray senderpubkey = 4;
+        required ByteArray amount       = 5;
+        required ByteArray gasprice     = 6;
+        required ByteArray gaslimit     = 7;
+        required bytes code             = 8;
+        required bytes data             = 9;
+    }
+    required bytes tranid               = 1;
+    required CoreTransactionInfo info   = 2;
+    required ByteArray signature        = 3;
+}
+
 message ProtoDSBlock
 {
     message DSBlockHashSet


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This is another PR for protobuf conversion, this time for `Transaction`.

This PR does these things:
1. Define `ProtoTransaction` in ZilliqaMessage.proto
2. Define `TransactionToProtobuf` and `ProtobufToTransaction` in Messenger.cpp
3. Define another constructor in Transaction.h which includes the `tranID`
4. Some maintenance
- Move the `xxxToArray` functions further up in Messenger.cpp
- Remove the commented-out code blocks inside Transaction.h and .cpp
- Change the `version` parameter in the `Transaction` constructor from `uint256_t` to `const uint256_t&`

At this time, we don't use the new Messenger.cpp functions yet. So, no expected impact on node behavior.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
