### PR TITLE
LoadShardStructure with retrieve should not do rejoin

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -175,7 +175,7 @@ void Node::LogReceivedDSBlockDetails([[gnu::unused]] const DSBlock& dsblock) {
   }
 }
 
-bool Node::LoadShardingStructure() {
+bool Node::LoadShardingStructure(bool callByRetrieve) {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "Node::LoadShardingStructure not expected to be called "
@@ -224,7 +224,7 @@ bool Node::LoadShardingStructure() {
     index++;
   }
 
-  if (!foundMe) {
+  if (!foundMe && !callByRetrieve) {
     LOG_GENERAL(WARNING, "I'm not in the sharding structure, why?");
     RejoinAsNormal();
     return false;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -355,7 +355,7 @@ bool Node::StartRetrieveHistory(bool& wakeupForUpgrade) {
   /// Retrieve sharding structure and setup relative variables
   BlockStorage::GetBlockStorage().GetShardStructure(
       m_mediator.m_ds->m_shards, m_mediator.m_node->m_myshardId);
-  LoadShardingStructure();
+  LoadShardingStructure(true);
   m_mediator.m_ds->ProcessShardingStructure(
       m_mediator.m_ds->m_shards, m_mediator.m_ds->m_publicKeyToshardIdMap,
       m_mediator.m_ds->m_mapNodeReputation);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -532,7 +532,7 @@ class Node : public Executable, public Broadcastable {
   void CommitTxnPacketBuffer();
 
   /// Used by oldest DS node to configure sharding variables as a new shard node
-  bool LoadShardingStructure();
+  bool LoadShardingStructure(bool callByRetrieve = false);
 
   /// Used by oldest DS node to configure txn sharing assignments as a new shard
   /// node


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Upgrading mechanism would call LoadShardStructure() to fill some parameters. In that case, node rejoin should not be called when it not belongs to any shard member. (i.e. DS node)

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
<del>- [ ] local machine test</del>
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (200 nodes)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
