### PR TITLE
Fix node rejoin and win DS PoW and then process sharding structure fail

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -416,9 +416,6 @@ class DirectoryService : public Executable, public Broadcastable {
   std::vector<unsigned char> ComposeVCGetDSTxBlockMessage();
   bool ComposeVCBlockForSender(std::vector<unsigned char>& vcblock_message);
 
-  // Reset certain variables to the initial state
-  bool CleanVariables();
-
   void CleanFinalblockConsensusBuffer();
 
   uint8_t CalculateNewDifficulty(const uint8_t& currentDifficulty);
@@ -600,6 +597,9 @@ class DirectoryService : public Executable, public Broadcastable {
   int64_t GetAllPoWSize() const;
 
   bool ProcessAndSendPoWPacketSubmissionToOtherDSComm();
+
+  // Reset certain variables to the initial state
+  bool CleanVariables();
 
  private:
   static std::map<DirState, std::string> DirStateStrings;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1362,6 +1362,7 @@ void Node::RejoinAsNormal() {
     auto func = [this]() mutable -> void {
       m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
       this->CleanVariables();
+      this->m_mediator.m_ds->CleanVariables();
       this->Install(SyncType::NORMAL_SYNC);
       this->StartSynchronization();
       this->ResetRejoinFlags();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
An external node may use the same pubkey and try to join from different IP address, so when a node start to rejoin, it should clear all the old PoWs and pow connections, then can ProcessShardingStructure of the latest one succesffully.
<!-- What is the context of your pull request? -->
Clean DS variables when start to rejoin as normal.
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/373

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
Check files changed.
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
