### PR TITLE
Fix Sha2 wrapper Update() when input is empty

### DIFF
--- a/src/libCrypto/Sha2.h
+++ b/src/libCrypto/Sha2.h
@@ -55,8 +55,8 @@ class SHA2 {
   /// Hash update function.
   void Update(const std::vector<unsigned char>& input) {
     if (input.size() <= 0) {
-      LOG_GENERAL(FATAL, "assertion failed (" << __FILE__ << ":" << __LINE__
-                                              << ": " << __FUNCTION__ << ")");
+      LOG_GENERAL(WARNING, "Nothing to update");
+      return;
     }
 
     SHA256_Update(&m_context, input.data(), input.size());

--- a/src/libCrypto/Sha2.h
+++ b/src/libCrypto/Sha2.h
@@ -54,7 +54,7 @@ class SHA2 {
 
   /// Hash update function.
   void Update(const std::vector<unsigned char>& input) {
-    if (input.size() <= 0) {
+    if (input.size() == 0) {
       LOG_GENERAL(WARNING, "Nothing to update");
       return;
     }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR fixes Sha2 wrapper Update() function when input is empty. 
- Remove LOG FATAL and replace it with an warning and returning from the function. This is because, if the input is empty, there will be nothing to update() and the hash value is the same. 

This PR also change `<= 0` to `== 0` as `size()` of `vector` will never be negative. 


## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~small-scale cloud test~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
