### PR TITLE
Trim the num of shard nodes to avoid going beyond COMM_SIZE

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -379,7 +379,7 @@ bool DirectoryService::VerifyPoWOrdering(
                                    << MISORDER_TOLERANCE << " = "
                                    << MAX_MISORDER_NODE << " nodes.");
 
-  auto sortedPoWSolns = SortPoWSoln(m_allPoWs);
+  auto sortedPoWSolns = SortPoWSoln(m_allPoWs, true);
   InjectPoWForDSNode(sortedPoWSolns,
                      m_pendingDSBlock->GetHeader().GetDSPoWWinners().size());
   if (DEBUG_LEVEL >= 5) {
@@ -609,16 +609,36 @@ void DirectoryService::ComputeTxnSharingAssignments(
   }
 }
 
-VectorOfPoWSoln DirectoryService::SortPoWSoln(const MapOfPubKeyPoW& mapOfPoWs) {
+VectorOfPoWSoln DirectoryService::SortPoWSoln(const MapOfPubKeyPoW& mapOfPoWs,
+                                              bool trimBeyondCommSize) {
   std::map<array<unsigned char, 32>, PubKey> PoWOrderSorter;
   for (const auto& powsoln : mapOfPoWs) {
     PoWOrderSorter[powsoln.second.result] = powsoln.first;
   }
 
-  // Put it back to vector for easy manipilation and adjustment of the ordering
+  // Put it back to vector for easy manipulation and adjustment of the ordering
   VectorOfPoWSoln sortedPoWSolns;
-  for (const auto& kv : PoWOrderSorter) {
-    sortedPoWSolns.emplace_back(kv);
+  if (trimBeyondCommSize && (COMM_SIZE > 0)) {
+    const unsigned int numNodesTotal = PoWOrderSorter.size();
+    const unsigned int numNodesTrimmed =
+        (numNodesTotal < COMM_SIZE)
+            ? numNodesTotal
+            : numNodesTotal - (numNodesTotal % COMM_SIZE);
+
+    LOG_GENERAL(INFO, "Trimming the solutions sorted list from "
+                          << numNodesTotal << " to " << numNodesTrimmed
+                          << " to avoid going over COMM_SIZE " << COMM_SIZE);
+
+    unsigned int count = 0;
+    for (auto kv = PoWOrderSorter.begin();
+         (kv != PoWOrderSorter.end()) && (count < numNodesTrimmed);
+         kv++, count++) {
+      sortedPoWSolns.emplace_back(*kv);
+    }
+  } else {
+    for (const auto& kv : PoWOrderSorter) {
+      sortedPoWSolns.emplace_back(kv);
+    }
   }
   return sortedPoWSolns;
 }
@@ -641,7 +661,7 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
   lock_guard<mutex> g2(m_mutexAllPoWConns, adopt_lock);
 
   auto sortedDSPoWSolns = SortPoWSoln(m_allDSPoWs);
-  auto sortedPoWSolns = SortPoWSoln(m_allPoWs);
+  auto sortedPoWSolns = SortPoWSoln(m_allPoWs, true);
 
   map<PubKey, Peer> powDSWinners;
   MapOfPubKeyPoW dsWinnerPoWs;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -551,7 +551,8 @@ class DirectoryService : public Executable, public Broadcastable {
 
   // Sort the PoW submissions. Put to public static function, so it can be
   // covered by auto test.
-  static VectorOfPoWSoln SortPoWSoln(const MapOfPubKeyPoW& pows);
+  static VectorOfPoWSoln SortPoWSoln(const MapOfPubKeyPoW& pows,
+                                     bool trimBeyondCommSize = false);
   int64_t GetAllPoWSize() const;
 
  private:


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
If we use `COMM_SIZE` in the constants file, we want to avoid this scenario:

1200 nodes --> 2 shards, 600 nodes each
1199 nodes --> 1 shard, 1199 nodes

To avoid this, we trim the extra nodes beyond multiples of `COMM_SIZE` in `SortPoWSoln`.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
