### PR TITLE
Fixed incorrect check of AccountStore::DeserializeDelta result

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1813,7 +1813,7 @@ bool Lookup::ProcessSetStateDeltaFromSeed(const vector<unsigned char>& message,
             "ProcessSetStateDeltaFromSeed sent by " << from << " for block "
                                                     << blockNum);
 
-  if (AccountStore::GetInstance().DeserializeDelta(stateDelta, 0) != 0) {
+  if (!AccountStore::GetInstance().DeserializeDelta(stateDelta, 0)) {
     LOG_GENERAL(WARNING, "AccountStore::GetInstance().DeserializeDelta failed");
     return false;
   }

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -157,7 +157,7 @@ void Retriever::RetrieveTxBlocks(bool& result, const bool& wakeupForUpgrade) {
       BlockStorage::GetBlockStorage().GetStateDelta(
           block->GetHeader().GetBlockNum(), stateDelta);
 
-      if (AccountStore::GetInstance().DeserializeDelta(stateDelta, 0) != 0) {
+      if (!AccountStore::GetInstance().DeserializeDelta(stateDelta, 0)) {
         LOG_GENERAL(WARNING,
                     "AccountStore::GetInstance().DeserializeDelta failed");
         result = false;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Missed a couple of places where `AccountStore::DeserializeDelta()` was still being checked as an unsigned int instead of bool.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
