### PR TITLE
Support ISO 8601 for log timestamp

### DIFF
--- a/src/libUtils/Logger.cpp
+++ b/src/libUtils/Logger.cpp
@@ -137,9 +137,9 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function) {
   if (IsG3Log()) {
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    LOG(level) << "[" << PAD(GetPid(), TID_LEN) << "]["
-               << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-               << PAD(get_ms(cur), 3) << "]["
+    LOG(level) << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+               << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+               << PAD(get_ms(cur), 3, '0') << "]["
                << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg;
     return;
   }
@@ -150,17 +150,18 @@ void Logger::LogGeneral(LEVELS level, const char* msg, const char* function) {
     checkLog();
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    m_logFile << "[" << PAD(GetPid(), TID_LEN) << "]["
-              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-              << PAD(get_ms(cur), 3) << "]["
+    m_logFile << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+              << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+              << PAD(get_ms(cur), 3, '0') << "]["
               << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
               << flush;
   } else {
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    cout << "[" << PAD(GetPid(), TID_LEN) << "]["
-         << put_time(gmtime(&cur_time_t), "%H:%M:%S:") << PAD(get_ms(cur), 3)
-         << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
+    cout << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+         << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+         << PAD(get_ms(cur), 3, '0') << "]["
+         << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg << endl
          << flush;
   }
 }
@@ -173,18 +174,19 @@ void Logger::LogEpoch([[gnu::unused]] LEVELS level, const char* msg,
     checkLog();
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    m_logFile << "[" << PAD(GetPid(), TID_LEN) << "]["
-              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-              << PAD(get_ms(cur), 3) << "]["
+    m_logFile << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+              << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+              << PAD(get_ms(cur), 3, '0') << "]["
               << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
               << "[Epoch " << epoch << "] " << msg << endl
               << flush;
   } else {
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    cout << "[" << PAD(GetPid(), TID_LEN) << "]["
-         << put_time(gmtime(&cur_time_t), "%H:%M:%S:") << PAD(get_ms(cur), 3)
-         << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+    cout << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+         << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+         << PAD(get_ms(cur), 3, '0') << "]["
+         << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
          << "[Epoch " << epoch << "] " << msg << endl
          << flush;
   }
@@ -203,17 +205,17 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
     if (payload.size() > max_bytes_to_display) {
-      m_logFile << "[" << PAD(GetPid(), TID_LEN) << "]["
-                << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-                << PAD(get_ms(cur), 3) << "]["
+      m_logFile << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+                << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+                << PAD(get_ms(cur), 3, '0') << "]["
                 << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                 << " (Len=" << payload.size() << "): " << payload_string.get()
                 << "..." << endl
                 << flush;
     } else {
-      m_logFile << "[" << PAD(GetPid(), TID_LEN) << "]["
-                << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-                << PAD(get_ms(cur), 3) << "]["
+      m_logFile << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+                << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+                << PAD(get_ms(cur), 3, '0') << "]["
                 << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
                 << " (Len=" << payload.size() << "): " << payload_string.get()
                 << endl
@@ -224,16 +226,18 @@ void Logger::LogPayload([[gnu::unused]] LEVELS level, const char* msg,
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
 
     if (payload.size() > max_bytes_to_display) {
-      cout << "[" << PAD(GetPid(), TID_LEN) << "]["
-           << put_time(gmtime(&cur_time_t), "%H:%M:%S:") << PAD(get_ms(cur), 3)
-           << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+      cout << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+           << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+           << PAD(get_ms(cur), 3, '0') << "]["
+           << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
            << " (Len=" << payload.size() << "): " << payload_string.get()
            << "..." << endl
            << flush;
     } else {
-      cout << "[" << PAD(GetPid(), TID_LEN) << "]["
-           << put_time(gmtime(&cur_time_t), "%H:%M:%S:") << PAD(get_ms(cur), 3)
-           << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
+      cout << "[" << PAD(GetPid(), TID_LEN, ' ') << "]["
+           << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+           << PAD(get_ms(cur), 3, '0') << "]["
+           << LIMIT(function, MAX_FUNCNAME_LEN) << "] " << msg
            << " (Len=" << payload.size() << "): " << payload_string.get()
            << endl
            << flush;
@@ -250,18 +254,19 @@ void Logger::LogEpochInfo(const char* msg, const char* function,
     checkLog();
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    m_logFile << "[" << PAD(tid, TID_LEN) << "]["
-              << put_time(gmtime(&cur_time_t), "%H:%M:%S:")
-              << PAD(get_ms(cur), 3) << "]["
+    m_logFile << "[" << PAD(tid, TID_LEN, ' ') << "]["
+              << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+              << PAD(get_ms(cur), 3, '0') << "]["
               << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
               << "[Epoch " << epoch << "] " << msg << endl
               << flush;
   } else {
     auto cur = chrono::system_clock::now();
     auto cur_time_t = chrono::system_clock::to_time_t(cur);
-    cout << "[" << PAD(tid, TID_LEN) << "]["
-         << put_time(gmtime(&cur_time_t), "%H:%M:%S:") << PAD(get_ms(cur), 3)
-         << "][" << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
+    cout << "[" << PAD(tid, TID_LEN, ' ') << "]["
+         << put_time(gmtime(&cur_time_t), "%y-%m-%dT%T.")
+         << PAD(get_ms(cur), 3, '0') << "]["
+         << LIMIT(function, MAX_FUNCNAME_LEN) << "]"
          << "[Epoch " << epoch << "] " << msg << endl
          << flush;
   }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Zilliqa log should follow the standard timestamp format ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601), to improve readability.

Ex. 18-12-06T11:21:32.007

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<del>- [ ] small-scale cloud test</del>
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
