### PR TITLE
Fix potential wrong messaging to wrong instruction handler and minor log message fix

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -703,25 +703,15 @@ bool DirectoryService::Execute(const vector<unsigned char>& message,
 
   std::vector<InstructionHandler> ins_handlers;
 
-  if (!LOOKUP_NODE_MODE) {
-    ins_handlers.insert(ins_handlers.end(),
-                        {&DirectoryService::ProcessSetPrimary,
-                         &DirectoryService::ProcessPoWSubmission,
-                         &DirectoryService::ProcessDSBlockConsensus,
-                         &DirectoryService::ProcessMicroblockSubmission,
-                         &DirectoryService::ProcessFinalBlockConsensus,
-                         &DirectoryService::ProcessViewChangeConsensus,
-                         &DirectoryService::ProcessGetDSTxBlockMessage,
-                         &DirectoryService::ProcessPoWPacketSubmission});
-  } else {
-    ins_handlers.insert(ins_handlers.end(),
-                        {&DirectoryService::ProcessSetPrimary,
-                         &DirectoryService::ProcessPoWSubmission,
-                         &DirectoryService::ProcessDSBlockConsensus,
-                         &DirectoryService::ProcessMicroblockSubmission,
-                         &DirectoryService::ProcessFinalBlockConsensus,
-                         &DirectoryService::ProcessPoWPacketSubmission});
-  }
+  ins_handlers.insert(ins_handlers.end(),
+                      {&DirectoryService::ProcessSetPrimary,
+                       &DirectoryService::ProcessPoWSubmission,
+                       &DirectoryService::ProcessDSBlockConsensus,
+                       &DirectoryService::ProcessMicroblockSubmission,
+                       &DirectoryService::ProcessFinalBlockConsensus,
+                       &DirectoryService::ProcessViewChangeConsensus,
+                       &DirectoryService::ProcessGetDSTxBlockMessage,
+                       &DirectoryService::ProcessPoWPacketSubmission});
 
   const unsigned char ins_byte = message.at(offset);
 

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -718,6 +718,13 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
     [[gnu::unused]] const Peer& from) {
   LOG_MARKER();
 
+  if (LOOKUP_NODE_MODE) {
+    LOG_GENERAL(WARNING,
+                "DirectoryService::ProcessGetDSTxBlockMessage not expected "
+                "to be called from LookUp node.");
+    return true;
+  }
+
   if (m_state != VIEWCHANGE_CONSENSUS_PREP) {
     LOG_EPOCH(
         WARNING, to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libNode/FallbackPostProcessing.cpp
+++ b/src/libNode/FallbackPostProcessing.cpp
@@ -63,7 +63,7 @@ bool Node::ComposeFallbackBlockMessageForSender(
 void Node::ProcessFallbackConsensusWhenDone() {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
-                "DirectoryService::ProcessViewChangeConsensusWhenDone not "
+                "DirectoryService::ProcessFallbackConsensusWhenDone not "
                 "expected to be called from LookUp node.");
     return;
   }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Check for whether node is a lookup should not be performed at the instruction handler level. 
For instance, `ProcessPoWPacketSubmission` has a message handler of `0x5` or `0x7` depending whether the node is lookup or not. However, in the Messages.h it is listed as `POWPACKETSUBMISSION = 0x07`

As such, the check for lookup node should be done at the function level. 

In addition, this PR fixes a minor inaccurate log message

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: 806fbb1b09291972baff6a8c1d9c2242371855cb)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test (commit: 806fbb1b09291972baff6a8c1d9c2242371855cb)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
