### PR TITLE
Hot fix to downgrade urllib3 for kube 7.0 support

### DIFF
--- a/scripts/ci_make_image.sh
+++ b/scripts/ci_make_image.sh
@@ -49,7 +49,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     vim \
     && rm -rf /var/lib/apt/lists/* \
     && pip install setuptools \
-    && pip install kubernetes
+    && pip install kubernetes \
+    && pip uninstall urllib3 --yes \
+    && pip install urllib3==1.23
 EOF
 
 docker push ${registry_url}


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
When building a new docker image, pip will install urllib3 from the public. A recent update to urllib3 will break kube support. This PR implement a hotfix by downgrading urllib3 to a supported version 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] l~ocal machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
