### PR TITLE
Fixed unbalanced transaction dispatching to shards

### DIFF
--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -188,25 +188,14 @@ void Transaction::SetSignature(const Signature& signature) {
 
 unsigned int Transaction::GetShardIndex(const Address& fromAddr,
                                         unsigned int numShards) {
-  unsigned int target_shard = 0;
-  unsigned int numbits = log2(numShards);
-  unsigned int numbytes = numbits / 8;
-  unsigned int extrabits = numbits % 8;
+  uint32_t x = 0;
 
-  if (extrabits > 0) {
-    unsigned char msb_mask = 0;
-    for (unsigned int i = 0; i < extrabits; i++) {
-      msb_mask |= 1 << i;
-    }
-    target_shard =
-        fromAddr.asArray().at(ACC_ADDR_SIZE - numbytes - 1) & msb_mask;
+  // Take the last four bytes of the address
+  for (unsigned int i = 0; i < 4; i++) {
+    x = (x << 8) | fromAddr.asArray().at(ACC_ADDR_SIZE - 4 + i);
   }
 
-  for (unsigned int i = ACC_ADDR_SIZE - numbytes; i < ACC_ADDR_SIZE; i++) {
-    target_shard = (target_shard << 8) + fromAddr.asArray().at(i);
-  }
-
-  return target_shard;
+  return x % numShards;
 }
 
 bool Transaction::operator==(const Transaction& tran) const {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`Transaction::GetShardIndex` uses `log2` to determine the number of bits needed to represent `numShards`.  This `log2` rounds down, so for example `log2(12)` will result in 3 instead of 4.  This means that only shards 0 to 7 will ever get assigned any transactions, while 8 to 11 get nothing.

Instead of implementing this function to support any bit length in a very generic way, it has now been revised to simply just take the last 4 bytes of the address and do a modulo operation to get the corresponding shard for it.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
