### PR TITLE
Check for null consensus object in consensus user

### DIFF
--- a/src/libConsensus/ConsensusUser.cpp
+++ b/src/libConsensus/ConsensusUser.cpp
@@ -156,6 +156,11 @@ bool ConsensusUser::ProcessConsensusMessage(
     const Peer& from) {
   LOG_MARKER();
 
+  if (m_consensus == nullptr) {
+    LOG_GENERAL(WARNING, "m_consensus is not yet initialize");
+    return false;
+  }
+
   std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
   if (cv_processConsensusMessage.wait_for(
           cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR add a check to `ProcessConsensusMessage` to check whether `m_consensus` is `nullptr` or not before proceeding. 

This PR fixes https://github.com/Zilliqa/Issues/issues/233

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: a0dc262414c848a54518d153e2dcf98d10db4adb)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test (commit: a0dc262414c848a54518d153e2dcf98d10db4adb)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
