### PR TITLE
[testnetv3-dev] Fix broadcast hash insertion and other testnet-discovered issues

### DIFF
--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -40,7 +40,6 @@ bool ConsensusBackup::CheckState(Action action) {
                                       // get ignored by the node)
        {RESPONSE_DONE, PROCESS_CHALLENGE},
        {RESPONSE_DONE, PROCESS_COLLECTIVESIG},
-       {RESPONSE_DONE, PROCESS_FINALCHALLENGE},
        {RESPONSE_DONE,
         PROCESS_FINALCOLLECTIVESIG},  // TODO: check this logic again. Issue #43
                                       // Node cannot proceed if
@@ -114,7 +113,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
       }
     }
 
-    m_state = ERROR;
+    LOG_GENERAL(WARNING, "Announcement content validation failed - dropping message but keeping state");
     return false;
   }
 
@@ -240,9 +239,11 @@ bool ConsensusBackup::ProcessMessageChallengeCore(
   Challenge challenge_verif =
       GetChallenge(m_messageToCosign, aggregated_commit, aggregated_key);
 
+  // If the challenge was gossiped, I may not necessarily be part of the 2/3
+  // backups that are part of the bitmap So, I shouldn't change to ERROR state
+  // here
   if (!(challenge_verif == m_challenge)) {
     LOG_GENERAL(WARNING, "Generated challenge mismatch");
-    m_state = ERROR;
     return false;
   }
 

--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -113,7 +113,9 @@ bool ConsensusBackup::ProcessMessageAnnounce(
       }
     }
 
-    LOG_GENERAL(WARNING, "Announcement content validation failed - dropping message but keeping state");
+    LOG_GENERAL(WARNING,
+                "Announcement content validation failed - dropping message but "
+                "keeping state");
     return false;
   }
 

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -392,8 +392,8 @@ bool DirectoryService::RunConsensusOnViewChangeWhenNotCandidateLeader() {
             "I am a backup DS node (after view change). Waiting for view "
             "change announcement. "
             "Leader is at index  "
-                << m_consensusLeaderID << " "
-                << m_mediator.m_DSCommittee->at(m_consensusLeaderID).second);
+                << m_viewChangeCounter << " "
+                << m_mediator.m_DSCommittee->at(m_viewChangeCounter).second);
 
   m_consensusBlockHash =
       m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash().asBytes();

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -1413,7 +1413,8 @@ bool GetConsensusAnnouncementCore(
   ProtobufByteArrayToSerializable(announcement.signature(), signature);
 
   if (!Schnorr::GetInstance().Verify(tmp, signature, leaderKey)) {
-    LOG_GENERAL(WARNING, "Invalid signature in announcement.");
+    LOG_GENERAL(WARNING, "Invalid signature in announcement. leaderID = "
+                             << leaderID << " leaderKey = " << leaderKey);
     return false;
   }
 

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -763,13 +763,15 @@ void P2PComm::SendBroadcastMessage(const vector<Peer>& peers,
   job->m_message = message;
   job->m_hash = sha256.Finalize();
 
+  vector<unsigned char> hashCopy(job->m_hash);
+
   // Queue job
   while (!m_sendQueue.push(job)) {
     // Keep attempting to push until success
   }
 
   lock_guard<mutex> guard(m_broadcastHashesMutex);
-  m_broadcastHashes.insert(job->m_hash);
+  m_broadcastHashes.insert(hashCopy);
 }
 
 void P2PComm::SendBroadcastMessage(const deque<Peer>& peers,
@@ -791,13 +793,15 @@ void P2PComm::SendBroadcastMessage(const deque<Peer>& peers,
   job->m_message = message;
   job->m_hash = sha256.Finalize();
 
+  vector<unsigned char> hashCopy(job->m_hash);
+
   // Queue job
   while (!m_sendQueue.push(job)) {
     // Keep attempting to push until success
   }
 
   lock_guard<mutex> guard(m_broadcastHashesMutex);
-  m_broadcastHashes.insert(job->m_hash);
+  m_broadcastHashes.insert(hashCopy);
 }
 
 void P2PComm::RebroadcastMessage(const vector<Peer>& peers,


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR introduces the following fixes:
1. Fix a potential crash by creating a duplicate copy of the broadcast hash in `SendBroadcastMessage` before queueing the job.
2. Prevent `ConsensusBackup` from accepting `PROCESS_FINALCHALLENGE` in `RESPONSE_DONE` state
3. Prevent `m_msgContentValidator` failure from causing change to `ERROR` state in `ConsensusBackup`
4. Prevent challenge verification failure from causing change to `ERROR` state in `ConsensusBackup`
5. Correct the logging information about the candidate leader in `RunConsensusOnViewChangeWhenNotCandidateLeader`
6. Add more logging information about announcement signature failure in Messenger.cpp

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
