### PR TITLE
Improve caching in image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ ARG BUILD_TYPE=RelWithDebInfo
 
 RUN git clone ${REPO} ${SOURCE_DIR} \
     && git -C ${SOURCE_DIR} checkout ${COMMIT} \
-    && git -C ${SOURCE_DIR} submodule update --init --recursive \
+    # && git -C ${SOURCE_DIR} submodule update --init --recursive \
     && cmake -H${SOURCE_DIR} -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
     && cmake --build ${BUILD_DIR} -- -j$(nproc) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     libtool \
     ocl-icd-opencl-dev \
+    pkg-config \
     protobuf-compiler \
     python \
     python-pip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \
     cmake \
+    # curl is not a build dependency
+    curl \
     git \
     golang \
     libboost-filesystem-dev \
@@ -46,6 +48,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python \
     python-pip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://github.com/mongodb/mongo-c-driver/releases/download/1.13.0/mongo-c-driver-1.13.0.tar.gz | tar -zx -C . \
+    && cmake -Hmongo-c-driver-1.13.0 -Bmongo-c-build -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build mongo-c-build -- -j$(nproc) \
+    && cmake --build mongo-c-build --target install \
+    && rm -rf mongo-c-* \
+    && curl -sL https://github.com/mongodb/mongo-cxx-driver/archive/r3.3.1.tar.gz | tar -zx -C . \
+    && cmake -Hmongo-cxx-driver-r3.3.1 -Bmongo-cxx-build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build mongo-cxx-build --target EP_mnmlstc_core \
+    && cmake --build mongo-cxx-build -- -j$(nproc) \
+    && cmake --build mongo-cxx-build --target install \
+    && rm -rf mongo-cxx-*
 
 # Intentionally left blank unless specific commit is provided in commandline
 ARG COMMIT=

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     logrotate \
     net-tools \
     rsyslog \
+    trickle \
     vim \
     && rm -rf /var/lib/apt/lists/* \
     && pip install setuptools \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: all ci k8s-zilliqa k8s-scilla
+.PHONY: all ci k8s-zilliqa k8s-scilla ubuntu-1804
 
 # build the default zilliqa docker image same as the one on Docker Hub
 all:
@@ -9,6 +9,9 @@ all:
 ci:
 	docker build -t zilliqa-ci -f Dockerfile.ci .
 
+# test build on Ubuntu 18.04
+ubuntu-1804: check-commit
+	docker build --build-arg COMMIT=$(commit) --build-arg BASE=ubuntu:18.04 -t zilliqa .
 
 len=$(shell echo $(COMMIT) | wc -c)
 commit=$(shell echo $(COMMIT) | cut -c 1-7)


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The installation of mongo drivers is taken out from the main compiling process and becomes a standalone `RUN` command to allow it to be cached. Along with this, the submodule update after the clone is not needed so it's removed as well.

A new target `ubuntu-1804` in Makefile is added to allow quick testing of building zilliqa on Ubuntu 18:04.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Try the following steps after checking out this branch to see the caching improvement

1. `git checkout fix/dockerfile`
2. `cd docker`
3. `make ubuntu-1804 COMMIT=a51a9c1` (the second last commit in this PR)
4. `make ubuntu-1804 COMMIT=d0a874a` (the last commit in this PR)
5. See the different of the output from the above step 4 and step 5. Locate the new layer being added and in 3 and skipped bulding in 4.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
