### PR TITLE
Avoid using set() when oom occurs in multisig.cpp

### DIFF
--- a/src/libCrypto/MultiSig.cpp
+++ b/src/libCrypto/MultiSig.cpp
@@ -138,9 +138,9 @@ CommitPoint::CommitPoint(const CommitSecret& secret)
   if (m_p == nullptr) {
     LOG_GENERAL(WARNING, "Memory allocation failure");
     // throw exception();
+  } else {
+    Set(secret);
   }
-
-  Set(secret);
 }
 
 CommitPoint::CommitPoint(const vector<unsigned char>& src,
@@ -255,9 +255,9 @@ Challenge::Challenge(const CommitPoint& aggregatedCommit,
   if (m_c == nullptr) {
     LOG_GENERAL(WARNING, "Memory allocation failure");
     // throw exception();
+  } else {
+    Set(aggregatedCommit, aggregatedPubkey, message, offset, size);
   }
-
-  Set(aggregatedCommit, aggregatedPubkey, message, offset, size);
 }
 
 Challenge::Challenge(const vector<unsigned char>& src, unsigned int offset) {
@@ -420,9 +420,9 @@ Response::Response(const CommitSecret& secret, const Challenge& challenge,
   if (m_r == nullptr) {
     LOG_GENERAL(WARNING, "Memory allocation failure");
     // throw exception();
+  } else {
+    Set(secret, challenge, privkey);
   }
-
-  Set(secret, challenge, privkey);
 }
 
 Response::Response(const vector<unsigned char>& src, unsigned int offset) {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In MulitSig.cpp, in certain constructors, it will proceeds to call set() even if memory allocation failed. This PR fixes this issue. In such case, the process will proceeds to de-reference a null ptr, resulting in segfault. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: 3d52f53994de79ec8dc656519f3a230135fe025f)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~small-scale cloud test~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
