### PR TITLE
Remove calls to HeartBeatPulse so we don't see them in logs

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -264,7 +264,7 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
   // Clear microblock(s)
   // m_microBlocks.clear();
 
-  m_mediator.HeartBeatPulse();
+  // m_mediator.HeartBeatPulse();
 
   if (m_mode == PRIMARY_DS) {
     LOG_STATE(

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -768,7 +768,7 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
     BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED, {'0'});
   }
 
-  m_mediator.HeartBeatPulse();
+  // m_mediator.HeartBeatPulse();
 
   if (txBlock.GetMicroBlockInfos().size() == 1) {
     LOG_STATE("[TXBOD][" << std::setw(15) << std::left


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`HeartBeatPulse` BEGIN and END messages still appear in the log, even if we already disabled the heartbeat feature.  `HeartBeatPulse` execution is also unnecessary and takes up CPU time, so better to just comment out the calls to this function as well, until the time we decide to have heartbeat again.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
