### PR TITLE
Cleanup hashes during re-initialization

### DIFF
--- a/src/libNetwork/RumorManager.cpp
+++ b/src/libNetwork/RumorManager.cpp
@@ -44,6 +44,7 @@ RumorManager::RumorManager()
     : m_peerIdPeerBimap(),
       m_peerIdSet(),
       m_rumorIdHashBimap(),
+      m_rumorHashRawMsgBimap(),
       m_tmpRumorHashSet(),
       m_selfPeer(),
       m_rumorIdGenerator(0),
@@ -134,6 +135,7 @@ bool RumorManager::Initialize(const std::vector<Peer>& peers,
   m_peerIdSet.clear();
   m_selfPeer = myself;
   m_tmpRumorHashSet.clear();
+  m_rumorHashRawMsgBimap.clear();
 
   int peerIdGenerator = 0;
   for (const auto& p : peers) {


### PR DESCRIPTION
## Description
Fix: Cleanup the gossip hash-rawmessage map during re-initialization.

## Review Suggestion
Please check the file changed.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
