### PR TITLE
Fix lookup dead loop when node retrieve blocks before bootstrap

### DIFF
--- a/src/libData/BlockChainData/BlockChain.h
+++ b/src/libData/BlockChainData/BlockChain.h
@@ -103,7 +103,7 @@ class BlockChain {
         m_blocks[blockNumOfNewBlock].GetHeader().GetBlockNum();
 
     if (blockNumOfExistingBlock < blockNumOfNewBlock ||
-        blockNumOfExistingBlock == (uint64_t)-1) {
+        INIT_BLOCK_NUMBER == blockNumOfExistingBlock) {
       m_blocks.insert_new(blockNumOfNewBlock, block);
     } else {
       return -1;

--- a/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
+++ b/src/libData/BlockData/BlockHeader/BlockHeaderBase.h
@@ -34,6 +34,8 @@
 // Hash for the committee that generated the block
 using CommitteeHash = dev::h256;
 
+const uint64_t INIT_BLOCK_NUMBER = (uint64_t)-1;
+
 /// [TODO] Base class for all supported block header types
 class BlockHeaderBase : public SerializableDataBlock {
  protected:

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-DSBlockHeader::DSBlockHeader() { m_blockNum = (uint64_t)-1; }
+DSBlockHeader::DSBlockHeader() : m_blockNum(INIT_BLOCK_NUMBER) {}
 
 DSBlockHeader::DSBlockHeader(const vector<unsigned char>& src,
                              unsigned int offset) {

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -24,7 +24,7 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-TxBlockHeader::TxBlockHeader() : m_blockNum((uint64_t)-1) {}
+TxBlockHeader::TxBlockHeader() : m_blockNum(INIT_BLOCK_NUMBER) {}
 
 TxBlockHeader::TxBlockHeader(const vector<unsigned char>& src,
                              unsigned int offset) {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -772,6 +772,13 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
 
   uint64_t curBlockNum =
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
+
+  if (INIT_BLOCK_NUMBER == curBlockNum) {
+    LOG_GENERAL(WARNING,
+                "Blockchain is still bootstraping, no ds blocks available.");
+    return;
+  }
+
   uint64_t minBlockNum = (curBlockNum > MEAN_GAS_PRICE_DS_NUM)
                              ? (curBlockNum - MEAN_GAS_PRICE_DS_NUM)
                              : 1;
@@ -916,6 +923,12 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   if (highBlockNum == 0) {
     highBlockNum =
         m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
+  }
+
+  if (INIT_BLOCK_NUMBER == highBlockNum) {
+    LOG_GENERAL(WARNING,
+                "Blockchain is still bootstraping, no tx blocks available.");
+    return;
   }
 
   uint64_t blockNum;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix lookup dead loop when node retrieve blocks before bootstrap
<!-- What is the context of your pull request? -->
Check if the block chain is initilized before proceesing the request.
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/327

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Run a 200 nodes cloud test to check if have lookup dead issue.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
