### PR TITLE
Verify the finalblock node before forcing the state change

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -643,32 +643,6 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
                              [[gnu::unused]] const Peer& from) {
   LOG_MARKER();
 
-  if (!LOOKUP_NODE_MODE) {
-    if (m_lastMicroBlockCoSig.first != m_mediator.m_currentEpochNum) {
-      std::unique_lock<mutex> cv_lk(m_MutexCVFBWaitMB);
-      if (cv_FBWaitMB.wait_for(
-              cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW)) ==
-          std::cv_status::timeout) {
-        LOG_GENERAL(WARNING, "Timeout, I didn't finish microblock consensus");
-      }
-    }
-
-    PrepareGoodStateForFinalBlock();
-
-    if (!CheckState(PROCESS_FINALBLOCK)) {
-      LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                "Too late - current state is " << m_state << ".");
-      return false;
-    }
-  }
-
-  LOG_STATE(
-      "[FLBLK]["
-      << setw(15) << left << m_mediator.m_selfPeer.GetPrintableIPAddress()
-      << "]["
-      << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
-      << "] RECEIVED FINAL BLOCK");
-
   uint32_t shardId = std::numeric_limits<uint32_t>::max();
   uint64_t dsBlockNumber = 0;
   uint32_t consensusID = 0;
@@ -681,6 +655,8 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
               "Messenger::GetNodeFinalBlock failed.");
     return false;
   }
+
+  lock_guard<mutex> g(m_mutexFinalBlock);
 
   BlockHash temp_blockHash = txBlock.GetHeader().GetMyHash();
   if (temp_blockHash != txBlock.GetBlockHash()) {
@@ -761,7 +737,31 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
     return false;
   }
 
-  lock_guard<mutex> g(m_mutexFinalBlock);
+  if (!LOOKUP_NODE_MODE) {
+    if (m_lastMicroBlockCoSig.first != m_mediator.m_currentEpochNum) {
+      std::unique_lock<mutex> cv_lk(m_MutexCVFBWaitMB);
+      if (cv_FBWaitMB.wait_for(
+              cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW)) ==
+          std::cv_status::timeout) {
+        LOG_GENERAL(WARNING, "Timeout, I didn't finish microblock consensus");
+      }
+    }
+
+    PrepareGoodStateForFinalBlock();
+
+    if (!CheckState(PROCESS_FINALBLOCK)) {
+      LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+                "Too late - current state is " << m_state << ".");
+      return false;
+    }
+  }
+
+  LOG_STATE(
+      "[FLBLK]["
+      << setw(15) << left << m_mediator.m_selfPeer.GetPrintableIPAddress()
+      << "]["
+      << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
+      << "] RECEIVED FINAL BLOCK");
 
   bool toSendTxnToLookup = false;
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Normally, once a shard node received a finalblock, it should skip the microblock consensus state and start processing the finalblock. But this mechanism didn't cover if the node received duplicate or malicious finalblock. So we will let the verification of the finalblock being done first before triggering the state change.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
