### PR TITLE
Revert use of libMessage in Peer and SWInfo serialization

### DIFF
--- a/src/libNetwork/Peer.h
+++ b/src/libNetwork/Peer.h
@@ -27,7 +27,7 @@
 #include "common/Serializable.h"
 
 /// Stores IP information on a single Zilliqa peer.
-struct Peer : public SerializableDataBlock {
+struct Peer : public Serializable {
   /// Peer IP address (net-encoded)
   boost::multiprecision::uint128_t m_ipAddress;  // net-encoded
 
@@ -63,10 +63,11 @@ struct Peer : public SerializableDataBlock {
   }
 
   /// Implements the Serialize function inherited from Serializable.
-  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
+  unsigned int Serialize(std::vector<unsigned char>& dst,
+                         unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Getters.
   const boost::multiprecision::uint128_t& GetIpAddress() const;

--- a/src/libUtils/SWInfo.cpp
+++ b/src/libUtils/SWInfo.cpp
@@ -45,25 +45,54 @@ SWInfo::SWInfo(const SWInfo& src)
 SWInfo::~SWInfo(){};
 
 /// Implements the Serialize function inherited from Serializable.
-bool SWInfo::Serialize(std::vector<unsigned char>& dst,
-                       unsigned int offset) const {
-  if (!MessengerSWInfo::SetSWInfo(dst, offset, *this)) {
-    LOG_GENERAL(WARNING, "MessengerSWInfo::SetSWInfo failed.");
-    return false;
+unsigned int SWInfo::Serialize(std::vector<unsigned char>& dst,
+                               unsigned int offset) const {
+  LOG_MARKER();
+
+  if ((offset + SIZE) > dst.size()) {
+    dst.resize(offset + SIZE);
   }
 
-  return true;
+  unsigned int curOffset = offset;
+
+  SetNumber<uint32_t>(dst, curOffset, m_major, sizeof(uint32_t));
+  curOffset += sizeof(uint32_t);
+  SetNumber<uint32_t>(dst, curOffset, m_minor, sizeof(uint32_t));
+  curOffset += sizeof(uint32_t);
+  SetNumber<uint32_t>(dst, curOffset, m_fix, sizeof(uint32_t));
+  curOffset += sizeof(uint32_t);
+  SetNumber<uint64_t>(dst, curOffset, m_upgradeDS, sizeof(uint64_t));
+  curOffset += sizeof(uint64_t);
+  SetNumber<uint32_t>(dst, curOffset, m_commit, sizeof(uint32_t));
+  curOffset += sizeof(uint32_t);
+
+  return SIZE;
 }
 
 /// Implements the Deserialize function inherited from Serializable.
-bool SWInfo::Deserialize(const std::vector<unsigned char>& src,
-                         unsigned int offset) {
-  if (!MessengerSWInfo::GetSWInfo(src, offset, *this)) {
-    LOG_GENERAL(WARNING, "MessengerSWInfo::GetSWInfo failed.");
-    return false;
+int SWInfo::Deserialize(const std::vector<unsigned char>& src,
+                        unsigned int offset) {
+  LOG_MARKER();
+
+  unsigned int curOffset = offset;
+
+  try {
+    m_major = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    curOffset += sizeof(uint32_t);
+    m_minor = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    curOffset += sizeof(uint32_t);
+    m_fix = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    curOffset += sizeof(uint32_t);
+    m_upgradeDS = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
+    curOffset += sizeof(uint64_t);
+    m_commit = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    curOffset += sizeof(uint32_t);
+  } catch (const std::exception& e) {
+    LOG_GENERAL(WARNING, "Error with SWInfo::Deserialize." << ' ' << e.what());
+    return -1;
   }
 
-  return true;
+  return 0;
 }
 
 /// Less-than comparison operator.

--- a/src/libUtils/SWInfo.h
+++ b/src/libUtils/SWInfo.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 #include "common/Serializable.h"
 
-class SWInfo : public SerializableDataBlock {
+class SWInfo : public Serializable {
   uint32_t m_major;
   uint32_t m_minor;
   uint32_t m_fix;
@@ -49,10 +49,11 @@ class SWInfo : public SerializableDataBlock {
   SWInfo(const SWInfo&);
 
   /// Implements the Serialize function inherited from Serializable.
-  bool Serialize(std::vector<unsigned char>& dst, unsigned int offset) const;
+  unsigned int Serialize(std::vector<unsigned char>& dst,
+                         unsigned int offset) const;
 
   /// Implements the Deserialize function inherited from Serializable.
-  bool Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
+  int Deserialize(const std::vector<unsigned char>& src, unsigned int offset);
 
   /// Less-than comparison operator.
   bool operator<(const SWInfo& r) const;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`Peer` and `SWInfo` serialization were modified in recent PRs #843 and #845 but the test scripts are still using the old serialization, preventing bootstrap from working.  Reverting the serialization to the old way until the test scripts are updated.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
