### PR TITLE
Fix libServer GetBalance bug

### DIFF
--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -334,7 +334,7 @@ Json::Value Server::GetBalance(const string& address) {
       LOG_GENERAL(INFO, "balance " << balance.str() << " nonce: "
                                    << nonce.convert_to<unsigned int>());
     } else if (account == nullptr) {
-      ret["balance"] = 0;
+      ret["balance"] = "0";
       ret["nonce"] = 0;
     }
 


### PR DESCRIPTION
## Description
Fix a trivial bug in GetBalance in which 0 was returned as a number if account was not present.
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
Check if the quotes are present, two in number.
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
