### PR TITLE
Change COINBASE_REWARD reading from constants to uint128_t

### DIFF
--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -335,8 +335,8 @@ const unsigned int NUM_TXN_TO_SEND_PER_ACCOUNT{
     ReadConstantNumeric("NUM_TXN_TO_SEND_PER_ACCOUNT", "node.tests.")};
 
 // Transaction constants
-const unsigned int COINBASE_REWARD{
-    ReadConstantNumeric("COINBASE_REWARD", "node.transactions.")};
+const boost::multiprecision::uint128_t COINBASE_REWARD{
+    ReadConstantString("COINBASE_REWARD", "node.transactions.")};
 const unsigned int LOOKUP_REWARD_IN_PERCENT{
     ReadConstantNumeric("LOOKUP_REWARD_IN_PERCENT", "node.transactions.")};
 const unsigned int MAX_CODE_SIZE_IN_BYTES{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -259,7 +259,7 @@ extern const unsigned int FALLBACK_TEST_EPOCH;
 extern const unsigned int NUM_TXN_TO_SEND_PER_ACCOUNT;
 
 // Transaction constants
-extern const unsigned int COINBASE_REWARD;
+extern const boost::multiprecision::uint128_t COINBASE_REWARD;
 extern const unsigned int LOOKUP_REWARD_IN_PERCENT;
 extern const unsigned int MAX_CODE_SIZE_IN_BYTES;
 extern const unsigned int MAX_CONTRACT_DEPTH;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`COINBASE_REWARD` has to be changed from `unsigned int` to `uint128_t`.
`uint128_t` has a constructor that accepts string input, so this change is easily done by calling `ReadConstantString` instead of `ReadConstantNumeric`.

Tested locally by displaying the read-out value in my test for a very large value.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
