### PR TITLE
Fix Fetch AccountStates from Lookup

### DIFF
--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -23,6 +23,7 @@
 #include <json/json.h>
 #include <map>
 #include <set>
+#include <shared_mutex>
 #include <unordered_map>
 
 #pragma GCC diagnostic push
@@ -84,7 +85,7 @@ class AccountStore
 
   // primary mutex used by account store for protecting permanent states from
   // external access
-  std::mutex m_mutexPrimary;
+  mutable std::shared_timed_mutex m_mutexPrimary;
   // mutex used when manipulating with state delta
   std::mutex m_mutexDelta;
   // mutex related to reversibles
@@ -101,6 +102,9 @@ class AccountStore
  public:
   /// Returns the singleton AccountStore instance.
   static AccountStore& GetInstance();
+
+  bool Serialize(std::vector<unsigned char>& src,
+                 unsigned int offset) const override;
 
   bool Deserialize(const std::vector<unsigned char>& src,
                    unsigned int offset) override;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1768,9 +1768,9 @@ bool Lookup::ProcessSetStateFromSeed(const vector<unsigned char>& message,
 
   unique_lock<mutex> lock(m_mutexSetState);
   PubKey lookupPubKey;
-  std::unordered_map<Address, Account> addressToAccountTmp;
+  vector<unsigned char> accountStoreBytes;
   if (!Messenger::GetLookupSetStateFromSeed(message, offset, lookupPubKey,
-                                            addressToAccountTmp)) {
+                                            accountStoreBytes)) {
     LOG_EPOCH(WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Messenger::GetLookupSetStateFromSeed failed.");
     return false;
@@ -1783,9 +1783,8 @@ bool Lookup::ProcessSetStateFromSeed(const vector<unsigned char>& message,
     return false;
   }
 
-  for (const auto& addressAccount : addressToAccountTmp) {
-    AccountStore::GetInstance().AddAccountDuringDeserialization(
-        addressAccount.first, addressAccount.second);
+  if (!AccountStore::GetInstance().Deserialize(accountStoreBytes, 0)) {
+    LOG_GENERAL(WARNING, "Deserialize AccountStore Failed");
   }
 
   if (ARCHIVAL_NODE) {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1785,6 +1785,7 @@ bool Lookup::ProcessSetStateFromSeed(const vector<unsigned char>& message,
 
   if (!AccountStore::GetInstance().Deserialize(accountStoreBytes, 0)) {
     LOG_GENERAL(WARNING, "Deserialize AccountStore Failed");
+    return false;
   }
 
   if (ARCHIVAL_NODE) {

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -4490,16 +4490,16 @@ bool Messenger::SetLookupSetStateFromSeed(
 
   LookupSetStateFromSeed result;
 
-  SerializableToProtobufByteArray(accountStore, *result.mutable_accounts());
-
   SerializableToProtobufByteArray(lookupKey.second, *result.mutable_pubkey());
   Signature signature;
 
   std::vector<unsigned char> tmp;
-  if (!SerializeToArray(result.accounts(), tmp, 0)) {
-    LOG_GENERAL(WARNING, "Failed to serialize accounts.");
+
+  if (!accountStore.Serialize(tmp, 0)) {
+    LOG_GENERAL(WARNING, "Failed to serialize AccountStore.");
     return false;
   }
+  result.mutable_accountstore()->set_data(tmp.data(), tmp.size());
 
   if (!Schnorr::GetInstance().Sign(tmp, lookupKey.first, lookupKey.second,
                                    signature)) {
@@ -4519,8 +4519,7 @@ bool Messenger::SetLookupSetStateFromSeed(
 
 bool Messenger::GetLookupSetStateFromSeed(
     const vector<unsigned char>& src, const unsigned int offset,
-    PubKey& lookupPubKey,
-    std::unordered_map<Address, Account>& addressToAccount) {
+    PubKey& lookupPubKey, vector<unsigned char>& accountStoreBytes) {
   LOG_MARKER();
 
   LookupSetStateFromSeed result;
@@ -4532,24 +4531,20 @@ bool Messenger::GetLookupSetStateFromSeed(
     return false;
   }
 
-  // ProtobufByteArrayToSerializable(result.accounts(), accountStore);
-  if (!MessengerAccountStoreBase::GetAccountStore(src, offset,
-                                                  addressToAccount)) {
-    LOG_GENERAL(WARNING, "MessengerAccountStoreBase::GetAccountStore failed.");
-    return false;
-  }
-
   ProtobufByteArrayToSerializable(result.pubkey(), lookupPubKey);
   Signature signature;
   ProtobufByteArrayToSerializable(result.signature(), signature);
 
-  std::vector<unsigned char> tmp;
-  if (!SerializeToArray(result.accounts(), tmp, 0)) {
-    LOG_GENERAL(WARNING, "Failed to serialize accounts.");
-    return false;
-  }
+  copy(result.accountstore().data().begin(), result.accountstore().data().end(),
+       back_inserter(accountStoreBytes));
 
-  if (!Schnorr::GetInstance().Verify(tmp, signature, lookupPubKey)) {
+  // if (!SerializeToArray(result.accountstore(), accountStoreBytes, 0)) {
+  //   LOG_GENERAL(WARNING, "Failed to serialize accounts.");
+  //   return false;
+  // }
+
+  if (!Schnorr::GetInstance().Verify(accountStoreBytes, signature,
+                                     lookupPubKey)) {
     LOG_GENERAL(WARNING, "Invalid signature in accounts.");
     return false;
   }

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -491,7 +491,7 @@ class Messenger {
       const AccountStore& accountStore);
   static bool GetLookupSetStateFromSeed(
       const std::vector<unsigned char>& src, const unsigned int offset,
-      PubKey& lookupPubKey, std::vector<unsigned char>& addressToAccount);
+      PubKey& lookupPubKey, std::vector<unsigned char>& accountStoreBytes);
   static bool SetLookupSetLookupOffline(std::vector<unsigned char>& dst,
                                         const unsigned int offset,
                                         const uint32_t listenPort);

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -491,8 +491,7 @@ class Messenger {
       const AccountStore& accountStore);
   static bool GetLookupSetStateFromSeed(
       const std::vector<unsigned char>& src, const unsigned int offset,
-      PubKey& lookupPubKey,
-      std::unordered_map<Address, Account>& addressToAccount);
+      PubKey& lookupPubKey, std::vector<unsigned char>& addressToAccount);
   static bool SetLookupSetLookupOffline(std::vector<unsigned char>& dst,
                                         const unsigned int offset,
                                         const uint32_t listenPort);

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -534,9 +534,9 @@ message LookupGetStateFromSeed
 
 message LookupSetStateFromSeed
 {
-    required ByteArray accounts  = 1;
-    required ByteArray pubkey    = 2;
-    required ByteArray signature = 3;
+    required ByteArray accountstore          = 1;
+    required ByteArray pubkey                = 2;
+    required ByteArray signature             = 3;
 }
 
 message LookupSetLookupOffline


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The previous code for protobufing the GetState and SetState is buggy. This pr is fixing it.
Also applied shared_mutex in AccountStore to provide read concurrency

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
