### PR TITLE
Added PoW solutions to DSBlock announcement

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -45,9 +45,28 @@
 
 class Mediator;
 
+struct PoWSolution {
+  uint64_t nonce;
+  std::array<unsigned char, 32> result;
+  std::array<unsigned char, 32> mixhash;
+
+  PoWSolution()
+      : nonce(0),
+        result({0}),
+        mixhash({0}) {
+  }  // The oldest DS (and now new shard node) will have this default value
+  PoWSolution(const uint64_t n, const std::array<unsigned char, 32>& r,
+              const std::array<unsigned char, 32>& m)
+      : nonce(n), result(r), mixhash(m) {}
+  bool operator==(const PoWSolution& rhs) const {
+    return (nonce == rhs.nonce) && (result == rhs.result) &&
+           (mixhash == rhs.mixhash);
+  }
+};
+
 using VectorOfPoWSoln =
     std::vector<std::pair<std::array<unsigned char, 32>, PubKey>>;
-using MapOfPubKeyPoW = std::map<PubKey, std::array<unsigned char, 32>>;
+using MapOfPubKeyPoW = std::map<PubKey, PoWSolution>;
 
 /// Implements Directory Service functionality including PoW verification, DS,
 /// Tx Block Consensus and sharding management.
@@ -201,7 +220,8 @@ class DirectoryService : public Executable, public Broadcastable {
 
   void ComputeTxnSharingAssignments(const std::vector<Peer>& proposedDSMembers);
   bool VerifyDifficulty();
-  bool VerifyPoWOrdering(const DequeOfShard& shards);
+  bool VerifyPoWOrdering(const DequeOfShard& shards,
+                         const MapOfPubKeyPoW& allPoWsFromTheLeader);
   bool VerifyNodePriority(const DequeOfShard& shards);
 
   // internal calls from RunConsensusOnDSBlock
@@ -534,7 +554,7 @@ class DirectoryService : public Executable, public Broadcastable {
   std::string GetActionString(Action action) const;
   bool ValidateViewChangeState(DirState NodeState, DirState StatePropose);
 
-  void AddDSPoWs(PubKey Pubk, std::array<unsigned char, 32> DSPOWSoln);
+  void AddDSPoWs(PubKey Pubk, const PoWSolution& DSPOWSoln);
   MapOfPubKeyPoW GetAllDSPoWs();
   void ClearDSPoWSolns();
   std::array<unsigned char, 32> GetDSPoWSoln(PubKey Pubk);

--- a/src/libDirectoryService/PoWProcessing.cpp
+++ b/src/libDirectoryService/PoWProcessing.cpp
@@ -184,20 +184,20 @@ bool DirectoryService::ProcessPoWSubmission(
       lock_guard<mutex> g(m_mutexAllPOW, adopt_lock);
       lock_guard<mutex> g2(m_mutexAllPoWConns, adopt_lock);
 
-      std::array<unsigned char, 32> winningHashArr =
-          DataConversion::HexStrToStdArray(resultingHash);
+      PoWSolution soln(nonce, DataConversion::HexStrToStdArray(resultingHash),
+                       DataConversion::HexStrToStdArray(mixHash));
 
       m_allPoWConns.emplace(submitterPubKey, submitterPeer);
       if (m_allPoWs.find(submitterPubKey) == m_allPoWs.end()) {
-        m_allPoWs[submitterPubKey] = winningHashArr;
-      } else if (m_allPoWs[submitterPubKey] > winningHashArr) {
-        LOG_EPOCH(
-            INFO, std::to_string(m_mediator.m_currentEpochNum).c_str(),
-            "Harder PoW result: "
-                << DataConversion::charArrToHexStr(winningHashArr)
-                << " overwrite the old PoW: "
-                << DataConversion::charArrToHexStr(m_allPoWs[submitterPubKey]));
-        m_allPoWs[submitterPubKey] = winningHashArr;
+        m_allPoWs[submitterPubKey] = soln;
+      } else if (m_allPoWs[submitterPubKey].result > soln.result) {
+        LOG_EPOCH(INFO, std::to_string(m_mediator.m_currentEpochNum).c_str(),
+                  "Harder PoW result: "
+                      << DataConversion::charArrToHexStr(soln.result)
+                      << " overwrite the old PoW: "
+                      << DataConversion::charArrToHexStr(
+                             m_allPoWs[submitterPubKey].result));
+        m_allPoWs[submitterPubKey] = soln;
       }
 
       uint8_t expectedDSDiff = DS_POW_DIFFICULTY;
@@ -208,7 +208,7 @@ bool DirectoryService::ProcessPoWSubmission(
       }
 
       if (difficultyLevel == expectedDSDiff) {
-        AddDSPoWs(submitterPubKey, winningHashArr);
+        AddDSPoWs(submitterPubKey, soln);
       }
 
       UpdatePoWSubmissionCounterforNode(submitterPubKey);
@@ -253,8 +253,7 @@ void DirectoryService::ResetPoWSubmissionCounter() {
   m_AllPoWCounter.clear();
 }
 
-void DirectoryService::AddDSPoWs(PubKey Pubk,
-                                 std::array<unsigned char, 32> DSPOWSoln) {
+void DirectoryService::AddDSPoWs(PubKey Pubk, const PoWSolution& DSPOWSoln) {
   lock_guard<mutex> g(m_mutexAllDSPOWs);
   m_allDSPoWs[Pubk] = DSPOWSoln;
 }
@@ -272,7 +271,7 @@ void DirectoryService::ClearDSPoWSolns() {
 std::array<unsigned char, 32> DirectoryService::GetDSPoWSoln(PubKey Pubk) {
   lock_guard<mutex> g(m_mutexAllDSPOWs);
   if (m_allDSPoWs.find(Pubk) != m_allDSPoWs.end()) {
-    return m_allDSPoWs[Pubk];
+    return m_allDSPoWs[Pubk].result;
   } else {
     LOG_GENERAL(WARNING, "No such element in m_allDSPoWs");
     return array<unsigned char, 32>();

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -22,6 +22,7 @@
 #include "libData/AccountData/ForwardedTxnEntry.h"
 #include "libData/BlockData/Block.h"
 #include "libData/BlockData/Block/FallbackBlockWShardingStructure.h"
+#include "libDirectoryService/DirectoryService.h"
 #include "libDirectoryService/ShardStruct.h"
 #include "libNetwork/Peer.h"
 
@@ -143,6 +144,7 @@ class Messenger {
       const DequeOfShard& shards, const std::vector<Peer>& dsReceivers,
       const std::vector<std::vector<Peer>>& shardReceivers,
       const std::vector<std::vector<Peer>>& shardSenders,
+      const MapOfPubKeyPoW& allPoWs,
       std::vector<unsigned char>& messageToCosign);
 
   static bool GetDSDSBlockAnnouncement(
@@ -152,7 +154,7 @@ class Messenger {
       const PubKey& leaderKey, DSBlock& dsBlock, DequeOfShard& shards,
       std::vector<Peer>& dsReceivers,
       std::vector<std::vector<Peer>>& shardReceivers,
-      std::vector<std::vector<Peer>>& shardSenders,
+      std::vector<std::vector<Peer>>& shardSenders, MapOfPubKeyPoW& allPoWs,
       std::vector<unsigned char>& messageToCosign);
 
   static bool SetDSFinalBlockAnnouncement(

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -17,6 +17,13 @@ message ProtoDSNode
     required ByteArray peer   = 2;
 }
 
+message ProtoPoWSolution
+{
+    required uint64 nonce  = 1;
+    required bytes result  = 2;
+    required bytes mixhash = 3;
+}
+
 message ProtoDSCommittee
 {
     repeated ProtoDSNode dsnodes = 1;
@@ -38,6 +45,22 @@ message ProtoBlockBase
     }
     required bytes blockhash            = 1;
     required CoSignatures cosigs        = 2;
+}
+
+message ProtoShardingStructureWithPoWSolns
+{
+    message Member
+    {
+        required ByteArray pubkey         = 1;
+        required ByteArray peerinfo       = 2;
+        required uint32 reputation        = 3;
+        required ProtoPoWSolution powsoln = 4;
+    }
+    message Shard
+    {
+        repeated Member members           = 1;
+    }
+    repeated Shard shards                 = 1;
 }
 
 message ProtoShardingStructure
@@ -257,9 +280,10 @@ message DSMicroBlockSubmission
 
 message DSDSBlockAnnouncement
 {
-    required ProtoDSBlock dsblock                  = 1;
-    required ProtoShardingStructure sharding       = 2;
-    required ProtoTxSharingAssignments assignments = 3;
+    required ProtoDSBlock dsblock                        = 1;
+    required ProtoShardingStructureWithPoWSolns sharding = 2;
+    required ProtoTxSharingAssignments assignments       = 3;
+    // TODO: Also send the PoW Solutions for the DS winners
 }
 
 message DSFinalBlockAnnouncement


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
DS Block consensus can stall if a backup does not have the PoW information for one or more of the nodes (`DirectoryService::VerifyPoWOrdering`).

To prevent this, the leader must include the PoW solution for all nodes (shard nodes and DS winners) so that the backup can verify the solution for submissions that it missed.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

**Done in this PR**
- [x] DS leader serializes PoW solutions for shard members inside DS Block announcement
- [x] DS backup deserializes the solutions
- [x] DS backup checks the list of solutions in the event it doesn't have the one for a member

**To be done in another PR**
- [ ] Leader serializes PoW solutions for DS winners inside DS Block announcement
- [ ] DS backup does PoW verification on the entry that it takes from the list of solutions
- [ ] DS backup cross-checks its PoW list against the list from the leader even for known members (maybe optional)

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
