### PR TITLE
Ensure that zilliqa/scilla is up-to-date

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,20 +28,23 @@ check-commit:
 		exit 1; \
 	fi
 
+get-scilla:
+	docker pull zilliqa/scilla:latest
+
 # build zilliqa docker image for Kubernetes usage
 k8s-zilliqa: check-commit
 	cat Dockerfile Dockerfile.k8s | docker build -t zilliqa:$(commit) \
 		--build-arg COMMIT=$(commit) -
 
-k8s-scilla: check-commit
+k8s-scilla: check-commit get-scilla
 	cat Dockerfile Dockerfile.k8s | docker build -t zilliqa:$(commit).scilla \
 		--build-arg COMMIT=$(commit) --build-arg BASE=zilliqa/scilla -
 
 # build release version docker image for public usage
-release: check-commit
+release: check-commit get-scilla
 	docker build -t zilliqa:release --build-arg BASE=zilliqa/scilla --build-arg COMMIT=$(commit) .
 
-release-cuda: check-commit
+release-cuda: check-commit get-scilla
 	docker build -t scilla:cuda --build-arg BASE=zilliqa/scilla -f Dockerfile.cuda .
 	docker build -t zilliqa:release-cuda --build-arg BASE=scilla:cuda --build-arg EXTRA_CMAKE_ARGS="-DCUDA_MINE=1" --build-arg COMMIT=$(commit) .
 


### PR DESCRIPTION
## Description

The old approach was error-prone as `zilliqa/scilla` had to be manually updated to the latest build by hand. This ensures that all images that use `zilliqa/scilla` as the `BASE_IMAGE` will always get the most up-to-date version of that image.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
