### PR TITLE
Fix DS backup verify difficulty fail problem

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -263,8 +263,9 @@ bool DirectoryService::VerifyDifficulty() {
   auto localDSDifficulty = CalculateNewDSDifficulty(
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetDSDifficulty());
   constexpr uint8_t DIFFICULTY_TOL = 1;
-  if (remoteDSDifficulty < localDSDifficulty ||
-      (remoteDSDifficulty - localDSDifficulty > DIFFICULTY_TOL)) {
+  if (std::max(remoteDSDifficulty, localDSDifficulty) -
+          std::min(remoteDSDifficulty, localDSDifficulty) >
+      DIFFICULTY_TOL) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "WARNING: The ds difficulty "
                   << std::to_string(remoteDSDifficulty)
@@ -277,8 +278,9 @@ bool DirectoryService::VerifyDifficulty() {
   auto remoteDifficulty = m_pendingDSBlock->GetHeader().GetDifficulty();
   auto localDifficulty = CalculateNewDifficulty(
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetDifficulty());
-  if (remoteDifficulty < localDifficulty ||
-      (remoteDifficulty - localDifficulty > DIFFICULTY_TOL)) {
+  if (std::max(remoteDifficulty, localDifficulty) -
+          std::min(remoteDifficulty, localDifficulty) >
+      DIFFICULTY_TOL) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "WARNING: The difficulty "
                   << std::to_string(remoteDifficulty)


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Sometimes the DS backup failed to verify DS difficulty because received different number of DS PoW, it will trigger view change which can be avoid
<!-- What is the context of your pull request? -->
Change the compare algorithm. Previous the DS leader POW window time is longer than DS backup, so the difficulty calculated should be equal or bigger than DS backup. Now the window time is the same, so DS backup may calculate the difficulty bigger than DS leader.
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/245

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check files changed.
<!-- How can the reviewers verify the pull request is working as expected -->
Run a 200 nodes clout test, see if find difficulty mismatch problem.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
