### PR TITLE
[testnetv3-dev]  Avoid dispatching same messages when gossip is not running

### DIFF
--- a/src/libNetwork/RumorManager.cpp
+++ b/src/libNetwork/RumorManager.cpp
@@ -43,6 +43,7 @@ RumorManager::RumorManager()
     : m_peerIdPeerBimap(),
       m_peerIdSet(),
       m_rumorIdRumorBimap(),
+      m_tmpRumorHashSet(),
       m_selfPeer(),
       m_rumorIdGenerator(0),
       m_mutex(),
@@ -131,6 +132,7 @@ bool RumorManager::Initialize(const std::vector<Peer>& peers,
   m_rumorIdRumorBimap.clear();
   m_peerIdSet.clear();
   m_selfPeer = myself;
+  m_tmpRumorHashSet.clear();
 
   int peerIdGenerator = 0;
   for (const auto& p : peers) {
@@ -278,17 +280,34 @@ bool RumorManager::RumorReceived(uint8_t type, int32_t round,
       {
         SHA2<HASH_TYPE::HASH_VARIANT_256> sha256;
         sha256.Update(message);  // raw_message hash
-        LOG_GENERAL(WARNING,
-                    "Round is not running. Will accept the msg received from "
-                        << from
-                        << ", but will not "
-                           "gossip it further. [Gossip_Message_Hash: "
-                        << DataConversion::Uint8VecToHexStr(sha256.Finalize())
-                               .substr(0, 6)
-                        << " ]");
+        std::string hash = DataConversion::Uint8VecToHexStr(sha256.Finalize());
+        {
+          std::lock_guard<std::mutex> guard(m_mutex);
+          // Is it old rumor message. If so then we have already dispatched it.
+          // Don't do it again.
+          auto it = m_rumorIdRumorBimap.right.find(message);
+          if (it == m_rumorIdRumorBimap.right.end()) {
+            // Now that round is not running , And i may receive same message
+            // multiple times from my other peers. So avoid sending it to
+            // dispatcher multiple times.
+            if (m_tmpRumorHashSet.insert(hash).second) {
+              LOG_GENERAL(
+                  WARNING,
+                  "Round is not running. Will accept the msg received from "
+                      << from
+                      << ", but will not "
+                         "gossip it further. [Gossip_Message_Hash: "
+                      << hash.substr(0, 6) << " ]");
+              return true;
+            } else {
+              LOG_GENERAL(WARNING,
+                          "Ignoring duplicate mesage.[Gossip_Message_Hash: "
+                              << hash.substr(0, 6));
+            }
+          }
+        }
       }
-
-      return true;
+      return false;
     }
   }
 

--- a/src/libNetwork/RumorManager.h
+++ b/src/libNetwork/RumorManager.h
@@ -52,6 +52,7 @@ class RumorManager {
   PeerIdPeerBiMap m_peerIdPeerBimap;
   std::unordered_set<int> m_peerIdSet;
   RumorIdRumorBimap m_rumorIdRumorBimap;
+  std::set<std::string> m_tmpRumorHashSet;
   Peer m_selfPeer;
 
   int64_t m_rumorIdGenerator;


### PR DESCRIPTION
## Description
In testnet, we observed that one slower node receive the txn packet when RumorManager was stopped during initialization ( Start of new DS epoch ).
Before it was fully initialized, we receive the same txn packets multiple times for this epoch from peers. Now since the gossip itself is down, we currently just send the message down to dispatcher but don't gossip. This was done so that node don't miss the message in worst case.

However, This results in same txn packet being dispatched down for processing multiple time to ProcessTxnPacketFromLookup. 

Issue : https://github.com/Zilliqa/Issues/issues/267

## Review Suggestion
Check the files changed,

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
