### PR TITLE
Fix DS nodes not sending DS microblock to Lookups

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -222,6 +222,10 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
   // Update the final block with the co-signatures from the consensus
   m_finalBlock->SetCoSignatures(*m_consensusObject);
 
+  // Update the DS microblock with the same co-signatures from the consensus
+  // If we don't do this, DataSender won't be able to process it
+  m_mediator.m_node->m_microblock->SetCoSignatures(*m_consensusObject);
+
   bool isVacuousEpoch = m_mediator.GetIsVacuousEpoch();
 
   // StoreMicroBlocksToDisk();

--- a/src/libNetwork/DataSender.cpp
+++ b/src/libNetwork/DataSender.cpp
@@ -179,7 +179,10 @@ bool DataSender::SendDataToOthers(
   LOG_MARKER();
 
   if (blockwcosig.GetB2().size() != sendercommittee.size()) {
-    LOG_GENERAL(WARNING, "B2 size and committee size is not identical!");
+    LOG_GENERAL(WARNING, "B2 size " << blockwcosig.GetB2().size()
+                                    << " and committee size "
+                                    << sendercommittee.size()
+                                    << " is not identical!");
     return false;
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The message "B2 size and committee size is not identical!" is showing up in every Tx epoch when doing `ProcessFinalBlockConsensusWhenDone`.
It turns out that this is happening when the DS microblock is being sent inside `Node::CallActOnFinalblock` to the lookup nodes.
This is because the DS microblock's cosignatures are still the default values (1-bit bitmaps) after finalblock consensus.
The fix is to set the DS microblock to have the same cosig as the finalblock.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
