### PR TITLE
Adjust the timing when lookup send out txn packet

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3174,7 +3174,14 @@ void Lookup::SenderTxnBatchThread() {
   }
   LOG_MARKER();
 
+  if (m_startedTxnBatchThread) {
+    LOG_GENERAL(WARNING,
+                "The last TxnBatchThread hasn't finished, discard this time");
+    return;
+  }
+
   auto main_func = [this]() mutable -> void {
+    m_startedTxnBatchThread = true;
     uint32_t numShards = 0;
     while (true) {
       if (!m_mediator.GetIsVacuousEpoch()) {
@@ -3190,6 +3197,7 @@ void Lookup::SenderTxnBatchThread() {
       }
       break;
     }
+    m_startedTxnBatchThread = false;
   };
   DetachedFunction(1, main_func);
 }

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3221,15 +3221,15 @@ void Lookup::SendTxnPacketToNodes(uint32_t numShards) {
 
   // allow receving nodes to be ready with latest DS block ( Only** for first
   // txn epoch of every ds epoch )
-  if ((m_mediator.m_currentEpochNum == 1) ||
-      (m_mediator.m_currentEpochNum > 1 &&
-       m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)) {
-    LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
-              "Waiting for " << LOOKUP_DELAY_SEND_TXNPACKET_IN_MS
-                             << " ms before sending txn packets to shards");
-    this_thread::sleep_for(
-        chrono::milliseconds(LOOKUP_DELAY_SEND_TXNPACKET_IN_MS));
-  }
+  // if ((m_mediator.m_currentEpochNum == 1) ||
+  //     (m_mediator.m_currentEpochNum > 1 &&
+  //      m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)) {
+  //   LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
+  //             "Waiting for " << LOOKUP_DELAY_SEND_TXNPACKET_IN_MS
+  //                            << " ms before sending txn packets to shards");
+  //   this_thread::sleep_for(
+  //       chrono::milliseconds(LOOKUP_DELAY_SEND_TXNPACKET_IN_MS));
+  // }
 
   for (unsigned int i = 0; i < numShards + 1; i++) {
     vector<unsigned char> msg = {MessageType::NODE,

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -73,6 +73,7 @@ class Lookup : public Executable, public Broadcastable {
   std::unordered_set<Peer> l_nodesInNetwork;
   std::map<uint32_t, std::vector<Transaction>> m_txnShardMap;
   std::mutex m_txnShardMapMutex;
+  bool m_startedTxnBatchThread = false;
 
   // Start PoW variables
   bool m_receivedRaiseStartPoW = false;

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -623,7 +623,12 @@ bool Node::ProcessVCDSBlocksMessage(const vector<unsigned char>& message,
     ResetConsensusId();
 
     if (m_mediator.m_lookup->GetIsServer()) {
-      m_mediator.m_lookup->SenderTxnBatchThread();
+      auto func = [this]() mutable -> void {
+        std::this_thread::sleep_for(
+            chrono::milliseconds(LOOKUP_DELAY_SEND_TXNPACKET_IN_MS));
+        m_mediator.m_lookup->SenderTxnBatchThread();
+      };
+      DetachedFunction(1, func);
     }
 
     FallbackTimerLaunch();

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -827,7 +827,9 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
     // Now only forwarded txn are left, so only call in lookup
     CommitMBnForwardedTransactionBuffer();
     if (m_mediator.m_lookup->GetIsServer() && !isVacuousEpoch &&
-        !m_mediator.GetIsVacuousEpoch()) {
+        !m_mediator.GetIsVacuousEpoch() &&
+        (((m_mediator.m_currentEpochNum + NUM_VACUOUS_EPOCHS + 1) %
+          NUM_FINAL_BLOCK_PER_POW) == 0)) {
       auto func = [this]() mutable -> void {
         std::this_thread::sleep_for(
             chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS));

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -828,8 +828,8 @@ bool Node::ProcessFinalBlock(const vector<unsigned char>& message,
     CommitMBnForwardedTransactionBuffer();
     if (m_mediator.m_lookup->GetIsServer() && !isVacuousEpoch &&
         !m_mediator.GetIsVacuousEpoch() &&
-        (((m_mediator.m_currentEpochNum + NUM_VACUOUS_EPOCHS + 1) %
-          NUM_FINAL_BLOCK_PER_POW) == 0)) {
+        ((m_mediator.m_currentEpochNum + NUM_VACUOUS_EPOCHS + 1) %
+         NUM_FINAL_BLOCK_PER_POW) != 0) {
       auto func = [this]() mutable -> void {
         std::this_thread::sleep_for(
             chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS));

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -619,11 +619,10 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader() {
   if (m_mediator.m_ds->m_mode == DirectoryService::Mode::IDLE &&
       !m_mediator.GetIsVacuousEpoch()) {
     unsigned int sleep_time =
-        TX_DISTRIBUTE_TIME_IN_MS +
-        ((m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() ==
-          m_mediator.m_currentEpochNum)
-             ? LOOKUP_DELAY_SEND_TXNPACKET_IN_MS
-             : 0);
+        (m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() ==
+         m_mediator.m_currentEpochNum)
+            ? LOOKUP_DELAY_SEND_TXNPACKET_IN_MS
+            : TX_DISTRIBUTE_TIME_IN_MS;
     LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
               "Non-vacuous epoch, going to sleep for " << sleep_time
                                                        << " milliseconds");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1079,10 +1079,6 @@ bool Node::ProcessTxnPacketFromLookup(
   }
 
   if (m_mediator.m_lookup->IsLookupNode(from)) {
-    if (epochNumber < m_mediator.m_currentEpochNum) {
-      LOG_GENERAL(WARNING, "Txn packet from older epoch, discard");
-      return false;
-    }
     lock_guard<mutex> g(m_mutexTxnPacketBuffer);
     LOG_GENERAL(INFO, "Received txn from lookup, stored to buffer");
     LOG_STATE("[TXNPKTPROC]["


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Now the lookup will send out the txn packet when TXN_DISTRIBUTE_TIME_IN_MS ended, saying during the microblock and finalblock consensus. With the previous implementation the lookup will avoid sending packet to the leader nodes which may congeste the consensus processing.

In this case, every first epoch in a DS epoch won't have any transaction to process, thus the waiting time before microblock consensus is reduced

And also a flag is introduced to fix the issue when the packet preparing is taking too long to flood the thread pool of the lookup.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
