### PR TITLE
[testnetv4-dev] [Hotfix] Disable retrieveHistory for local test

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -253,6 +253,11 @@ void Lookup::SendMessageToRandomLookupNode(
 
   // int index = rand() % (NUM_LOOKUP_USE_FOR_SYNC) + m_lookupNodes.size()
   // - NUM_LOOKUP_USE_FOR_SYNC;
+  if (0 == m_lookupNodes.size()) {
+    LOG_GENERAL(WARNING, "There is no lookup node existed yet!");
+    return;
+  }
+
   int index = rand() % m_lookupNodes.size();
 
   P2PComm::GetInstance().SendMessage(m_lookupNodes[index].second, message);

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -473,7 +473,14 @@ bool BlockStorage::GetDSCommittee(
   LOG_MARKER();
 
   unsigned int index = 0;
-  consensusLeaderID = stoul(m_dsCommitteeDB->Lookup(index++));
+  string strConsensusLeaderID = m_dsCommitteeDB->Lookup(index++);
+
+  if (strConsensusLeaderID.empty()) {
+    LOG_GENERAL(WARNING, "Cannot retrieve DS committee!");
+    return false;
+  }
+
+  consensusLeaderID = stoul(strConsensusLeaderID);
   LOG_GENERAL(INFO, "Retrieved DS leader ID: " << consensusLeaderID);
   string dataStr;
 
@@ -537,7 +544,14 @@ bool BlockStorage::GetShardStructure(DequeOfShard& shards,
   LOG_MARKER();
 
   unsigned int index = 0;
-  myshardId = stoul(m_shardStructureDB->Lookup(index++));
+  string strMyshardId = m_shardStructureDB->Lookup(index++);
+
+  if (strMyshardId.empty()) {
+    LOG_GENERAL(WARNING, "Cannot retrieve sharding structure!");
+    return false;
+  }
+
+  myshardId = stoul(strMyshardId);
   LOG_GENERAL(INFO, "Retrieved shard ID: " << myshardId);
   string dataStr = m_shardStructureDB->Lookup(index++);
   Messenger::ArrayToShardStructure(

--- a/tests/Zilliqa/test_zilliqa_archival.py
+++ b/tests/Zilliqa/test_zilliqa_archival.py
@@ -116,7 +116,7 @@ def run_start():
 	# Launch node zilliqa process
 	for x in range(0, count):
 		keypair = keypairs[x].split(" ")
-		os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/archivezilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 1 > ./error_log_zilliqa 2>&1 &')
+		os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/archivezilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 0 > ./error_log_zilliqa 2>&1 &')
 
 if __name__ == "__main__":
 	main()

--- a/tests/Zilliqa/test_zilliqa_local.py
+++ b/tests/Zilliqa/test_zilliqa_local.py
@@ -222,9 +222,9 @@ def run_start(numdsnodes):
 
 		if (x < numdsnodes):
 			shutil.copyfile('config_normal.xml', LOCAL_RUN_FOLDER + testfolders_list[x] + '/config.xml')
-			os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 1 0 1 > ./error_log_zilliqa 2>&1 &')
+			os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 1 0 0 > ./error_log_zilliqa 2>&1 &')
 		else:
-			os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 1 > ./error_log_zilliqa 2>&1 &')
+			os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 0 > ./error_log_zilliqa 2>&1 &')
 
 def run_connect(numnodes):
 	testfolders_list = get_immediate_subdirectories(LOCAL_RUN_FOLDER)

--- a/tests/Zilliqa/test_zilliqa_lookup.py
+++ b/tests/Zilliqa/test_zilliqa_lookup.py
@@ -189,7 +189,7 @@ def run_start():
 	# Launch node zilliqa process
 	for x in range(0, count):
 		keypair = keypairs[x].split(" ")
-		os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/lzilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 1 > ./error_log_zilliqa 2>&1 &')
+		os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[x] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/lzilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + x) + ' 0 0 0 > ./error_log_zilliqa 2>&1 &')
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The Zilliqa process parameter "toRetrieveHistory" should only be set when node recovery, rejoin, and upgrading mechanism. For the local testing without a standalone daemon, we need to make the script more flexible. Now a hotfix is just disable toRetrieveHistory for local test.
Besides, this PR also add some protection for system crash.

Follow-up:
We should support a flexible local-test script that allow to disable toRetrieveHistory at first time, and enable toRetrieveHistory then.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
