### PR TITLE
Buffer final block consensus msg when in FINALBLOCK_CONSENSUS_PREP state

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -440,9 +440,10 @@ bool DirectoryService::ProcessFinalBlockConsensus(
                 "Ignoring final block consensus message");
       return false;
     }
-    // Only buffer the Final block consensus message if in MICROBLOCK_SUBMISSION
-    // or VIEWCHANGE_CONSENSUS state
+    // Only buffer the Final block consensus message if in the immediate states
+    // before consensus, or when doing view change
     if (!((m_state == MICROBLOCK_SUBMISSION) ||
+          (m_state == FINALBLOCK_CONSENSUS_PREP) ||
           (m_state == VIEWCHANGE_CONSENSUS))) {
       LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
                 "Ignoring final block consensus message");


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Final block consensus messages are currently buffered in two states: `MICROBLOCK_SUBMISSION` and `VIEWCHANGE_CONSENSUS`.  They should also be buffered just before the start of the consensus, which is state `FINALBLOCK_CONSENSUS_PREP`.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
