### PR TITLE
Use find_package to locate libjson-rpc-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,25 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # check dependencies
 #
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 pkg_check_modules(LIBEVENT REQUIRED libevent)
-pkg_check_modules(MINIUPNPC miniupnpc)
-pkg_check_modules(JSONRPCCPP libjsonrpccpp-server libjsonrpccpp-common)
-include_directories(${JSONCPP_INCLUDE_DIRS})
-link_directories(${JSONCPP_LIBRARY_DIRS} ${LIBEVENT_LIBRARY_DIRS} ${MINIUPNPC_LIBRARY_DIRS} ${JSONRPCCPP_LIBRARY_DIRS})
+link_directories(${LIBEVENT_LIBRARY_DIRS})
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    pkg_check_modules(MINIUPNPC miniupnpc REQUIRED)
+    link_directories(${MINIUPNPC_LIBRARY_DIRS})
+
+    find_package(jsoncpp REQUIRED)
+    find_package(libjson-rpc-cpp REQUIRED COMPONENTS jsonrpccommon jsonrpcserver)
+    set(JSONCPP_LINK_TARGETS "jsoncpp_lib")
+    set(JSONRPCCPP_LINK_TARGETS "libjson-rpc-cpp::jsonrpccommon;libjson-rpc-cpp::jsonrpcserver")
+else()
+    pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+    include_directories(${JSONCPP_INCLUDE_DIRS})
+    link_directories(${JSONCPP_LIBRARY_DIRS})
+    set(JSONCPP_LINK_TARGETS "jsoncpp")
+    set(JSONRPCCPP_LINK_TARGETS "jsonrpccpp-common;jsonrpccpp-server")
+endif()
+
 
 include(InstallG3log)
 find_package(g3logger CONFIG REQUIRED)

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -1,0 +1,39 @@
+# - Try to find MHD
+# Once done this will define
+#
+#  MHD_FOUND - system has MHD
+#  MHD_INCLUDE_DIRS - the MHD include directory
+#  MHD_LIBRARY - Link these to use MHD
+
+find_path(
+    MHD_INCLUDE_DIR
+    NAMES microhttpd.h
+    DOC "microhttpd include dir"
+)
+
+find_library(
+    MHD_LIBRARY
+    NAMES microhttpd microhttpd-10 libmicrohttpd libmicrohttpd-dll
+    DOC "microhttpd library"
+)
+
+set(MHD_INCLUDE_DIRS ${MHD_INCLUDE_DIR})
+set(MHD_LIBRARIES ${MHD_LIBRARY})
+
+# debug library on windows
+# same naming convention as in qt (appending debug library with d)
+# boost is using the same "hack" as us with "optimized" and "debug"
+# official MHD project actually uses _d suffix
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    find_library(
+        MHD_LIBRARY_DEBUG
+        NAMES microhttpd_d microhttpd-10_d libmicrohttpd_d libmicrohttpd-dll_d
+        DOC "mhd debug library"
+    )
+    set(MHD_LIBRARIES optimized ${MHD_LIBRARIES} debug ${MHD_LIBRARY_DEBUG})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(mhd DEFAULT_MSG MHD_INCLUDE_DIR MHD_LIBRARY)
+mark_as_advanced(MHD_INCLUDE_DIR MHD_LIBRARY)
+

--- a/src/libData/AccountData/CMakeLists.txt
+++ b/src/libData/AccountData/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(AccountData Account.cpp AccountStoreTemp.cpp AccountStoreBase.tpp AccountStoreSC.tpp AccountStoreTrie.tpp AccountStore.cpp AccountStoreAtomic.tpp Transaction.cpp LogEntry.cpp TransactionReceipt.cpp)
 target_include_directories(AccountData PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries (AccountData PUBLIC Block BlockHeader Crypto Message Trie Utils Persistence jsoncpp)
+target_link_libraries (AccountData PUBLIC Block BlockHeader Crypto Message Trie Utils Persistence ${JSONCPP_LINK_TARGETS})

--- a/src/libServer/CMakeLists.txt
+++ b/src/libServer/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(Server Server.cpp JSONConversion.cpp)
 target_include_directories(Server PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries (Server PUBLIC AccountData jsoncpp jsonrpccpp-common jsonrpccpp-server)
+target_link_libraries (Server PUBLIC AccountData ${JSONCPP_LINK_TARGETS} ${JSONRPCCPP_LINK_TARGETS})


### PR DESCRIPTION
## Issue
On macOS, the latest version of `libjson-rpc-cpp` installed through `brew install libjson-rpc-cpp` is 1.1.1, which affects the output of `pkg-config ` 

**before, with 1.1.0**
```console
$ pkg-config libjsonrpccpp-common --libs
-L/usr/local/Cellar/libjson-rpc-cpp/1.1.0/lib/ -ljsoncpp
```
**now, with 1.1.1**
```console
$ pkg-config libjsonrpccpp-common --libs
-Llib/pkgconfig -ljsoncpp
```

This causes the issue where `pkg_check_module` find the relative path instead of the absolute path of the library.

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR fixes the above issue by using `find_package` to do library path search on Mac. It also comes with an improvement that the way of searching is explicilty decided by the platform. 

Others:
- The file `FindMHD.cmake` (pulled from `libjson-rpc-cpp`) is saved in the repo to make `find_package` work on Mac.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Reproduce the issue with `libjson-rpc-cpp 1.1.1`  on macOS with the latest master.

Confirm this PR works in the following environment
- macOS, `libjson-rpc-cpp 1.1.1` via `brew`
- macOS, `libjson-rpc-cpp 1.1.0` via `brew`
- Ubuntu 16.04, `libjsonrpccpp-dev` via `apt-get`

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
