### PR TITLE
Use log fatal instead of assert in rumourholder.cpp

### DIFF
--- a/src/libRumorSpreading/RumorHolder.cpp
+++ b/src/libRumorSpreading/RumorHolder.cpp
@@ -101,7 +101,7 @@ RumorHolder::RumorHolder(const std::unordered_set<int>& peers,
   if (networkConfig.networkSize() != peers.size()) {
     LOG_GENERAL(
         FATAL,
-        "size of netoworkConfig does not match size of pees. networkConfig: "
+        "size of netoworkConfig does not match size of peers. networkConfig: "
             << networkConfig.networkSize() << " peers: " << peers.size());
   }
   toVector(peers);
@@ -138,7 +138,7 @@ RumorHolder::RumorHolder(const std::unordered_set<int>& peers,
   if (networkConfig.networkSize() != peers.size()) {
     LOG_GENERAL(
         FATAL,
-        "size of netoworkConfig does not match size of pees. networkConfig: "
+        "size of netoworkConfig does not match size of peers. networkConfig: "
             << networkConfig.networkSize() << " peers: " << peers.size());
   }
   toVector(peers);

--- a/src/libRumorSpreading/RumorHolder.cpp
+++ b/src/libRumorSpreading/RumorHolder.cpp
@@ -20,7 +20,6 @@
 #include "RumorHolder.h"
 #include "libUtils/Logger.h"
 
-#include <cassert>
 #include <random>
 
 #define LITERAL(s) #s
@@ -99,7 +98,12 @@ RumorHolder::RumorHolder(const std::unordered_set<int>& peers,
       m_nextMemberCb(),
       m_statistics(),
       m_maxNeighborsPerRound(1) {
-  assert(networkConfig.networkSize() == peers.size());
+  if (networkConfig.networkSize() != peers.size()) {
+    LOG_GENERAL(
+        FATAL,
+        "size of netoworkConfig does not match size of pees. networkConfig: "
+            << networkConfig.networkSize() << " peers: " << peers.size());
+  }
   toVector(peers);
 }
 
@@ -131,7 +135,12 @@ RumorHolder::RumorHolder(const std::unordered_set<int>& peers,
       m_nextMemberCb(cb),
       m_statistics(),
       m_maxNeighborsPerRound(1) {
-  assert(networkConfig.networkSize() == peers.size());
+  if (networkConfig.networkSize() != peers.size()) {
+    LOG_GENERAL(
+        FATAL,
+        "size of netoworkConfig does not match size of pees. networkConfig: "
+            << networkConfig.networkSize() << " peers: " << peers.size());
+  }
   toVector(peers);
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
As the build is in release mode, `assert` will not be trigger. This PR replace `assert` in `rumourholder.cpp` with LOG FATAL. 

Note: I did a scan of usage of assert in the Zilliqa codebase (exclude depends) and this is the only place it was found.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: 085907608b9e3073de8a751eceaf405f10d8d775)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
