### PR TITLE
Fix DoS when Schnorr deserialization failed 

### DIFF
--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -243,6 +243,7 @@ int PrivKey::Deserialize(const vector<unsigned char>& src,
     if (m_d == nullptr) {
       LOG_GENERAL(WARNING, "Deserialization failure");
       m_initialized = false;
+      return -1;
     } else {
       m_initialized = true;
     }
@@ -349,6 +350,7 @@ int PubKey::Deserialize(const vector<unsigned char>& src, unsigned int offset) {
     if (m_P == nullptr) {
       LOG_GENERAL(WARNING, "Deserialization failure");
       m_initialized = false;
+      return -1;
     } else {
       m_initialized = true;
     }
@@ -488,12 +490,14 @@ int Signature::Deserialize(const vector<unsigned char>& src,
     if (m_r == nullptr) {
       LOG_GENERAL(WARNING, "Deserialization failure");
       m_initialized = false;
+      return -1;
     } else {
       m_s = BIGNUMSerialize::GetNumber(src, offset + SIGNATURE_CHALLENGE_SIZE,
                                        SIGNATURE_RESPONSE_SIZE);
       if (m_s == nullptr) {
         LOG_GENERAL(WARNING, "Deserialization failure");
         m_initialized = false;
+        return -1;
       } else {
         m_initialized = true;
       }

--- a/tests/Crypto/Test_Schnorr.cpp
+++ b/tests/Crypto/Test_Schnorr.cpp
@@ -305,4 +305,43 @@ BOOST_AUTO_TEST_CASE(test_serialization) {
   BOOST_CHECK(!SignatureOutput.is_empty(false));
 }
 
+/**
+ * \brief test_error_deserialization_pubkey
+ *
+ * \details Test failure in deserialization of public key
+ */
+BOOST_AUTO_TEST_CASE(test_error_deserialization_pubkey) {
+  PubKey pubkey;
+  vector<unsigned char> pubkey_bytes_empty;
+  int returnValue = pubkey.Deserialize(pubkey_bytes_empty, 0);
+  BOOST_CHECK_MESSAGE(returnValue == -1,
+                      "Expected: -1 Obtained: " << returnValue);
+}
+
+/**
+ * \brief test_error_deserialization_privkey
+ *
+ * \details Test failure in deserialization of private key
+ */
+BOOST_AUTO_TEST_CASE(test_error_deserialization_privkey) {
+  PrivKey privkey;
+  vector<unsigned char> privkey_bytes_empty;
+  int returnValue = privkey.Deserialize(privkey_bytes_empty, 0);
+  BOOST_CHECK_MESSAGE(returnValue == -1,
+                      "Expected: -1 Obtained: " << returnValue);
+}
+
+/**
+ * \brief test_error_deserialization_signature
+ *
+ * \details Test failure in deserialization of signature
+ */
+BOOST_AUTO_TEST_CASE(test_error_deserialization_signature) {
+  Signature signature;
+  vector<unsigned char> sig_bytes_empty;
+  int returnValue = signature.Deserialize(sig_bytes_empty, 0);
+  BOOST_CHECK_MESSAGE(returnValue == -1,
+                      "Expected: -1 Obtained: " << returnValue);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR fixes the return value (from 0 to -1) when deserialization failed in `Schnorr` library. Fixes have been applied to 
- PubKey
- PrivKey
- Signature

Issue: https://github.com/Zilliqa/Issues/issues/231

TODO:
- [x] Unit tests

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
- Check through the code coverage for the unit test. 
- Run unit tests (tests/Crypto/Test_Schnorr)

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test (commit: 652d9d227589348aaefbf8911d8a2aac0a1c72d4)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
