### PR TITLE
Build option for clang-tidy-fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ set -e
 dir=build
 
 run_clang_format_fix=0
+run_clang_tidy_fix=0
 
 for option in "$@"
 do
@@ -44,7 +45,12 @@ do
     style)
         CMAKE_EXTRA_OPTIONS="-DLLVM_EXTRA_TOOLS=ON ${CMAKE_EXTRA_OPTIONS}"
         run_clang_format_fix=1
-        echo "Build with LLVM Extra Tools for codying style check"
+        echo "Build with LLVM Extra Tools for coding style check (clang-format-fix)"
+    ;;
+    linter)
+        CMAKE_EXTRA_OPTIONS="-DLLVM_EXTRA_TOOLS=ON ${CMAKE_EXTRA_OPTIONS}"
+        run_clang_tidy_fix=1
+        echo "Build with LLVM Extra Tools for linter check (clang-tidy-fix)"
     ;;
     heartbeattest)
         CMAKE_EXTRA_OPTIONS="-DHEARTBEATTEST=1 ${CMAKE_EXTRA_OPTIONS}"
@@ -116,4 +122,5 @@ done
 cmake -H. -B${dir} ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON -DCMAKE_INSTALL_PREFIX=..
 cmake --build ${dir} -- -j4
 ./scripts/license_checker.sh
+[ ${run_clang_tidy_fix} -ne 0 ] && cmake --build ${dir} --target clang-tidy-fix
 [ ${run_clang_format_fix} -ne 0 ] && cmake --build ${dir} --target clang-format-fix


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Because currently Travis build will check clang-tidy, now we support a build option "linter" for enabling clang-tidy-fix, which is disabled by default.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<del>- [ ] small-scale cloud test</del>
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
