### PR TITLE
Fix crash when do DS node rejoin

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1698,7 +1698,8 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
 
   if ((m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0) &&
       !ARCHIVAL_NODE) {
-    LOG_GENERAL(INFO, "At new DS epoch now, try getting state from lookup");
+    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+              "At new DS epoch now, try getting state from lookup");
     GetStateFromLookupNodes();
   }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -79,7 +79,7 @@ Node::Node(Mediator& mediator, [[gnu::unused]] unsigned int syncType,
 
 Node::~Node() {}
 
-bool Node::Install(unsigned int syncType, bool toRetrieveHistory) {
+bool Node::Install(SyncType syncType, bool toRetrieveHistory) {
   LOG_MARKER();
 
   // m_state = IDLE;
@@ -87,8 +87,9 @@ bool Node::Install(unsigned int syncType, bool toRetrieveHistory) {
 
   if (toRetrieveHistory) {
     bool wakeupForUpgrade = false;
+    bool retrieveSuccessButTooLate = false;
 
-    if (StartRetrieveHistory(wakeupForUpgrade)) {
+    if (StartRetrieveHistory(wakeupForUpgrade, retrieveSuccessButTooLate)) {
       m_mediator.m_currentEpochNum =
           m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() +
           1;
@@ -164,6 +165,13 @@ bool Node::Install(unsigned int syncType, bool toRetrieveHistory) {
         return true;
       }
     }
+
+    // When do node recovery, if retrieve the history success, then shouldn't
+    // continue to run add genesis account, but let the node to synchronize with
+    // lookup node.
+    if (retrieveSuccessButTooLate) {
+      return true;
+    }
   }
 
   if (runInitializeGenesisBlocks) {
@@ -232,7 +240,8 @@ void Node::Prepare(bool runInitializeGenesisBlocks) {
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1);
 }
 
-bool Node::StartRetrieveHistory(bool& wakeupForUpgrade) {
+bool Node::StartRetrieveHistory(bool& wakeupForUpgrade,
+                                bool& retrieveSuccessButTooLate) {
   LOG_MARKER();
 
   m_mediator.m_txBlockChain.Reset();
@@ -312,6 +321,7 @@ bool Node::StartRetrieveHistory(bool& wakeupForUpgrade) {
     }
 
     if (m_mediator.m_txBlockChain.GetBlockCount() > oldTxNum + 1) {
+      retrieveSuccessButTooLate = true;
       LOG_GENERAL(INFO,
                   "Node recovery too late, apply re-join process instead");
       return false;
@@ -1118,7 +1128,7 @@ void Node::RejoinAsNormal() {
     auto func = [this]() mutable -> void {
       m_mediator.m_lookup->m_syncType = SyncType::NORMAL_SYNC;
       this->CleanVariables();
-      this->Install(true);
+      this->Install(SyncType::NORMAL_SYNC);
       this->StartSynchronization();
       this->ResetRejoinFlags();
     };

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -429,7 +429,7 @@ class Node : public Executable, public Broadcastable {
   ~Node();
 
   /// Install the Node
-  bool Install(unsigned int syncType, bool toRetrieveHistory = true);
+  bool Install(SyncType syncType, bool toRetrieveHistory = true);
 
   /// Set initial state, variables, and clean-up storage
   void Init();
@@ -460,7 +460,8 @@ class Node : public Executable, public Broadcastable {
   Mediator& GetMediator() { return m_mediator; }
 
   /// Recover the previous state by retrieving persistence data
-  bool StartRetrieveHistory(bool& wakeupForUpgrade);
+  bool StartRetrieveHistory(bool& wakeupForUpgrade,
+                            bool& retrieveSuccessButTooLate);
 
   // Erase m_committedTransactions for given epoch number
   // void EraseCommittedTransactions(uint64_t epochNum)

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -141,7 +141,7 @@ Zilliqa::Zilliqa(const std::pair<PrivKey, PubKey>& key, const Peer& peer,
   P2PComm::GetInstance().SetSelfPeer(peer);
 
   auto func = [this, toRetrieveHistory, syncType, key, peer]() mutable -> void {
-    if (!m_n.Install(syncType, toRetrieveHistory)) {
+    if (!m_n.Install((SyncType)syncType, toRetrieveHistory)) {
       if (LOOKUP_NODE_MODE) {
         syncType = SyncType::LOOKUP_SYNC;
       } else {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix node crash when do DS node rejoin.
<!-- What is the context of your pull request? -->
Function RejoinAsDS. it will call GetTxBlockFromLookupNodes, when the node receive the Tx blocks, it trigger ProcessSetTxBlockFromSeed, it success, it call CommitTxBlocks, then it will call GetStateFromLookupNodes, when it receive State which is accounts from lookup nodes, it need to operate it, but at the same time, Node::Init is called, two threads try to operate the AccountStore instance at the same time, so node crashed.
The document for this scenario in document.
https://docs.google.com/document/d/1KHEs3DGHGyoTi-YUVBGjG_wO5tpL2doAsqlT4ug9oiM/edit
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/308

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check code modified.
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
