### PR TITLE
Remove insecure function `memcpy` in libPoW and add unit tests

### DIFF
--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -101,7 +101,14 @@ int POW::FromHex(char _i) {
 ethash_h256_t POW::StringToBlockhash(std::string const& _s) {
   ethash_h256_t ret;
   std::vector<uint8_t> b = HexStringToBytes(_s);
-  memcpy(&ret, b.data(), b.size());
+  if (b.size() != 32) {
+    LOG_GENERAL(WARNING,
+                "Input to StringToBlockhash is not of size 32. Returning "
+                "uninitialize ethash_h256_t. Size is "
+                    << b.size());
+    return ret;
+  }
+  copy(b.begin(), b.end(), ret.b);
   return ret;
 }
 

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -46,10 +46,8 @@ typedef struct ethash_mining_result {
 /// Implements the proof-of-work functionality.
 class POW {
   static std::string BytesToHexString(const uint8_t* str, const uint64_t s);
-  static std::string BlockhashToHexString(ethash_h256_t* _hash);
   static int FromHex(char _i);
   static std::vector<uint8_t> HexStringToBytes(std::string const& _s);
-  static ethash_h256_t StringToBlockhash(std::string const& _s);
   static ethash_h256_t DifficultyLevelInInt(uint8_t difficulty);
   std::mutex m_mutexLightClientConfigure;
   std::mutex m_mutexPoWMine;
@@ -61,6 +59,9 @@ class POW {
   void operator=(POW const&) = delete;
 
  public:
+  static ethash_h256_t StringToBlockhash(std::string const& _s);
+  static std::string BlockhashToHexString(ethash_h256_t* _hash);
+
   /// Returns the singleton POW instance.
   static POW& GetInstance();
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR implements the followings
- Removal of insecure c function, `memcpy`, from `pow.cpp`
- Add boundary check to `StringToBlockhash()`
- Make static function BlockhashToHexString() and StringToBlockhash()
- `Test_Pow` to use static function `BlockhashToHexString()` and `StringToBlockhash()` instead of a duplicated function in the same test cae 
- Added unit tests for `StringToBlockhash()`

This PR fixes https://github.com/Zilliqa/Issues/issues/235

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: 7f2122116aee4999a16088949d23304a8b6bbe2b) 
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~small-scale cloud test~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
