### PR TITLE
Remove the dependency on GENESIS_KEYS

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -130,18 +130,15 @@ bool Lookup::GenTxnToSend(size_t num_txn,
                           uint32_t numShards) {
   vector<Transaction> txns;
 
-  if (GENESIS_KEYS.size() == 0) {
-    LOG_GENERAL(WARNING, "No genesis keys found");
+  if (GENESIS_WALLETS.size() == 0) {
+    LOG_GENERAL(WARNING, "No genesis accounts found");
     return false;
   }
 
-  unsigned int NUM_TXN_TO_DS = num_txn / GENESIS_KEYS.size();
+  unsigned int NUM_TXN_TO_DS = num_txn / GENESIS_WALLETS.size();
 
-  for (auto& privKeyHexStr : GENESIS_KEYS) {
-    auto privKeyBytes{DataConversion::HexStrToUint8Vec(privKeyHexStr)};
-    auto privKey = PrivKey{privKeyBytes, 0};
-    auto pubKey = PubKey{privKey};
-    auto addr = Account::GetAddressFromPublicKey(pubKey);
+  for (auto& addrStr : GENESIS_WALLETS) {
+    Address addr{DataConversion::HexStrToUint8Vec(addrStr)};
 
     if (numShards == 0) {
       return false;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Lookup node does not require genesis keys to generate the testing transaction anymore. This PR removes the use of GENESIS_KEYS in lookup code, as a necessary step to get https://github.com/Zilliqa/testnet/pull/190 work.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

N/A

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (commit: 74f637a)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
