### PR TITLE
Fix bug for StartRetrieveHistory that may cause state delta check failed

### DIFF
--- a/src/libDirectoryService/Coinbase.cpp
+++ b/src/libDirectoryService/Coinbase.cpp
@@ -180,8 +180,13 @@ bool DirectoryService::SaveCoinbase(const vector<bool>& b1,
   LOG_MARKER();
   LOG_GENERAL(INFO, "Save coin base for shardId: " << shard_id << ", epochNum: "
                                                    << epochNum);
-  if (shard_id == (int32_t)m_shards.size() ||
-      shard_id == CoinbaseReward::FINALBLOCK_REWARD) {
+
+  if (shard_id == (int32_t)m_shards.size()) {
+    LOG_GENERAL(INFO, "Skip the micro block with shardId = shard size.");
+    return true;
+  }
+
+  if (shard_id == CoinbaseReward::FINALBLOCK_REWARD) {
     // DS
     lock(m_mediator.m_mutexDSCommittee, m_mutexCoinbaseRewardees);
     lock_guard<mutex> g(m_mediator.m_mutexDSCommittee, adopt_lock);

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -406,7 +406,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
   }
 
   /// Save coin base for final block, from last DS epoch to current TX epoch
-  if (!LOOKUP_NODE_MODE) {
+  if (bDS) {
     for (uint64_t blockNum =
              m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum();
          blockNum <=
@@ -473,12 +473,13 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
       (m_mediator.m_txBlockChain.GetBlockCount()) % NUM_FINAL_BLOCK_PER_POW;
 
   /// Save coin base for micro block, from last DS epoch to current TX epoch
-  if (!LOOKUP_NODE_MODE) {
+  if (bDS) {
     std::list<MicroBlockSharedPtr> microBlocks;
     if (BlockStorage::GetBlockStorage().GetRangeMicroBlocks(
             m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum(),
-            m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
-            0, m_mediator.m_ds->m_shards.size(), microBlocks)) {
+            m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() +
+                1,
+            0, m_mediator.m_ds->m_shards.size() - 1, microBlocks)) {
       for (const auto& microBlock : microBlocks) {
         LOG_GENERAL(INFO,
                     "Retrieve microblock with epochNum: "

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -479,7 +479,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
             m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum(),
             m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() +
                 1,
-            0, m_mediator.m_ds->m_shards.size() - 1, microBlocks)) {
+            0, m_mediator.m_ds->m_shards.size(), microBlocks)) {
       for (const auto& microBlock : microBlocks) {
         LOG_GENERAL(INFO,
                     "Retrieve microblock with epochNum: "


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
1. StartRetrieveHistory may call SaveCoinbase() for final blocks and micro blocks. This operation should only be applied on DS node. 
2. Regards to the scenario of entire node recovery, database would be copied from lookup node to every nodes.
Thus, for SaveCoinBase(), the shard ID should only be allowed between 0 ~ shardSize - 1.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<del>- [ ] small-scale cloud test</del>
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
