### PR TITLE
Initialize the m_isVacuousEpoch flag

### DIFF
--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -36,6 +36,7 @@ Mediator::Mediator(const pair<PrivKey, PubKey>& key, const Peer& peer)
   m_validator = nullptr;
   m_currentEpochNum = 0;
   m_isRetrievedHistory = false;
+  m_isVacuousEpoch = false;
   m_DSCommittee = make_shared<std::deque<pair<PubKey, Peer>>>();
   m_initialDSCommittee = make_shared<vector<PubKey>>();
   m_archDB = nullptr;


### PR DESCRIPTION
## Description
Initialize the  m_isVacuousEpoch to false in constructor of Mediator.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
