### PR TITLE
Make persistence database as thread-safe

### DIFF
--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -215,6 +215,20 @@ class BlockStorage : public Singleton<BlockStorage> {
 
   /// Clean all DB
   bool ResetAll();
+
+ private:
+  std::mutex m_mutexMetadata;
+  std::mutex m_mutexDsBlockchain;
+  std::mutex m_mutexTxBlockchain;
+  std::mutex m_mutexMicroBlock;
+  std::mutex m_mutexDsCommittee;
+  std::mutex m_mutexVCBlock;
+  std::mutex m_mutexFallbackBlock;
+  std::mutex m_mutexBlockLink;
+  std::mutex m_mutexShardStructure;
+  std::mutex m_mutexStateDelta;
+  std::mutex m_mutexTxBody;
+  std::mutex m_mutexTxBodyTmp;
 };
 
 #endif  // BLOCKSTORAGE_H


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
When node-rejoin, there is some probability that storing database and retrieving database at the same time, then cause crash. This PR made the database that may cause conflict (m_dsCommitteeDB, m_shardStructureDB) as thread-safe. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
