### PR TITLE
Protobuf the missing txns and microblocks error messages

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -384,7 +384,7 @@ class DirectoryService : public Executable, public Broadcastable {
   bool OnNodeFinalConsensusError(const std::vector<unsigned char>& errorMsg,
                                  const Peer& from);
   bool OnNodeMissingMicroBlocks(const std::vector<unsigned char>& errorMsg,
-                                const Peer& from);
+                                const unsigned int offset, const Peer& from);
 
   // void StoreMicroBlocksToDisk();
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -269,6 +269,15 @@ class Messenger {
       const PubKey& leaderKey, VCBlock& vcBlock,
       std::vector<unsigned char>& messageToCosign);
 
+  static bool SetDSMissingMicroBlocksErrorMsg(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const std::vector<BlockHash>& missingMicroBlockHashes,
+      const uint64_t epochNum, const uint32_t listenPort);
+  static bool GetDSMissingMicroBlocksErrorMsg(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      std::vector<BlockHash>& missingMicroBlockHashes, uint64_t& epochNum,
+      uint32_t& listenPort);
+
   // ============================================================================
   // Node messages
   // ============================================================================
@@ -368,6 +377,16 @@ class Messenger {
   static bool ArrayToShardStructure(const std::vector<unsigned char>& src,
                                     const unsigned int offset,
                                     DequeOfShard& shards);
+
+  static bool SetNodeMissingTxnsErrorMsg(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const std::vector<TxnHash>& missingTxnHashes, const uint64_t epochNum,
+      const uint32_t listenPort);
+  static bool GetNodeMissingTxnsErrorMsg(const std::vector<unsigned char>& src,
+                                         const unsigned int offset,
+                                         std::vector<TxnHash>& missingTxnHashes,
+                                         uint64_t& epochNum,
+                                         uint32_t& listenPort);
 
   // ============================================================================
   // Lookup messages

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -352,6 +352,13 @@ message DSVCBlockAnnouncement
     required ByteArray vcblock = 1;
 }
 
+message DSMissingMicroBlocksErrorMsg
+{
+    repeated bytes mbhashes    = 1;
+    required uint64 epochnum   = 2;
+    required uint32 listenport = 3;
+}
+
 // ============================================================================
 // Node messages
 // ============================================================================
@@ -408,6 +415,13 @@ message NodeFallbackBlockAnnouncement
 message NodeFallbackBlock
 {
     required ProtoFallbackBlock fallbackblock = 1;
+}
+
+message NodeMissingTxnsErrorMsg
+{
+    repeated bytes txnhashes   = 1;
+    required uint64 epochnum   = 2;
+    required uint32 listenport = 3;
 }
 
 // ============================================================================

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -162,10 +162,8 @@ bool Node::ComposeMicroBlock() {
 }
 
 bool Node::OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
-                             const Peer& from) {
+                             const unsigned int offset, const Peer& from) {
   LOG_MARKER();
-
-  unsigned int offset = 0;
 
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
@@ -174,35 +172,17 @@ bool Node::OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
     return true;
   }
 
-  if (errorMsg.size() < sizeof(uint32_t) + sizeof(uint64_t) + offset) {
-    LOG_GENERAL(WARNING, "Malformed Message");
+  vector<TxnHash> missingTransactions;
+  uint64_t epochNum = 0;
+  uint32_t portNo = 0;
+
+  if (!Messenger::GetNodeMissingTxnsErrorMsg(
+          errorMsg, offset, missingTransactions, epochNum, portNo)) {
+    LOG_GENERAL(WARNING, "Messenger::GetNodeMissingTxnsErrorMsg failed.");
     return false;
   }
 
-  uint32_t numOfAbsentHashes =
-      Serializable::GetNumber<uint32_t>(errorMsg, offset, sizeof(uint32_t));
-  offset += sizeof(uint32_t);
-
-  uint64_t epochNum =
-      Serializable::GetNumber<uint64_t>(errorMsg, offset, sizeof(uint64_t));
-  offset += sizeof(uint64_t);
-
-  vector<TxnHash> missingTransactions;
-
-  for (uint32_t i = 0; i < numOfAbsentHashes; i++) {
-    TxnHash txnHash;
-    copy(errorMsg.begin() + offset, errorMsg.begin() + offset + TRAN_HASH_SIZE,
-         txnHash.asArray().begin());
-    offset += TRAN_HASH_SIZE;
-
-    missingTransactions.emplace_back(txnHash);
-  }
-
-  uint32_t portNo =
-      Serializable::GetNumber<uint32_t>(errorMsg, offset, sizeof(uint32_t));
-
-  uint128_t ipAddr = from.m_ipAddress;
-  Peer peer(ipAddr, portNo);
+  Peer peer(from.m_ipAddress, portNo);
 
   lock_guard<mutex> g(m_mutexProcessedTransactions);
 
@@ -223,15 +203,15 @@ bool Node::OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
                                   ? t_processedTransactions
                                   : m_processedTransactions[epochNum];
 
-  for (uint32_t i = 0; i < numOfAbsentHashes; i++) {
+  for (const auto& hash : missingTransactions) {
     // LOG_GENERAL(INFO, "Peer " << from << " : " << portNo << " missing txn "
     // << missingTransactions[i])
-    auto found = processedTransactions.find(missingTransactions[i]);
+    auto found = processedTransactions.find(hash);
     if (found != processedTransactions.end()) {
-      txns.push_back(found->second.GetTransaction());
+      txns.emplace_back(found->second.GetTransaction());
     } else {
-      LOG_GENERAL(INFO, "Leader unable to find txn proposed in microblock "
-                            << missingTransactions[i]);
+      LOG_GENERAL(INFO,
+                  "Leader unable to find txn proposed in microblock " << hash);
       continue;
     }
   }
@@ -676,7 +656,7 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader() {
 
   auto nodeMissingTxnsFunc = [this](const vector<unsigned char>& errorMsg,
                                     const Peer& from) mutable -> bool {
-    return OnNodeMissingTxns(errorMsg, from);
+    return OnNodeMissingTxns(errorMsg, 0, from);
   };
 
   auto commitFailureFunc =
@@ -960,35 +940,18 @@ unsigned char Node::CheckLegitimacyOfTxnHashes(
       return LEGITIMACYRESULT::WRONGORDER;
     }
 
-    m_numOfAbsentTxnHashes = 0;
-
-    int offset = 0;
-
-    for (auto const& hash : missingTxnHashes) {
-      LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-                "Missing txn: " << hash)
-      if (errorMsg.size() == 0) {
-        errorMsg.resize(sizeof(uint32_t) + sizeof(uint64_t) + TRAN_HASH_SIZE);
-        offset += (sizeof(uint32_t) + sizeof(uint64_t));
-      } else {
-        errorMsg.resize(offset + TRAN_HASH_SIZE);
-      }
-      copy(hash.asArray().begin(), hash.asArray().end(),
-           errorMsg.begin() + offset);
-      offset += TRAN_HASH_SIZE;
-      m_numOfAbsentTxnHashes++;
+    if (!Messenger::SetNodeMissingTxnsErrorMsg(
+            errorMsg, 0, missingTxnHashes, m_mediator.m_currentEpochNum,
+            m_mediator.m_selfPeer.m_listenPortHost)) {
+      LOG_GENERAL(WARNING, "Messenger::SetNodeMissingTxnsErrorMsg failed.");
+      return false;
     }
 
-    if (m_numOfAbsentTxnHashes > 0) {
+    if (missingTxnHashes.size() > 0) {
       {
         lock_guard<mutex> g(m_mutexCreatedTransactions);
         LOG_GENERAL(WARNING, m_createdTxns);
       }
-      Serializable::SetNumber<uint32_t>(errorMsg, 0, m_numOfAbsentTxnHashes,
-                                        sizeof(uint32_t));
-      Serializable::SetNumber<uint64_t>(errorMsg, sizeof(uint32_t),
-                                        m_mediator.m_currentEpochNum,
-                                        sizeof(uint64_t));
 
       m_txnsOrdering = m_microblock->GetTranHashes();
 
@@ -1263,9 +1226,6 @@ bool Node::MicroBlockValidator(const vector<unsigned char>& message,
 
   if (!CheckMicroBlockValidity(errorMsg)) {
     m_microblock = nullptr;
-    Serializable::SetNumber<uint32_t>(errorMsg, errorMsg.size(),
-                                      m_mediator.m_selfPeer.m_listenPortHost,
-                                      sizeof(uint32_t));
     LOG_GENERAL(WARNING, "CheckMicroBlockValidity Failed");
     return false;
   }

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -122,8 +122,6 @@ class Node : public Executable, public Broadcastable {
   // operates under m_mutexProcessedTransaction
   std::vector<TxnHash> m_TxnOrder;
 
-  uint32_t m_numOfAbsentTxnHashes;
-
   uint64_t m_gasUsedTotal;
   boost::multiprecision::uint128_t m_txnFees;
 
@@ -489,7 +487,7 @@ class Node : public Executable, public Broadcastable {
   bool ComposeMicroBlock();
   bool CheckMicroBlockValidity(std::vector<unsigned char>& errorMsg);
   bool OnNodeMissingTxns(const std::vector<unsigned char>& errorMsg,
-                         const Peer& from);
+                         const unsigned int offset, const Peer& from);
 
   void UpdateStateForNextConsensusRound();
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR converts `errorMsg` into Protobuf.
This PR re-implements #959 so that Protobuf-ing is in line with existing practice (i.e., encapsulation inside Messenger).

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Basically, this is how our `errorMsg` system works:
1. `ConsensusBackup` has a `MsgContentValidatorFunc` function which generates `errorMsg`
2. Whenever `errorMsg` isn't empty, `ConsensusBackup` sends `COMMITFAILURE` message
3. `ConsensusLeader` has a `NodeCommitFailureHandlerFunc` function that is called whenever `COMMITFAILURE` message is received
4. `MsgContentValidatorFunc` is mostly unused except for `DirectoryService::FinalBlockValidator` and `Node::MicroBlockValidator`
5. `NodeCommitFailureHandlerFunc` is mostly unused except for `DirectoryService::OnNodeFinalConsensusError` and `Node::OnNodeMissingTxns`
6. `errorMsg` can contain only one of two things:
- Format 1: missing txn hashes + txn hash count + epochnum (as generated by `Node::CheckLegitimacyOfTxnHashes`)
- Format 2: missing block hashes + block hash count + epochnum (as generated by `DirectoryService::CheckMicroBlocks`)
- Finally, listenport is appended to the end in both cases wherever these 2 generating functions are called

So what I have done is:
1. Define Protobuf messages for each of the 2 `errorMsg` formats (including the listenport)
2. Define set and get for these messages inside Messenger
3. Call the set inside the generating functions
4. Call the get inside the `COMMITFAILURE` handling functions
5. Make sure the manual inclusion of listenport has been removed (as it is already included inside the set function)

The tricky part:
1. In `DirectoryService::FinalBlockValidator`, we also prepend a type byte to `errorMsg`
2. In `Node::MicroBlockValidator`, we don't prepend anything
3. Both validators share calls to `Node::CheckMicroBlockValidity`, so the resulting `errorMsg` can have a prepended type or not, depending on which validator called it
4. So, you will notice I added an `offset` parameter to some of the functions called by the validators. This offset will account for the type whenever it is used.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
