### PR TITLE
Handle null messages from the interpreter's output.json.

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -617,6 +617,13 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
   }
   gasRemained = atoi(_json["gas_remaining"].asString().c_str());
 
+  if (!_json.isMember("_accepted")) {
+    LOG_GENERAL(
+        WARNING,
+        "The json output of this contract doesn't contain _accepted");
+    return false;
+  }
+
   if (!_json.isMember("message") || !_json.isMember("states") ||
       !_json.isMember("events")) {
     if (_json.isMember("errors")) {
@@ -627,17 +634,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
     return false;
   }
 
-  if (!_json["message"].isMember("_tag") ||
-      !_json["message"].isMember("_amount") ||
-      !_json["message"].isMember("params") ||
-      !_json["message"].isMember("_recipient") ||
-      !_json["message"].isMember("_accepted")) {
-    LOG_GENERAL(WARNING,
-                "The message in the json output of this contract is corrupted");
-    return false;
-  }
-
-  if (_json["message"]["_accepted"].asString() == "true") {
+  if (_json["_accepted"].asString() == "true") {
     // LOG_GENERAL(INFO, "Contract accept amount transfer");
     if (!TransferBalanceAtomic(m_curSenderAddr, m_curContractAddr,
                                m_curAmount)) {
@@ -677,6 +674,24 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
       return false;
     }
     m_curTranReceipt.AddEntry(entry);
+  }
+
+  // If output message is null
+  if (_json["message"].isNull()) {
+    LOG_GENERAL(INFO,
+                "null message in scilla output when invoking a "
+                "contract, transaction finished");
+    return true;
+  }
+
+  // Non-null messages must have few mandatory fields.
+  if (!_json["message"].isMember("_tag") ||
+      !_json["message"].isMember("_amount") ||
+      !_json["message"].isMember("params") ||
+      !_json["message"].isMember("_recipient")) {
+    LOG_GENERAL(WARNING,
+                "The message in the json output of this contract is corrupted");
+    return false;
   }
 
   Address recipient = Address(_json["message"]["_recipient"].asString());

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -618,9 +618,8 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
   gasRemained = atoi(_json["gas_remaining"].asString().c_str());
 
   if (!_json.isMember("_accepted")) {
-    LOG_GENERAL(
-        WARNING,
-        "The json output of this contract doesn't contain _accepted");
+    LOG_GENERAL(WARNING,
+                "The json output of this contract doesn't contain _accepted");
     return false;
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Scilla contracts can output a null message, handle this case. Also the format for conveying acceptance of incoming amount is now changed in Scilla. Update accordingly to match the Scilla update.

<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/scilla/pull/314


## Status
Complete

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [*] **ready for review**
- No testing has been performed as the unit tests for testing contract execution is broken.

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
