### PR TITLE
Fix - DSLD node drops out when not enough commit received for Final Block Consensus

### DIFF
--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -225,7 +225,9 @@ bool ConsensusLeader::ProcessMessageCommitFailure(
 
     P2PComm::GetInstance().SendMessage(peerInfo, consensusFailureMsg);
     auto main_func = [this]() mutable -> void {
-      m_shardCommitFailureHandlerFunc(m_commitFailureMap);
+      if (m_shardCommitFailureHandlerFunc != nullptr) {
+        m_shardCommitFailureHandlerFunc(m_commitFailureMap);
+      }
     };
     DetachedFunction(1, main_func);
   }


### PR DESCRIPTION
## Description
During FinalBlock consensus, When number of commits failure count exceeds tolerance, handler function is invoked. However, no handler is defined as of now. So it results in crash,

Now, we check for validity of function handler before invocation. Does nothing (no crash though) and would trigger for view change as per the flow.

## Review Suggestion
Check the file changed.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
