### PR TITLE
Bound the message size in ProcessPingAll

### DIFF
--- a/src/libNetwork/PeerManager.cpp
+++ b/src/libNetwork/PeerManager.cpp
@@ -142,8 +142,11 @@ bool PeerManager::ProcessPingAll(const vector<unsigned char>& message,
 
   vector<unsigned char> ping_message = {MessageType::PEER,
                                         PeerManager::InstructionType::PING};
-  ping_message.resize(ping_message.size() + message.size() - offset);
-  copy(message.begin() + offset, message.end(),
+
+  const unsigned int message_size = min(message.size() - offset, (size_t)1024);
+
+  ping_message.resize(ping_message.size() + message_size);
+  copy(message.begin() + offset, message.begin() + offset + message_size,
        ping_message.begin() + MessageOffset::BODY);
   P2PComm::GetInstance().SendMessage(PeerStore::GetStore().GetAllPeers(),
                                      ping_message);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Test function `PeerManager::ProcessPingAll()` has an unbounded `resize`.
This PR restricts the message size to 1k.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

This function - like most of the functions currently inside `PeerManager` - is currently unused but can still prove useful for testing purposes. We should eventually enable this code only for local testing builds. See https://github.com/Zilliqa/Zilliqa/issues/759.

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
