### PR TITLE
Fix lowest 2 bits mask values in DifficultyLevelInInt

### DIFF
--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -124,15 +124,16 @@ bool POW::CheckDificulty(const ethash_hash256& result,
 
 ethash_hash256 POW::DifficultyLevelInInt(uint8_t difficulty) {
   uint8_t b[UINT256_SIZE];
-  std::fill(b, b + 32, 0xff);
+  std::fill(b, b + UINT256_SIZE, 0xFF);
   uint8_t firstNbytesToSet = difficulty / 8;
   uint8_t nBytesBitsToSet = difficulty % 8;
 
   for (int i = 0; i < firstNbytesToSet; i++) {
     b[i] = 0;
   }
-  const unsigned char masks[9] = {0xFF, 0x7F, 0x3F, 0x1F,
-                                  0x0F, 0x07, 0x01, 0x00};
+
+  const unsigned char masks[] = {0xFF, 0x7F, 0x3F, 0x1F,
+                                 0x0F, 0x07, 0x03, 0x01};
   b[firstNbytesToSet] = masks[nBytesBitsToSet];
   return StringToBlockhash(BytesToHexString(b, UINT256_SIZE));
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Lowest two values inside `mask` are currently wrong.

Also some minor improvements:
1. Changed magic number `32` to `UINT256_SIZE`
2. Removed `9` from `mask` and just let compiler compute the size (will be 8)

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
