### PR TITLE
Rename SWInfo container to prevent the naming confliction for GCC 7.3.0

### DIFF
--- a/src/libMessage/MessengerSWInfo.cpp
+++ b/src/libMessage/MessengerSWInfo.cpp
@@ -37,16 +37,17 @@ bool SerializeToArray(const T& protoMessage, vector<unsigned char>& dst,
 }
 
 void SWInfoToProtobuf(const SWInfo& swInfo, ProtoSWInfo& protoSWInfo) {
-  protoSWInfo.set_major(swInfo.GetMajor());
-  protoSWInfo.set_minor(swInfo.GetMinor());
-  protoSWInfo.set_fix(swInfo.GetFix());
+  protoSWInfo.set_majorversion(swInfo.GetMajorVersion());
+  protoSWInfo.set_minorversion(swInfo.GetMinorVersion());
+  protoSWInfo.set_fixversion(swInfo.GetFixVersion());
   protoSWInfo.set_upgradeds(swInfo.GetUpgradeDS());
   protoSWInfo.set_commit(swInfo.GetCommit());
 }
 
 void ProtobufToSWInfo(const ProtoSWInfo& protoSWInfo, SWInfo& swInfo) {
-  swInfo = SWInfo(protoSWInfo.major(), protoSWInfo.minor(), protoSWInfo.fix(),
-                  protoSWInfo.upgradeds(), protoSWInfo.commit());
+  swInfo = SWInfo(protoSWInfo.majorversion(), protoSWInfo.minorversion(),
+                  protoSWInfo.fixversion(), protoSWInfo.upgradeds(),
+                  protoSWInfo.commit());
 }
 
 bool MessengerSWInfo::SetSWInfo(std::vector<unsigned char>& dst,

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -175,11 +175,11 @@ message ProtoTransactionWithReceipt
 
 message ProtoSWInfo
 {
-    required uint32 major       = 1;
-    required uint32 minor       = 2;
-    required uint32 fix         = 3;
-    required uint64 upgradeds   = 4;
-    required uint32 commit      = 5;
+    required uint32 majorversion        = 1;
+    required uint32 minorversion        = 2;
+    required uint32 fixversion          = 3;
+    required uint64 upgradeds           = 4;
+    required uint32 commit              = 5;
 }
 
 message ProtoDSBlock

--- a/src/libUtils/SWInfo.cpp
+++ b/src/libUtils/SWInfo.cpp
@@ -24,21 +24,25 @@
 using namespace std;
 
 SWInfo::SWInfo()
-    : m_major(0), m_minor(0), m_fix(0), m_upgradeDS(0), m_commit(0) {}
+    : m_majorVersion(0),
+      m_minorVersion(0),
+      m_fixVersion(0),
+      m_upgradeDS(0),
+      m_commit(0) {}
 
-SWInfo::SWInfo(const uint32_t& major, const uint32_t& minor,
-               const uint32_t& fix, const uint64_t& upgradeDS,
+SWInfo::SWInfo(const uint32_t& majorVersion, const uint32_t& minorVersion,
+               const uint32_t& fixVersion, const uint64_t& upgradeDS,
                const uint32_t& commit)
-    : m_major(major),
-      m_minor(minor),
-      m_fix(fix),
+    : m_majorVersion(majorVersion),
+      m_minorVersion(minorVersion),
+      m_fixVersion(fixVersion),
       m_upgradeDS(upgradeDS),
       m_commit(commit) {}
 
 SWInfo::SWInfo(const SWInfo& src)
-    : m_major(src.m_major),
-      m_minor(src.m_minor),
-      m_fix(src.m_fix),
+    : m_majorVersion(src.m_majorVersion),
+      m_minorVersion(src.m_minorVersion),
+      m_fixVersion(src.m_fixVersion),
       m_upgradeDS(src.m_upgradeDS),
       m_commit(src.m_commit) {}
 
@@ -55,11 +59,11 @@ unsigned int SWInfo::Serialize(std::vector<unsigned char>& dst,
 
   unsigned int curOffset = offset;
 
-  SetNumber<uint32_t>(dst, curOffset, m_major, sizeof(uint32_t));
+  SetNumber<uint32_t>(dst, curOffset, m_majorVersion, sizeof(uint32_t));
   curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_minor, sizeof(uint32_t));
+  SetNumber<uint32_t>(dst, curOffset, m_minorVersion, sizeof(uint32_t));
   curOffset += sizeof(uint32_t);
-  SetNumber<uint32_t>(dst, curOffset, m_fix, sizeof(uint32_t));
+  SetNumber<uint32_t>(dst, curOffset, m_fixVersion, sizeof(uint32_t));
   curOffset += sizeof(uint32_t);
   SetNumber<uint64_t>(dst, curOffset, m_upgradeDS, sizeof(uint64_t));
   curOffset += sizeof(uint64_t);
@@ -77,11 +81,11 @@ int SWInfo::Deserialize(const std::vector<unsigned char>& src,
   unsigned int curOffset = offset;
 
   try {
-    m_major = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    m_majorVersion = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
     curOffset += sizeof(uint32_t);
-    m_minor = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    m_minorVersion = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
     curOffset += sizeof(uint32_t);
-    m_fix = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
+    m_fixVersion = GetNumber<uint32_t>(src, curOffset, sizeof(uint32_t));
     curOffset += sizeof(uint32_t);
     m_upgradeDS = GetNumber<uint64_t>(src, curOffset, sizeof(uint64_t));
     curOffset += sizeof(uint64_t);
@@ -97,8 +101,9 @@ int SWInfo::Deserialize(const std::vector<unsigned char>& src,
 
 /// Less-than comparison operator.
 bool SWInfo::operator<(const SWInfo& r) const {
-  return tie(m_major, m_minor, m_fix, m_upgradeDS, m_commit) <
-         tie(r.m_major, r.m_minor, r.m_fix, r.m_upgradeDS, r.m_commit);
+  return tie(m_majorVersion, m_minorVersion, m_fixVersion, m_upgradeDS,
+             m_commit) < tie(r.m_majorVersion, r.m_minorVersion, r.m_fixVersion,
+                             r.m_upgradeDS, r.m_commit);
 }
 
 /// Greater-than comparison operator.
@@ -106,16 +111,17 @@ bool SWInfo::operator>(const SWInfo& r) const { return r < *this; }
 
 /// Equality operator.
 bool SWInfo::operator==(const SWInfo& r) const {
-  return tie(m_major, m_minor, m_fix, m_upgradeDS, m_commit) ==
-         tie(r.m_major, r.m_minor, r.m_fix, r.m_upgradeDS, r.m_commit);
+  return tie(m_majorVersion, m_minorVersion, m_fixVersion, m_upgradeDS,
+             m_commit) == tie(r.m_majorVersion, r.m_minorVersion,
+                              r.m_fixVersion, r.m_upgradeDS, r.m_commit);
 }
 
 /// Unequality operator.
 bool SWInfo::operator!=(const SWInfo& r) const { return !(*this == r); }
 
 /// Getters.
-const uint32_t& SWInfo::GetMajor() const { return m_major; };
-const uint32_t& SWInfo::GetMinor() const { return m_minor; };
-const uint32_t& SWInfo::GetFix() const { return m_fix; };
+const uint32_t& SWInfo::GetMajorVersion() const { return m_majorVersion; };
+const uint32_t& SWInfo::GetMinorVersion() const { return m_minorVersion; };
+const uint32_t& SWInfo::GetFixVersion() const { return m_fixVersion; };
 const uint64_t& SWInfo::GetUpgradeDS() const { return m_upgradeDS; };
 const uint32_t& SWInfo::GetCommit() const { return m_commit; };

--- a/src/libUtils/SWInfo.h
+++ b/src/libUtils/SWInfo.h
@@ -24,9 +24,9 @@
 #include "common/Serializable.h"
 
 class SWInfo : public Serializable {
-  uint32_t m_major;
-  uint32_t m_minor;
-  uint32_t m_fix;
+  uint32_t m_majorVersion;
+  uint32_t m_minorVersion;
+  uint32_t m_fixVersion;
   uint64_t m_upgradeDS;
   uint32_t m_commit;
 
@@ -39,8 +39,9 @@ class SWInfo : public Serializable {
   SWInfo();
 
   /// Constructor.
-  SWInfo(const uint32_t& major, const uint32_t& minor, const uint32_t& fix,
-         const uint64_t& upgradeDS, const uint32_t& commit);
+  SWInfo(const uint32_t& majorVersion, const uint32_t& minorVersion,
+         const uint32_t& fixVersion, const uint64_t& upgradeDS,
+         const uint32_t& commit);
 
   /// Destructor.
   ~SWInfo();
@@ -68,9 +69,9 @@ class SWInfo : public Serializable {
   bool operator!=(const SWInfo& r) const;
 
   /// Getters.
-  const uint32_t& GetMajor() const;
-  const uint32_t& GetMinor() const;
-  const uint32_t& GetFix() const;
+  const uint32_t& GetMajorVersion() const;
+  const uint32_t& GetMinorVersion() const;
+  const uint32_t& GetFixVersion() const;
   const uint64_t& GetUpgradeDS() const;
   const uint32_t& GetCommit() const;
 };


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Zilliqa/issues/853
"major" and "minor" is preserved word in GCC 7.3.0, thus we need to rename the variables of SWInfo.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<del>- [ ] small-scale cloud test</del>
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
