### PR TITLE
Refactor dockerfiles and docker build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull zilliqa/zilliqa-ci;
-      docker run -d -v $(pwd):/zilliqa -v $HOME/.ccache:/root/.ccache -w /zilliqa --name ci zilliqa/zilliqa-ci tail -f /dev/null;
+      docker run -d -v $(pwd):/zilliqa -v $HOME/.ccache:/root/.ccache -w /zilliqa --name ci zilliqa/zilliqa-ci:20181105 tail -f /dev/null;
     fi
 
 install:
@@ -39,23 +38,3 @@ after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       docker exec -e CI="true" -e TRAVIS="$TRAVIS" -e TRAVIS_PULL_REQUEST_SHA="$TRAVIS_PULL_REQUEST_SHA" -e TRAVIS_COMMIT="$TRAVIS_COMMIT" -e TRAVIS_JOB_NUMBER="$TRAVIS_JOB_NUMBER" -e TRAVIS_PULL_REQUEST="$TRAVIS_PULL_REQUEST" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_REPO_SLUG="$TRAVIS_REPO_SLUG" -e TRAVIS_OS_NAME="$TRAVIS_OS_NAME" -e TRAVIS_TAG="$TRAVIS_TAG" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" -t ci /bin/sh -c "./scripts/ci_report_coverage.sh";
     fi
-
-stages:
-  - test
-  - name: deploy
-    if: type = push
-
-jobs:
-  include:
-  - stage: deploy
-    os: linux
-    sudo: required
-    env: BUILD_COMMAND="./scripts/ci_make_image.sh"
-    before_install: # left blank
-    install: # left blank
-    - pip install --user awscli
-    - export PATH=$PATH:$HOME/.local/bin
-    cache: false
-    script:
-    - $BUILD_COMMAND
-    after_success: # left blank

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,54 +1,67 @@
-# escape=\
-FROM zilliqa/mongodb
+# Copyright (c) 2018 Zilliqa
+# This source code is being disclosed to you solely for the purpose of your
+# participation in testing Zilliqa. You may view, compile and run the code for
+# that purpose and pursuant to the protocols and algorithms that are programmed
+# into, and intended by, the code. You may not do anything else with the code
+# without express permission from Zilliqa Research Pte. Ltd., including
+# modifying or publishing the code (or any part of it), and developing or
+# forming another public or private blockchain network. This source code is
+# provided 'as is' and no warranties are given as to title or non-infringement,
+# merchantability or fitness for purpose and, to the extent permitted by law,
+# all liability for your use of the code is disclaimed. Some programs in this
+# code are governed by the GNU General Public License v3.0 (available at
+# https://www.gnu.org/licenses/gpl-3.0.en.html) ('GPLv3'). The programs that
+# are governed by GPLv3.0 are those programs that are located in the folders
+# src/depends and tests/depends and which include a reference to GPLv3 in their
+# program files.
+#
+ARG BASE=ubuntu:16.04
+FROM ${BASE}
 
-#--------------------------------------------------------------------
-# PACKAGES
-#--------------------------------------------------------------------
+# Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
     build-essential \
     ca-certificates \
     cmake \
     git \
+    golang \
     libboost-filesystem-dev \
     libboost-system-dev \
     libboost-test-dev \
+    libcurl4-openssl-dev \
+    libevent-dev \
     libjsoncpp-dev \
     libjsonrpccpp-dev \
     libleveldb-dev \
     libmicrohttpd-dev \
+    libminiupnpc-dev \
+    libprotobuf-dev \
     libsnappy-dev \
     libssl-dev \
-    libjsonrpccpp-dev \
-    libevent-dev \
-    libminiupnpc-dev \
+    libtool \
     ocl-icd-opencl-dev \
-    libprotobuf-dev \
     protobuf-compiler \
-    libcurl4-openssl-dev \
-    python python-pip \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install netaddr
+    python \
+    python-pip \
+    && rm -rf /var/lib/apt/lists/*
 
-#--------------------------------------------------------------------
-# BUILDING
-#--------------------------------------------------------------------
-# don't do check-out if COMMIT is empty
+# Intentionally left blank unless specific commit is provided in commandline
 ARG COMMIT=
 ARG REPO=https://github.com/Zilliqa/Zilliqa.git
 ARG SOURCE_DIR=/zilliqa
 ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local
 ARG BUILD_TYPE=RelWithDebInfo
-ARG JOBS=2
 
-# FIXME: see issue https://github.com/Zilliqa/Zilliqa/issues/240
-RUN git clone --recursive ${REPO} ${SOURCE_DIR} && \
-    git -C ${SOURCE_DIR} checkout ${COMMIT} && \
-    mkdir $BUILD_DIR && cd $BUILD_DIR && \
-    cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ${SOURCE_DIR} && \
-    make -j${JOBS} && make install && \
-    cd ${INSTALL_DIR} && rm -rf ${BUILD_DIR}
+RUN git clone ${REPO} ${SOURCE_DIR} \
+    && git -C ${SOURCE_DIR} checkout ${COMMIT} \
+    && git -C ${SOURCE_DIR} submodule update --init --recursive \
+    && cmake -H${SOURCE_DIR} -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+    && cmake --build ${BUILD_DIR} -- -j$(nproc) \
+    && cmake --build ${BUILD_DIR} --target install \
+    && rm -rf ${BUILD_DIR}
 
 ENV LD_LIBRARY_PATH=${INSTALL_DIR}/lib
 

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) 2018 Zilliqa
 # This source code is being disclosed to you solely for the purpose of your
 # participation in testing Zilliqa. You may view, compile and run the code for
@@ -15,42 +14,25 @@
 # are governed by GPLv3.0 are those programs that are located in the folders
 # src/depends and tests/depends and which include a reference to GPLv3 in their
 # program files.
+
+# This Dockerfile provides a standard environment for CI
 #
-# The script is dedicated for CI use
+# It includes dependencies and tools
+# * that are necessary for style checking, code coverage in CI
+# * that are too heavy to be installed during CI
+# * that are common and not subject to frequent change
 #
-# Usage:
-#
-#    ./scripts/ci_make_image.sh zilliqa # make k8s-zilliqa
-#    ./scripts/ci_make_image.sh scilla  # make k8s-scilla
+# It should not include
+# * things are specific to commit (they should go to scripts/ci_install_deps.sh
 
-set -e
-
-target=$1
-
-ext=""
-case $target in
-    zilliqa)
-        # Do nothing
-    ;;
-    scilla)
-        ext=".scilla"
-    ;;
-    *)
-        echo "Usage: $0 [zilliqa|scilla]"
-        exit 1
-    ;;
-esac
-
-docker --version
-aws --version
-
-commit=$(git rev-parse --short=7 ${TRAVIS_COMMIT})
-account_id=$(aws sts get-caller-identity --output text --query 'Account')
-region_id=us-west-2
-source_image=zilliqa:${commit}${ext}
-target_image=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit}${ext}
-
-eval $(aws ecr get-login --no-include-email --region ${region_id})
-make -C docker k8s-${target} COMMIT=${commit}
-docker tag ${source_image} ${target_image}
-docker push ${target_image}
+FROM ubuntu:16.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" >> /etc/apt/sources.list.d/llvm.list \
+    && echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" >> /etc/apt/sources.list.d/llvm.list \
+    && curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    clang-format-7 \
+    clang-tidy-7 \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) 2018 Zilliqa
 # This source code is being disclosed to you solely for the purpose of your
 # participation in testing Zilliqa. You may view, compile and run the code for
@@ -16,41 +15,16 @@
 # src/depends and tests/depends and which include a reference to GPLv3 in their
 # program files.
 #
-# The script is dedicated for CI use
-#
-# Usage:
-#
-#    ./scripts/ci_make_image.sh zilliqa # make k8s-zilliqa
-#    ./scripts/ci_make_image.sh scilla  # make k8s-scilla
+# This Dockerfile is incomplete and should only be used with other Dockerfiles
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dnsutils \
+    gdb \
+    less \
+    logrotate \
+    net-tools \
+    rsyslog \
+    vim \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install setuptools \
+    && pip install urllib3==1.23 kubernetes netaddr
 
-set -e
-
-target=$1
-
-ext=""
-case $target in
-    zilliqa)
-        # Do nothing
-    ;;
-    scilla)
-        ext=".scilla"
-    ;;
-    *)
-        echo "Usage: $0 [zilliqa|scilla]"
-        exit 1
-    ;;
-esac
-
-docker --version
-aws --version
-
-commit=$(git rev-parse --short=7 ${TRAVIS_COMMIT})
-account_id=$(aws sts get-caller-identity --output text --query 'Account')
-region_id=us-west-2
-source_image=zilliqa:${commit}${ext}
-target_image=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit}${ext}
-
-eval $(aws ecr get-login --no-include-email --region ${region_id})
-make -C docker k8s-${target} COMMIT=${commit}
-docker tag ${source_image} ${target_image}
-docker push ${target_image}

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,36 @@
+
+.PHONY: all ci k8s-zilliqa k8s-scilla
+
+# build the default zilliqa docker image same as the one on Docker Hub
+all:
+	docker build -t zilliqa .
+
+# build zilliqa docker image for CI usage
+ci:
+	docker build -t zilliqa-ci -f Dockerfile.ci .
+
+
+len=$(shell echo $(COMMIT) | wc -c)
+commit=$(shell echo $(COMMIT) | cut -c 1-7)
+
+check-commit:
+	@if [ -z "$(COMMIT)" ]; \
+	then \
+		echo "COMMIT=xxxxxxx is not passed in after make target"; \
+		exit 1; \
+	fi
+	@if [ $(len) -lt 7 ]; \
+	then \
+		echo "COMMIT doesn't have enough length (at least 7)"; \
+		exit 1; \
+	fi
+
+# build zilliqa docker image for Kubernetes usage
+k8s-zilliqa: check-commit
+	cat Dockerfile Dockerfile.k8s | docker build -t zilliqa:$(commit) \
+		--build-arg COMMIT=$(commit) -
+
+k8s-scilla: check-commit
+	cat Dockerfile Dockerfile.k8s | docker build -t zilliqa:$(commit).scilla \
+		--build-arg COMMIT=$(commit) --build-arg BASE=zilliqa/scilla -
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,21 +1,16 @@
-# Zilliqa container (Experimental)
+# Zilliqa Dockerfiles
 
-## Overview
-This repository contains a Dockerfile that can built into a Docker image containing the Zilliqa binaries.
+This folder includes multiple Dockerfiles
 
-## Building the Docker image
-Executing the following command will start building a Docker image of Zilliqa:
+- `Dockerfile`: main Zilliqa Dockerfile containing build instructions, also read by Docker Hub Automated Build.
+- `Dockerfile.ci`: CI environment Dockerfile containing CI tools and dependencies
+- `Dockerfile.k8s`: *partial* Dockerfile containing dependencies needed for testnets running on Kubernetes
 
-> docker build --rm -t zilliqa .
+## Getting Started
 
-This build step will fetch the Zilliqa sources, gather it's dependencies and build Zilliqa from source. The result is a Docker image that can be used to start up a Docker container.
+A few most useful commands are provided through `Makefile` for quick access. The Dockerfiles can be passed to `docker build` with proper build arguments, when operated by experienced users.
 
-> Note: by default the 'master' branch of the Zilliqa repo will be built in 'Debug' mode. You can specify an other branch and/or configuration by providing build arguments like so:
-> docker build --build-arg BRANCH=<branchname> --build-arg CONFIG=<Debug/Release> --rm -t zilliqa . 
-
-## Running a Docker container
-To start up a Docker container from the previously built Docker image, you can run the following command:
-
-> docker run --rm -i -t zilliqa
-
-This will spawn a Docker container (running Ubuntu 16.04) which contains the entire source- and buildtree of Zilliqa. From there, you can run the deamon, test scripts, etc...
+- `make`: build a standard Zilliqa image for the latest commit on `master` branch
+- `make ci`: build CI image used by CI services for testing
+- `make k8s-zilliqa COMMIT=XXXXXXX`: build Zilliqa image for Kubernetes testnets
+- `make k8s-scilla COMMIT=XXXXXXX`: build Zilliqa image with Scilla for Kubernetes testnets


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR refactors the entire `docker/` folder to achieve the following goals

- sort out dependencies and put them in different dockerfiles for different usage
- use working-directory-independent build instructions in main Dockerfile

It also disables the `deploy` stage on Travis due to long waiting time caused by high workloads. Now the developer with access to the private docker registry have to build and push images manually through `scripts/make_image.sh`. Read more in the help message `scripts/make_image.sh --help`

## Review Suggestion

<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (commit: c956af1)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
