### PR TITLE
Avoid buffering of FB while in MBSUBMISSION or VC State

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -434,6 +434,14 @@ bool DirectoryService::ProcessFinalBlockConsensus(
                 "Ignoring final block consensus message");
       return false;
     }
+    // Only buffer the Final block consensus message if in MICROBLOCK_SUBMISSION
+    // or VIEWCHANGE_CONSENSUS state
+    if (!((m_state == MICROBLOCK_SUBMISSION) ||
+          (m_state == VIEWCHANGE_CONSENSUS))) {
+      LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                "Ignoring final block consensus message");
+      return false;
+    }    
     {
       lock_guard<mutex> h(m_mutexFinalBlockConsensusBuffer);
       m_finalBlockConsensusBuffer[consensus_id].push_back(

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -441,7 +441,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(
       LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                 "Ignoring final block consensus message");
       return false;
-    }    
+    }
     {
       lock_guard<mutex> h(m_mutexFinalBlockConsensusBuffer);
       m_finalBlockConsensusBuffer[consensus_id].push_back(


### PR DESCRIPTION
## Description
While in DS Consensus Prep state, node accepts the Final block announcement for consensus, and it lands up in final block consensus state which is bug. Check should be added such that Final Block Consensus messages are not bufferred and should be ignored if Node is in DSBLOCK_CONSENSUS_PREP state.
In general, should be buffered only in MICROBLOCKSUBMISSION or VC STATE.

Issue - Zilliqa/Issues#264

## Review Suggestion
Check the file changed.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
