### PR TITLE
[testnetv4-dev] Avoid commit window when NUM_CONSENSUS_SUBSETS=1

### DIFF
--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -21,7 +21,11 @@
 #include "common/Constants.h"
 #include "common/Messages.h"
 #include "libMessage/Messenger.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "libMessage/ZilliqaMessage.pb.h"
+#pragma GCC diagnostic pop
+
 #include "libNetwork/P2PComm.h"
 #include "libUtils/BitVector.h"
 #include "libUtils/DataConversion.h"

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -103,7 +103,6 @@ void ConsensusLeader::SetStateSubset(uint16_t subsetID, State newState) {
 
 void ConsensusLeader::GenerateConsensusSubsets() {
   LOG_MARKER();
-  lock_guard<mutex> g(m_mutex);
 
   // Get the list of all the peers who committed, by peer index
   vector<unsigned int> peersWhoCommitted;
@@ -173,7 +172,6 @@ void ConsensusLeader::GenerateConsensusSubsets() {
 
 void ConsensusLeader::StartConsensusSubsets() {
   LOG_MARKER();
-  lock_guard<mutex> g(m_mutex);
 
   ConsensusMessageType type;
   // Update overall internal state
@@ -328,12 +326,21 @@ bool ConsensusLeader::ProcessMessageCommitCore(
       m_commitRedundantCounter++;
     }
 
-    // notify the waiting thread to start with subset creations and subset
-    // consensus.
-    if (m_commitCounter == m_committee.size()) {
-      lock_guard<mutex> g(m_mutexAnnounceSubsetConsensus);
-      m_allCommitsReceived = true;
-      cv_scheduleSubsetConsensus.notify_all();
+    if (NUM_CONSENSUS_SUBSETS > 1) {
+      // notify the waiting thread to start with subset creations and subset
+      // consensus.
+      if (m_commitCounter == m_committee.size()) {
+        lock_guard<mutex> g(m_mutexAnnounceSubsetConsensus);
+        m_allCommitsReceived = true;
+        cv_scheduleSubsetConsensus.notify_all();
+      }
+    } else {
+      if (m_commitCounter == m_numForConsensus) {
+        LOG_GENERAL(INFO, "Sufficient commits obtained. Required/Actual = "
+                              << m_commitCounter);
+        GenerateConsensusSubsets();
+        StartConsensusSubsets();
+      }
     }
   }
 
@@ -613,7 +620,7 @@ bool ConsensusLeader::ProcessMessageResponseCore(
         P2PComm::GetInstance().SendMessage(peerInfo, collectivesig);
       }
 
-      if (m_state == COLLECTIVESIG_DONE) {
+      if ((m_state == COLLECTIVESIG_DONE) && (NUM_CONSENSUS_SUBSETS > 1)) {
         // Start timer for accepting final commits
         // =================================
         auto func = [this]() -> void {
@@ -641,6 +648,7 @@ bool ConsensusLeader::ProcessMessageResponseCore(
                 INFO,
                 "Sufficient final commits obtained after timeout. Required = "
                     << m_numForConsensus << " Actual = " << m_commitCounter);
+            lock_guard<mutex> g(m_mutex);
             GenerateConsensusSubsets();
             StartConsensusSubsets();
           }
@@ -826,35 +834,40 @@ bool ConsensusLeader::StartConsensus(
 
     P2PComm::GetInstance().SendMessage(peer, announcement_message);
   }
-  // Start timer for accepting commits
-  // =================================
-  auto func = [this]() -> void {
-    std::unique_lock<std::mutex> cv_lk(m_mutexAnnounceSubsetConsensus);
-    m_allCommitsReceived = false;
-    if (cv_scheduleSubsetConsensus.wait_for(
-            cv_lk, std::chrono::seconds(COMMIT_WINDOW_IN_SECONDS),
-            [&] { return m_allCommitsReceived; })) {
-      LOG_GENERAL(INFO, "Received all commits within the Commit window. !!");
-    } else {
-      LOG_GENERAL(
-          INFO,
-          "Timeout - Commit window closed. Will process commits received !!");
-    }
 
-    if (m_commitCounter < m_numForConsensus) {
-      LOG_GENERAL(WARNING,
-                  "Insufficient commits obtained after timeout. Required = "
+  if (NUM_CONSENSUS_SUBSETS > 1) {
+    // Start timer for accepting commits
+    // =================================
+    auto func = [this]() -> void {
+      std::unique_lock<std::mutex> cv_lk(m_mutexAnnounceSubsetConsensus);
+      m_allCommitsReceived = false;
+      if (cv_scheduleSubsetConsensus.wait_for(
+              cv_lk, std::chrono::seconds(COMMIT_WINDOW_IN_SECONDS),
+              [&] { return m_allCommitsReceived; })) {
+        LOG_GENERAL(INFO, "Received all commits within the Commit window. !!");
+      } else {
+        LOG_GENERAL(
+            INFO,
+            "Timeout - Commit window closed. Will process commits received !!");
+      }
+
+      if (m_commitCounter < m_numForConsensus) {
+        LOG_GENERAL(WARNING,
+                    "Insufficient commits obtained after timeout. Required = "
+                        << m_numForConsensus
+                        << " Actual = " << m_commitCounter);
+        m_state = ERROR;
+      } else {
+        LOG_GENERAL(
+            INFO, "Sufficient commits obtained after timeout. Required = "
                       << m_numForConsensus << " Actual = " << m_commitCounter);
-      m_state = ERROR;
-    } else {
-      LOG_GENERAL(INFO, "Sufficient commits obtained after timeout. Required = "
-                            << m_numForConsensus
-                            << " Actual = " << m_commitCounter);
-      GenerateConsensusSubsets();
-      StartConsensusSubsets();
-    }
-  };
-  DetachedFunction(1, func);
+        lock_guard<mutex> g(m_mutex);
+        GenerateConsensusSubsets();
+        StartConsensusSubsets();
+      }
+    };
+    DetachedFunction(1, func);
+  }
 
   return true;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Previous behavior before the consensus subsets were implemented was to proceed with challenge phase when we receive the minimum 2/3 commits.

After subsets was implemented, we now have a time window to receive as many commits as we want, even above the minimum 2/3.

This PR brings back the old behavior (just receive minimum commits, no timer) when we set `NUM_CONSENSUS_SUBSETS` to 1 in the constants file.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
