### PR TITLE
Avoid unnecessary errorMsg generation for some calls to CheckMicroBlocks

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -339,8 +339,8 @@ class DirectoryService : public Executable, public Broadcastable {
   bool CheckPreviousFinalBlockHash();
   bool CheckFinalBlockNumber();
   bool CheckFinalBlockTimestamp();
-  bool CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
-                        bool fromShards = false);
+  bool CheckMicroBlocks(std::vector<unsigned char>& errorMsg, bool fromShards,
+                        bool generateErrorMsg);
   bool CheckLegitimacyOfMicroBlocks();
   bool CheckMicroBlockInfo();
   bool CheckStateRoot();

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -186,8 +186,6 @@ class DirectoryService : public Executable, public Broadcastable {
 
   Mediator& m_mediator;
 
-  uint32_t m_numOfAbsentMicroBlocks;
-
   // Coinbase
   std::map<uint64_t, std::map<int32_t, std::vector<Address>>>
       m_coinbaseRewardees;

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -484,9 +484,6 @@ bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
     }
   }
 
-  m_numOfAbsentMicroBlocks = 0;
-  int offset = 0;
-
   if (!m_missingMicroBlocks[m_mediator.m_currentEpochNum].empty()) {
     if (fromShards) {
       LOG_GENERAL(INFO, "Only check for microblocks from shards, failed");
@@ -494,6 +491,9 @@ bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
     }
 
     if (generateErrorMsg) {
+      unsigned int numOfAbsentMicroBlocks = 0;
+      int offset = 0;
+
       for (auto const& hash :
            m_missingMicroBlocks[m_mediator.m_currentEpochNum]) {
         if (errorMsg.empty()) {
@@ -507,11 +507,11 @@ bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
              errorMsg.begin() + offset);
         offset += BLOCK_HASH_SIZE;
 
-        m_numOfAbsentMicroBlocks++;
+        numOfAbsentMicroBlocks++;
       }
 
-      if (m_numOfAbsentMicroBlocks > 0) {
-        Serializable::SetNumber<uint32_t>(errorMsg, 0, m_numOfAbsentMicroBlocks,
+      if (numOfAbsentMicroBlocks > 0) {
+        Serializable::SetNumber<uint32_t>(errorMsg, 0, numOfAbsentMicroBlocks,
                                           sizeof(uint32_t));
         Serializable::SetNumber<uint64_t>(errorMsg, sizeof(uint32_t),
                                           m_mediator.m_currentEpochNum,

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -492,7 +492,7 @@ bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
 
     if (generateErrorMsg) {
       unsigned int numOfAbsentMicroBlocks = 0;
-      int offset = 0;
+      unsigned int offset = 0;
 
       for (auto const& hash :
            m_missingMicroBlocks[m_mediator.m_currentEpochNum]) {

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -443,7 +443,8 @@ bool DirectoryService::CheckFinalBlockTimestamp() {
 
 // Check microblock hashes
 bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
-                                        bool fromShards) {
+                                        bool fromShards,
+                                        bool generateErrorMsg) {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::CheckMicroBlocks not expected to "
@@ -492,30 +493,33 @@ bool DirectoryService::CheckMicroBlocks(std::vector<unsigned char>& errorMsg,
       return false;
     }
 
-    for (auto const& hash :
-         m_missingMicroBlocks[m_mediator.m_currentEpochNum]) {
-      if (errorMsg.empty()) {
-        errorMsg.resize(sizeof(uint32_t) + sizeof(uint64_t) + BLOCK_HASH_SIZE);
-        offset += (sizeof(uint32_t) + sizeof(uint64_t));
-      } else {
-        errorMsg.resize(offset + BLOCK_HASH_SIZE);
+    if (generateErrorMsg) {
+      for (auto const& hash :
+           m_missingMicroBlocks[m_mediator.m_currentEpochNum]) {
+        if (errorMsg.empty()) {
+          errorMsg.resize(sizeof(uint32_t) + sizeof(uint64_t) +
+                          BLOCK_HASH_SIZE);
+          offset += (sizeof(uint32_t) + sizeof(uint64_t));
+        } else {
+          errorMsg.resize(offset + BLOCK_HASH_SIZE);
+        }
+        copy(hash.asArray().begin(), hash.asArray().end(),
+             errorMsg.begin() + offset);
+        offset += BLOCK_HASH_SIZE;
+
+        m_numOfAbsentMicroBlocks++;
       }
-      copy(hash.asArray().begin(), hash.asArray().end(),
-           errorMsg.begin() + offset);
-      offset += BLOCK_HASH_SIZE;
 
-      m_numOfAbsentMicroBlocks++;
+      if (m_numOfAbsentMicroBlocks > 0) {
+        Serializable::SetNumber<uint32_t>(errorMsg, 0, m_numOfAbsentMicroBlocks,
+                                          sizeof(uint32_t));
+        Serializable::SetNumber<uint64_t>(errorMsg, sizeof(uint32_t),
+                                          m_mediator.m_currentEpochNum,
+                                          sizeof(uint64_t));
+      }
+
+      LOG_PAYLOAD(INFO, "ErrorMsg generated:", errorMsg, 200);
     }
-
-    if (m_numOfAbsentMicroBlocks > 0) {
-      Serializable::SetNumber<uint32_t>(errorMsg, 0, m_numOfAbsentMicroBlocks,
-                                        sizeof(uint32_t));
-      Serializable::SetNumber<uint64_t>(errorMsg, sizeof(uint32_t),
-                                        m_mediator.m_currentEpochNum,
-                                        sizeof(uint64_t));
-    }
-
-    LOG_PAYLOAD(INFO, "ErrorMsg generated:", errorMsg, 200);
 
     // AccountStore::GetInstance().InitTemp();
     // LOG_GENERAL(WARNING, "Got missing microblocks, revert state delta");
@@ -996,7 +1000,7 @@ bool DirectoryService::CheckFinalBlockValidity(
 
   if (CheckBlockHash() && CheckBlockTypeIsFinal() && CheckFinalBlockVersion() &&
       CheckFinalBlockNumber() && CheckPreviousFinalBlockHash() &&
-      CheckFinalBlockTimestamp() && CheckMicroBlocks(errorMsg) &&
+      CheckFinalBlockTimestamp() && CheckMicroBlocks(errorMsg, false, true) &&
       CheckLegitimacyOfMicroBlocks() && CheckMicroBlockInfo() &&
       CheckStateRoot() && CheckStateDeltaHash()) {
     return true;
@@ -1090,8 +1094,9 @@ bool DirectoryService::FinalBlockValidator(
   }
 
   vector<unsigned char> t_errorMsg;
-  if (CheckMicroBlocks(t_errorMsg, true)) {  // Firstly check whether the leader
-                                             // has any mb that I don't have
+  if (CheckMicroBlocks(t_errorMsg, true,
+                       false)) {  // Firstly check whether the leader
+                                  // has any mb that I don't have
     if (m_mediator.m_node->m_microblock != nullptr && m_needCheckMicroBlock) {
       if (!CheckMicroBlockValidity(errorMsg)) {
         LOG_GENERAL(WARNING,

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -622,7 +622,7 @@ bool DirectoryService::ProcessMissingMicroblockSubmission(
 
   // TODO: Check if every microblock is obtained
   std::vector<unsigned char> errorMsg;
-  if (!CheckMicroBlocks(errorMsg)) {
+  if (!CheckMicroBlocks(errorMsg, false, false)) {
     LOG_GENERAL(WARNING,
                 "Still have missing microblocks after fetching, what to do???");
     return false;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
It looks like the value of `errorMsg` returned when calling `CheckMicroBlocks` is actually never used in some places where the function is called.  So, it's better to add a flag to indicate if we want to have the list of hashes copied into `errorMsg` or not.

Also, `DirectoryService::m_numOfAbsentMicroBlocks` is not used anywhere else outside of `CheckMicroBlocks` so I just moved it into the function as a local variable.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
