### PR TITLE
protobuf swinfo serialize and deserialize

### DIFF
--- a/src/libMessage/CMakeLists.txt
+++ b/src/libMessage/CMakeLists.txt
@@ -1,5 +1,11 @@
 protobuf_generate_cpp(PROTO_SRC PROTO_HEADER Message.proto ZilliqaMessage.proto)
+
 add_library (Message ${PROTO_HEADER} ${PROTO_SRC} Messenger.cpp MessengerAccountStoreBase.cpp)
 target_compile_options(Message PRIVATE "-Wno-unused-parameter")
 target_include_directories (Message PUBLIC ${PROJECT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
 target_link_libraries (Message PUBLIC ${PROTOBUF_LIBRARY} AccountData Block BlockHeader Utils)
+
+add_library (MessageSWInfo ${PROTO_HEADER} ${PROTO_SRC} MessengerSWInfo.cpp)
+target_compile_options(MessageSWInfo PRIVATE "-Wno-unused-parameter")
+target_include_directories (MessageSWInfo PUBLIC ${PROJECT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
+target_link_libraries (MessageSWInfo PUBLIC ${PROTOBUF_LIBRARY} Utils)

--- a/src/libMessage/MessengerSWInfo.cpp
+++ b/src/libMessage/MessengerSWInfo.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 Zilliqa
+ * This source code is being disclosed to you solely for the purpose of your
+ * participation in testing Zilliqa. You may view, compile and run the code for
+ * that purpose and pursuant to the protocols and algorithms that are programmed
+ * into, and intended by, the code. You may not do anything else with the code
+ * without express permission from Zilliqa Research Pte. Ltd., including
+ * modifying or publishing the code (or any part of it), and developing or
+ * forming another public or private blockchain network. This source code is
+ * provided 'as is' and no warranties are given as to title or non-infringement,
+ * merchantability or fitness for purpose and, to the extent permitted by law,
+ * all liability for your use of the code is disclaimed. Some programs in this
+ * code are governed by the GNU General Public License v3.0 (available at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html) ('GPLv3'). The programs that
+ * are governed by GPLv3.0 are those programs that are located in the folders
+ * src/depends and tests/depends and which include a reference to GPLv3 in their
+ * program files.
+ */
+
+#include "MessengerSWInfo.h"
+#include "libMessage/ZilliqaMessage.pb.h"
+#include "libUtils/Logger.h"
+#include "libUtils/SWInfo.h"
+
+using namespace std;
+using namespace ZilliqaMessage;
+
+template <class T = ProtoSWInfo>
+bool SerializeToArray(const T& protoMessage, vector<unsigned char>& dst,
+                      const unsigned int offset) {
+  if ((offset + protoMessage.ByteSize()) > dst.size()) {
+    dst.resize(offset + protoMessage.ByteSize());
+  }
+
+  return protoMessage.SerializeToArray(dst.data() + offset,
+                                       protoMessage.ByteSize());
+}
+
+void SWInfoToProtobuf(const SWInfo& swInfo, ProtoSWInfo& protoSWInfo) {
+  protoSWInfo.set_major(swInfo.GetMajor());
+  protoSWInfo.set_minor(swInfo.GetMinor());
+  protoSWInfo.set_fix(swInfo.GetFix());
+  protoSWInfo.set_upgradeds(swInfo.GetUpgradeDS());
+  protoSWInfo.set_commit(swInfo.GetCommit());
+}
+
+void ProtobufToSWInfo(const ProtoSWInfo& protoSWInfo, SWInfo& swInfo) {
+  swInfo = SWInfo(protoSWInfo.major(), protoSWInfo.minor(), protoSWInfo.fix(),
+                  protoSWInfo.upgradeds(), protoSWInfo.commit());
+}
+
+bool MessengerSWInfo::SetSWInfo(std::vector<unsigned char>& dst,
+                                const unsigned int offset,
+                                const SWInfo& swInfo) {
+  ProtoSWInfo result;
+
+  SWInfoToProtobuf(swInfo, result);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "SWInfo initialization failed.");
+    return false;
+  }
+
+  return SerializeToArray(result, dst, offset);
+}
+
+bool MessengerSWInfo::GetSWInfo(const std::vector<unsigned char>& src,
+                                const unsigned int offset, SWInfo& swInfo) {
+  ProtoSWInfo result;
+
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "SWInfo initialization failed.");
+    return false;
+  }
+
+  ProtobufToSWInfo(result, swInfo);
+
+  return true;
+}

--- a/src/libMessage/MessengerSWInfo.h
+++ b/src/libMessage/MessengerSWInfo.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Zilliqa
+ * This source code is being disclosed to you solely for the purpose of your
+ * participation in testing Zilliqa. You may view, compile and run the code for
+ * that purpose and pursuant to the protocols and algorithms that are programmed
+ * into, and intended by, the code. You may not do anything else with the code
+ * without express permission from Zilliqa Research Pte. Ltd., including
+ * modifying or publishing the code (or any part of it), and developing or
+ * forming another public or private blockchain network. This source code is
+ * provided 'as is' and no warranties are given as to title or non-infringement,
+ * merchantability or fitness for purpose and, to the extent permitted by law,
+ * all liability for your use of the code is disclaimed. Some programs in this
+ * code are governed by the GNU General Public License v3.0 (available at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html) ('GPLv3'). The programs that
+ * are governed by GPLv3.0 are those programs that are located in the folders
+ * src/depends and tests/depends and which include a reference to GPLv3 in their
+ * program files.
+ */
+#ifndef __MESSENGERSWINFO_H__
+#define __MESSENGERSWINFO_H__
+
+#include <vector>
+
+// This class is only used by AccountStoreBase template class
+// If AccountStoreBase.tpp included Messenger.h, we enter into some circular
+// dependency issue Putting the messenger functions below into this new class
+// avoids that issue
+
+class SWInfo;
+
+class MessengerSWInfo {
+ public:
+  // ============================================================================
+  // Primitives
+  // ============================================================================
+
+  static bool GetSWInfo(const std::vector<unsigned char>& src,
+                        const unsigned int offset, SWInfo& swInfo);
+
+  static bool SetSWInfo(std::vector<unsigned char>& dst,
+                        const unsigned int offset, const SWInfo& swInfo);
+};
+
+#endif  // __MESSENGERSWINFO_H__

--- a/src/libMessage/MessengerSWInfo.h
+++ b/src/libMessage/MessengerSWInfo.h
@@ -21,11 +21,6 @@
 
 #include <vector>
 
-// This class is only used by AccountStoreBase template class
-// If AccountStoreBase.tpp included Messenger.h, we enter into some circular
-// dependency issue Putting the messenger functions below into this new class
-// avoids that issue
-
 class SWInfo;
 
 class MessengerSWInfo {

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -165,6 +165,15 @@ message ProtoTransactionWithReceipt
     required ProtoTransactionReceipt receipt = 2;
 }
 
+message ProtoSWInfo
+{
+    required uint32 major       = 1;
+    required uint32 minor       = 2;
+    required uint32 fix         = 3;
+    required uint64 upgradeds   = 4;
+    required uint32 commit      = 5;
+}
+
 message ProtoDSBlock
 {
     message DSBlockHashSet

--- a/src/libUtils/CMakeLists.txt
+++ b/src/libUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(Utils BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp)
 target_include_directories(Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Crypto Boost ${G3LOG_INCLUDE_DIRS})
 target_link_libraries(Utils INTERFACE Threads::Threads curl)
-target_link_libraries(Utils PUBLIC g3logger Constants)
+target_link_libraries(Utils PUBLIC g3logger Constants MessageSWInfo)

--- a/src/libUtils/SWInfo.cpp
+++ b/src/libUtils/SWInfo.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "SWInfo.h"
+#include "libMessage/MessengerSWInfo.h"
 #include "libUtils/Logger.h"
 
 using namespace std;
@@ -44,54 +45,25 @@ SWInfo::SWInfo(const SWInfo& src)
 SWInfo::~SWInfo(){};
 
 /// Implements the Serialize function inherited from Serializable.
-unsigned int SWInfo::Serialize(std::vector<unsigned char>& dst,
-                               unsigned int offset) const {
-  LOG_MARKER();
-
-  if ((offset + SIZE) > dst.size()) {
-    dst.resize(offset + SIZE);
+bool SWInfo::Serialize(std::vector<unsigned char>& dst,
+                       unsigned int offset) const {
+  if (!MessengerSWInfo::SetSWInfo(dst, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::SetSWInfo failed.");
+    return false;
   }
 
-  unsigned int curOffset = offset;
-
-  SetNumber<uint32_t>(dst, curOffset, m_major, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_minor, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_fix, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-  SetNumber<uint64_t>(dst, curOffset, m_upgradeDS, sizeof(uint64_t));
-  curOffset += sizeof(uint64_t);
-  SetNumber<uint32_t>(dst, curOffset, m_commit, sizeof(uint32_t));
-  curOffset += sizeof(uint32_t);
-
-  return SIZE;
+  return true;
 }
 
 /// Implements the Deserialize function inherited from Serializable.
-int SWInfo::Deserialize(const std::vector<unsigned char>& src,
-                        unsigned int offset) {
-  LOG_MARKER();
-
-  unsigned int curOffset = offset;
-
-  try {
-    m_major = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_minor = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_fix = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-    m_upgradeDS = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
-    curOffset += sizeof(uint64_t);
-    m_commit = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
-    curOffset += sizeof(uint32_t);
-  } catch (const std::exception& e) {
-    LOG_GENERAL(WARNING, "Error with SWInfo::Deserialize." << ' ' << e.what());
-    return -1;
+bool SWInfo::Deserialize(const std::vector<unsigned char>& src,
+                         unsigned int offset) {
+  if (!MessengerSWInfo::GetSWInfo(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetSWInfo failed.");
+    return false;
   }
 
-  return 0;
+  return true;
 }
 
 /// Less-than comparison operator.
@@ -112,4 +84,9 @@ bool SWInfo::operator==(const SWInfo& r) const {
 /// Unequality operator.
 bool SWInfo::operator!=(const SWInfo& r) const { return !(*this == r); }
 
+/// Getters.
+const uint32_t& SWInfo::GetMajor() const { return m_major; };
+const uint32_t& SWInfo::GetMinor() const { return m_minor; };
+const uint32_t& SWInfo::GetFix() const { return m_fix; };
 const uint64_t& SWInfo::GetUpgradeDS() const { return m_upgradeDS; };
+const uint32_t& SWInfo::GetCommit() const { return m_commit; };

--- a/src/libUtils/SWInfo.cpp
+++ b/src/libUtils/SWInfo.cpp
@@ -48,7 +48,7 @@ SWInfo::~SWInfo(){};
 bool SWInfo::Serialize(std::vector<unsigned char>& dst,
                        unsigned int offset) const {
   if (!MessengerSWInfo::SetSWInfo(dst, offset, *this)) {
-    LOG_GENERAL(WARNING, "Messenger::SetSWInfo failed.");
+    LOG_GENERAL(WARNING, "MessengerSWInfo::SetSWInfo failed.");
     return false;
   }
 
@@ -59,7 +59,7 @@ bool SWInfo::Serialize(std::vector<unsigned char>& dst,
 bool SWInfo::Deserialize(const std::vector<unsigned char>& src,
                          unsigned int offset) {
   if (!MessengerSWInfo::GetSWInfo(src, offset, *this)) {
-    LOG_GENERAL(WARNING, "Messenger::GetSWInfo failed.");
+    LOG_GENERAL(WARNING, "MessengerSWInfo::GetSWInfo failed.");
     return false;
   }
 

--- a/src/libUtils/SWInfo.h
+++ b/src/libUtils/SWInfo.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include "common/Serializable.h"
 
-class SWInfo : public Serializable {
+class SWInfo : public SerializableDataBlock {
   uint32_t m_major;
   uint32_t m_minor;
   uint32_t m_fix;
@@ -49,11 +49,10 @@ class SWInfo : public Serializable {
   SWInfo(const SWInfo&);
 
   /// Implements the Serialize function inherited from Serializable.
-  unsigned int Serialize(std::vector<unsigned char>& dst,
-                         unsigned int offset) const;
+  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Less-than comparison operator.
   bool operator<(const SWInfo& r) const;
@@ -67,8 +66,12 @@ class SWInfo : public Serializable {
   /// Unequality operator.
   bool operator!=(const SWInfo& r) const;
 
-  /// Returns the upgrade DS block number.
+  /// Getters.
+  const uint32_t& GetMajor() const;
+  const uint32_t& GetMinor() const;
+  const uint32_t& GetFix() const;
   const uint64_t& GetUpgradeDS() const;
+  const uint32_t& GetCommit() const;
 };
 
 #endif  // __SWINFO_H__


### PR DESCRIPTION
## Description
This PR does the conversion to Protobuf for `SWInfo`: https://github.com/Zilliqa/Zilliqa/issues/833

Since `Message` is already depending on `Utils` (for `Logger`), adding the new protobuf functions in `Message` will lead to cyclic dependency (as then `Utils` will also need to depend on `Message`). As such, I have created a new library `MessageSWInfo` and placed the protobuf functions for SWInfo inside it.

<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
* Make ProtoDSBlock to use ProtoSWInfo, if required
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
