### PR TITLE
[testnetv3-dev] Check index before accessing committee member in consensus

### DIFF
--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -86,7 +86,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
   std::vector<unsigned char> errorMsg;
   if (!m_msgContentValidator(announcement, offset, errorMsg, m_consensusID,
                              m_blockNumber, m_blockHash, m_leaderID,
-                             m_committee.at(m_leaderID).first,
+                             GetCommitteeMember(m_leaderID).first,
                              m_messageToCosign)) {
     LOG_GENERAL(WARNING, "Message validation failed");
 
@@ -106,8 +106,8 @@ bool ConsensusBackup::ProcessMessageAnnounce(
 
         // Unicast to the leader
         // =====================
-        P2PComm::GetInstance().SendMessage(m_committee.at(m_leaderID).second,
-                                           commitFailureMsg);
+        P2PComm::GetInstance().SendMessage(
+            GetCommitteeMember(m_leaderID).second, commitFailureMsg);
 
         return true;
       }
@@ -136,7 +136,7 @@ bool ConsensusBackup::ProcessMessageAnnounce(
 
     // Unicast to the leader
     // =====================
-    P2PComm::GetInstance().SendMessage(m_committee.at(m_leaderID).second,
+    P2PComm::GetInstance().SendMessage(GetCommitteeMember(m_leaderID).second,
                                        commit);
   }
   return result;
@@ -160,7 +160,7 @@ bool ConsensusBackup::GenerateCommitFailureMessage(
   if (!Messenger::SetConsensusCommitFailure(
           commitFailure, offset, m_consensusID, m_blockNumber, m_blockHash,
           m_myID, errorMsg,
-          make_pair(m_myPrivKey, m_committee.at(m_myID).first))) {
+          make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
     LOG_GENERAL(WARNING, "Messenger::SetConsensusCommitFailure failed.");
     return false;
   }
@@ -183,7 +183,7 @@ bool ConsensusBackup::GenerateCommitMessage(vector<unsigned char>& commit,
   if (!Messenger::SetConsensusCommit(
           commit, offset, m_consensusID, m_blockNumber, m_blockHash, m_myID,
           *m_commitPoint,
-          make_pair(m_myPrivKey, m_committee.at(m_myID).first))) {
+          make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
     LOG_GENERAL(WARNING, "Messenger::SetConsensusCommit failed.");
     return false;
   }
@@ -212,7 +212,7 @@ bool ConsensusBackup::ProcessMessageChallengeCore(
   if (!Messenger::GetConsensusChallenge(
           challenge, offset, m_consensusID, m_blockNumber, m_blockHash,
           m_leaderID, aggregated_commit, aggregated_key, m_challenge,
-          m_committee.at(m_leaderID).first)) {
+          GetCommitteeMember(m_leaderID).first)) {
     LOG_GENERAL(WARNING, "Messenger::GetConsensusChallenge failed.");
     return false;
   }
@@ -265,7 +265,7 @@ bool ConsensusBackup::ProcessMessageChallengeCore(
     // Unicast to the leader
     // =====================
 
-    P2PComm::GetInstance().SendMessage(m_committee.at(m_leaderID).second,
+    P2PComm::GetInstance().SendMessage(GetCommitteeMember(m_leaderID).second,
                                        response);
   }
 
@@ -290,7 +290,7 @@ bool ConsensusBackup::GenerateResponseMessage(vector<unsigned char>& response,
 
   if (!Messenger::SetConsensusResponse(
           response, offset, m_consensusID, m_blockNumber, m_blockHash, m_myID,
-          r, make_pair(m_myPrivKey, m_committee.at(m_myID).first))) {
+          r, make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
     LOG_GENERAL(WARNING, "Messenger::SetConsensusResponse failed.");
     return false;
   }
@@ -317,7 +317,7 @@ bool ConsensusBackup::ProcessMessageCollectiveSigCore(
   if (!Messenger::GetConsensusCollectiveSig(
           collectivesig, offset, m_consensusID, m_blockNumber, m_blockHash,
           m_leaderID, m_responseMap, m_collectiveSig,
-          m_committee.at(m_leaderID).first)) {
+          GetCommitteeMember(m_leaderID).first)) {
     LOG_GENERAL(WARNING, "Messenger::GetConsensusCollectiveSig failed.");
     return false;
   }
@@ -366,7 +366,7 @@ bool ConsensusBackup::ProcessMessageCollectiveSigCore(
 
       // Unicast to the leader
       // =====================
-      P2PComm::GetInstance().SendMessage(m_committee.at(m_leaderID).second,
+      P2PComm::GetInstance().SendMessage(GetCommitteeMember(m_leaderID).second,
                                          finalcommit);
     }
   } else {

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -87,8 +87,9 @@ Signature ConsensusCommon::SignMessage(const vector<unsigned char>& msg,
   LOG_MARKER();
 
   Signature signature;
-  bool result = Schnorr::GetInstance().Sign(
-      msg, offset, size, m_myPrivKey, m_committee.at(m_myID).first, signature);
+  bool result =
+      Schnorr::GetInstance().Sign(msg, offset, size, m_myPrivKey,
+                                  GetCommitteeMember(m_myID).first, signature);
   if (!result) {
     return Signature();
   }
@@ -100,13 +101,13 @@ bool ConsensusCommon::VerifyMessage(const vector<unsigned char>& msg,
                                     const Signature& toverify,
                                     uint16_t peer_id) {
   LOG_MARKER();
-  bool result = Schnorr::GetInstance().Verify(msg, offset, size, toverify,
-                                              m_committee.at(peer_id).first);
+  bool result = Schnorr::GetInstance().Verify(
+      msg, offset, size, toverify, GetCommitteeMember(peer_id).first);
 
   if (!result) {
     LOG_GENERAL(INFO, "Peer id: " << peer_id << " pubkey: 0x"
                                   << DataConversion::SerializableToHexStr(
-                                         m_committee.at(peer_id).first));
+                                         GetCommitteeMember(peer_id).first));
     LOG_GENERAL(INFO, "pubkeys size: " << m_committee.size());
   }
   return result;
@@ -175,6 +176,17 @@ Challenge ConsensusCommon::GetChallenge(const vector<unsigned char>& msg,
   LOG_MARKER();
 
   return Challenge(aggregated_commit, aggregated_key, msg);
+}
+
+pair<PubKey, Peer> ConsensusCommon::GetCommitteeMember(
+    const unsigned int index) {
+  if (m_committee.size() <= index) {
+    LOG_GENERAL(WARNING, "Committee size " << m_committee.size() << " <= index "
+                                           << index
+                                           << ". Returning default values.");
+    return make_pair(PubKey(), Peer());
+  }
+  return m_committee.at(index);
 }
 
 ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -194,6 +194,8 @@ class ConsensusCommon {
                          const CommitPoint& aggregated_commit,
                          const PubKey& aggregated_key);
 
+  std::pair<PubKey, Peer> GetCommitteeMember(const unsigned int index);
+
  public:
   /// Consensus message processing function
   virtual bool ProcessMessage(

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -273,7 +273,7 @@ bool ConsensusLeader::GenerateChallengeMessage(vector<unsigned char>& challenge,
   if (!Messenger::SetConsensusChallenge(
           challenge, offset, m_consensusID, m_blockNumber, m_blockHash, m_myID,
           aggregated_commit, aggregated_key, m_challenge,
-          make_pair(m_myPrivKey, m_committee.at(m_myID).first))) {
+          make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
     LOG_GENERAL(WARNING, "Messenger::SetConsensusChallenge failed.");
     return false;
   }
@@ -316,7 +316,8 @@ bool ConsensusLeader::ProcessMessageResponseCore(
     return false;
   }
 
-  if (!MultiSig::VerifyResponse(r, m_challenge, m_committee.at(backupID).first,
+  if (!MultiSig::VerifyResponse(r, m_challenge,
+                                GetCommitteeMember(backupID).first,
                                 m_commitPointMap.at(backupID))) {
     LOG_GENERAL(WARNING, "Invalid response for this backup");
     return false;
@@ -474,7 +475,7 @@ bool ConsensusLeader::GenerateCollectiveSigMessage(
   if (!Messenger::SetConsensusCollectiveSig(
           collectivesig, offset, m_consensusID, m_blockNumber, m_blockHash,
           m_myID, m_collectiveSig, m_responseMap,
-          make_pair(m_myPrivKey, m_committee.at(m_myID).first))) {
+          make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
     LOG_GENERAL(WARNING, "Messenger::SetConsensusCollectiveSig failed.");
     return false;
   }
@@ -556,7 +557,7 @@ bool ConsensusLeader::StartConsensus(
   if (!announcementGeneratorFunc(
           announcement_message, MessageOffset::BODY + sizeof(unsigned char),
           m_consensusID, m_blockNumber, m_blockHash, m_myID,
-          make_pair(m_myPrivKey, m_committee.at(m_myID).first),
+          make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first),
           m_messageToCosign)) {
     LOG_GENERAL(WARNING, "Failed to generate announcement message.");
     return false;

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -362,7 +362,8 @@ int PubKey::Deserialize(const vector<unsigned char>& src, unsigned int offset) {
 }
 
 PubKey& PubKey::operator=(const PubKey& src) {
-  m_initialized = (EC_POINT_copy(m_P.get(), src.m_P.get()) == 1);
+  m_initialized =
+      src.m_initialized && (EC_POINT_copy(m_P.get(), src.m_P.get()) == 1);
   return *this;
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This scenario happened during testing:
1. Mutex was held by a thread processing the transaction packet
2. MicroBlock announcement was received, but stalled waiting for the mutex
3. FinalBlock was received, and node proceeded to move to next epoch
4. Consensus object was re-created at this next epoch
5. Mutex from 1 was finally acquired by 2, and 2 continued execution
6. Eventually 2 tried to access a member of `m_committee` but the index specified by `m_myID` was a corrupt value at this point.

To fix this, we:
1. Create an accessor function `ConsensusCommon::GetCommitteeMember()` that returns a default, uninitialized `Peer`/`PubKey` pair when the `index` is beyond the size of the committee.
2. Modify `PubKey::operator=()` to copy a `src` key only when it is initialized

Note: This is not a complete fix. Behavior of the re-created consensus object may be unpredictable for the scenario described above (for example, `m_myID` could still be a valid number, or `m_committee` itself could be corrupted, ...). Complete fix should prevent proceeding with the consensus in the first place.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

Tested normal case only (error not triggered).

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
