### PR TITLE
[testnetv3-dev] Add state log for number of peers in shards

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -479,14 +479,14 @@ vector<Peer> Lookup::GetNodePeers() {
 }
 
 bool Lookup::ProcessEntireShardingStructure() {
+  LOG_MARKER();
+
   if (!LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "Lookup::ProcessEntireShardingStructure not expected to be "
                 "called from other than the LookUp node.");
     return true;
   }
-
-  LOG_MARKER();
 
   LOG_GENERAL(INFO, "[LOOKUP received sharding structure]");
 
@@ -496,9 +496,14 @@ bool Lookup::ProcessEntireShardingStructure() {
 
   m_nodesInNetwork.clear();
   unordered_set<Peer> t_nodesInNetwork;
+  unsigned int totalNodeCount = 0;
 
   for (unsigned int i = 0; i < m_mediator.m_ds->m_shards.size(); i++) {
     unsigned int index = 0;
+
+    totalNodeCount += m_mediator.m_ds->m_shards.at(i).size();
+    LOG_STATE("[SHARD " << to_string(i) << "] Num nodes = "
+                        << m_mediator.m_ds->m_shards.at(i).size());
 
     for (const auto& shardNode : m_mediator.m_ds->m_shards.at(i)) {
       const PubKey& key = std::get<SHARD_NODE_PUBKEY>(shardNode);
@@ -518,6 +523,8 @@ bool Lookup::ProcessEntireShardingStructure() {
       index++;
     }
   }
+
+  LOG_STATE("[SHARDS] Total num nodes = " << totalNodeCount);
 
   for (auto& peer : t_nodesInNetwork) {
     if (!l_nodesInNetwork.erase(peer)) {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
We'll see a message like this in the lookup node's state log:
```
[ 05:34:07:924 ][SHARD 0] Num nodes = 5
[ 05:34:07:924 ][SHARD 1] Num nodes = 5
[ 05:34:07:924 ][SHARDS] Total num nodes = 10
```

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
