### PR TITLE
Validate the ConsensusFailure message from the Leader

### DIFF
--- a/src/libConsensus/ConsensusBackup.cpp
+++ b/src/libConsensus/ConsensusBackup.cpp
@@ -143,9 +143,15 @@ bool ConsensusBackup::ProcessMessageAnnounce(
 }
 
 bool ConsensusBackup::ProcessMessageConsensusFailure(
-    [[gnu::unused]] const vector<unsigned char>& announcement,
-    [[gnu::unused]] unsigned int offset) {
+    const vector<unsigned char>& announcement, unsigned int offset) {
   LOG_MARKER();
+
+  if (!Messenger::GetConsensusConsensusFailure(
+          announcement, offset, m_consensusID, m_blockNumber, m_blockHash,
+          m_leaderID, GetCommitteeMember(m_leaderID).first)) {
+    LOG_GENERAL(WARNING, "Messenger::GetConsensusConsensusFailure failed.");
+    return false;
+  }
 
   m_state = INITIAL;
 

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -387,6 +387,15 @@ bool ConsensusLeader::ProcessMessageCommitFailure(
 
     vector<unsigned char> consensusFailureMsg = {m_classByte, m_insByte,
                                                  CONSENSUSFAILURE};
+
+    if (!Messenger::SetConsensusConsensusFailure(
+            consensusFailureMsg, MessageOffset::BODY + sizeof(unsigned char),
+            m_consensusID, m_blockNumber, m_blockHash, m_myID,
+            make_pair(m_myPrivKey, GetCommitteeMember(m_myID).first))) {
+      LOG_GENERAL(WARNING, "Messenger::SetConsensusConsensusFailure failed.");
+      return false;
+    }
+
     deque<Peer> peerInfo;
 
     for (auto const& i : m_committee) {

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -5478,12 +5478,12 @@ bool Messenger::GetLookupSetTxnsFromLookup(
 
 bool Messenger::SetLookupGetDirectoryBlocksFromSeed(vector<unsigned char>& dst,
                                                     const unsigned int offset,
-                                                    const uint32_t portno,
-                                                    const uint64_t& index_num) {
+                                                    const uint32_t portNo,
+                                                    const uint64_t& indexNum) {
   LookupGetDirectoryBlocksFromSeed result;
 
-  result.set_portno(portno);
-  result.set_indexnum(index_num);
+  result.set_portno(portNo);
+  result.set_indexnum(indexNum);
 
   if (!result.IsInitialized()) {
     LOG_GENERAL(WARNING,
@@ -5496,7 +5496,7 @@ bool Messenger::SetLookupGetDirectoryBlocksFromSeed(vector<unsigned char>& dst,
 
 bool Messenger::GetLookupGetDirectoryBlocksFromSeed(
     const vector<unsigned char>& src, const unsigned int offset,
-    uint32_t& portno, uint64_t& index_num) {
+    uint32_t& portNo, uint64_t& indexNum) {
   LookupGetDirectoryBlocksFromSeed result;
 
   result.ParseFromArray(src.data() + offset, src.size() - offset);
@@ -5507,9 +5507,9 @@ bool Messenger::GetLookupGetDirectoryBlocksFromSeed(
     return false;
   }
 
-  portno = result.portno();
+  portNo = result.portno();
 
-  index_num = result.indexnum();
+  indexNum = result.indexnum();
 
   return true;
 }
@@ -5519,10 +5519,10 @@ bool Messenger::SetLookupSetDirectoryBlocksFromSeed(
     const vector<
         boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
         directoryBlocks,
-    const uint64_t& index_num) {
+    const uint64_t& indexNum) {
   LookupSetDirectoryBlocksFromSeed result;
 
-  result.set_indexnum(index_num);
+  result.set_indexnum(indexNum);
 
   for (const auto& dirblock : directoryBlocks) {
     ProtoSingleDirectoryBlock* proto_dir_blocks = result.add_dirblocks();
@@ -5555,7 +5555,7 @@ bool Messenger::GetLookupSetDirectoryBlocksFromSeed(
     const vector<unsigned char>& src, const unsigned int offset,
     vector<boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
         directoryBlocks,
-    uint64_t& index_num) {
+    uint64_t& indexNum) {
   LookupSetDirectoryBlocksFromSeed result;
 
   result.ParseFromArray(src.data() + offset, src.size() - offset);
@@ -5566,7 +5566,7 @@ bool Messenger::GetLookupSetDirectoryBlocksFromSeed(
     return false;
   }
 
-  index_num = result.indexnum();
+  indexNum = result.indexnum();
 
   for (const auto& dirblock : result.dirblocks()) {
     DSBlock dsblock;
@@ -6078,13 +6078,6 @@ bool Messenger::GetConsensusCollectiveSig(
     return false;
   }
 
-  if (result.consensusinfo().blocknumber() != blockNumber) {
-    LOG_GENERAL(WARNING, "Block number mismatch. Expected: "
-                             << blockNumber << " Actual: "
-                             << result.consensusinfo().blocknumber());
-    return false;
-  }
-
   if (result.consensusinfo().leaderid() != leaderID) {
     LOG_GENERAL(WARNING, "Leader ID mismatch. Expected: "
                              << leaderID << " Actual: "
@@ -6321,13 +6314,6 @@ bool Messenger::GetConsensusConsensusFailure(
                     << DataConversion::Uint8VecToHexStr(blockHash)
                     << " Actual: "
                     << DataConversion::Uint8VecToHexStr(remoteBlockHash));
-    return false;
-  }
-
-  if (result.consensusinfo().blocknumber() != blockNumber) {
-    LOG_GENERAL(WARNING, "Block number mismatch. Expected: "
-                             << blockNumber << " Actual: "
-                             << result.consensusinfo().blocknumber());
     return false;
   }
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -188,12 +188,14 @@ class Messenger {
   static bool GetTransactionReceipt(const std::vector<unsigned char>& src,
                                     const unsigned int offset,
                                     TransactionReceipt& transactionReceipt);
+
   static bool SetTransactionWithReceipt(
       std::vector<unsigned char>& dst, const unsigned int offset,
       const TransactionWithReceipt& transactionWithReceipt);
   static bool GetTransactionWithReceipt(
       const std::vector<unsigned char>& src, const unsigned int offset,
       TransactionWithReceipt& transactionWithReceipt);
+
   static bool SetPeer(std::vector<unsigned char>& dst,
                       const unsigned int offset, const Peer& peer);
   static bool GetPeer(const std::vector<unsigned char>& src,
@@ -202,6 +204,20 @@ class Messenger {
   static bool StateDeltaToAddressMap(
       const std::vector<unsigned char>& src, const unsigned int offset,
       std::unordered_map<Address, boost::multiprecision::int256_t>& accountMap);
+
+  static bool SetBlockLink(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const std::tuple<uint64_t, uint64_t, BlockType, BlockHash>& blocklink);
+  static bool GetBlockLink(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      std::tuple<uint64_t, uint64_t, BlockType, BlockHash>& blocklink);
+
+  static bool SetFallbackBlockWShardingStructure(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const FallbackBlock& fallbackblock, const DequeOfShard& shards);
+  static bool GetFallbackBlockWShardingStructure(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      FallbackBlock& fallbackblock, DequeOfShard& shards);
 
   // ============================================================================
   // Peer Manager messages
@@ -632,6 +648,26 @@ class Messenger {
       const std::vector<unsigned char>& src, const unsigned int offset,
       PubKey& lookupPubKey, std::vector<TransactionWithReceipt>& txns);
 
+  static bool SetLookupGetDirectoryBlocksFromSeed(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const uint32_t portno, const uint64_t& index_num);
+  static bool GetLookupGetDirectoryBlocksFromSeed(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      uint32_t& portno, uint64_t& index_num);
+
+  static bool SetLookupSetDirectoryBlocksFromSeed(
+      std::vector<unsigned char>& dst, const unsigned int offset,
+      const std::vector<
+          boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
+          directoryBlocks,
+      const uint64_t& index_num);
+  static bool GetLookupSetDirectoryBlocksFromSeed(
+      const std::vector<unsigned char>& src, const unsigned int offset,
+      std::vector<
+          boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
+          directoryBlocks,
+      uint64_t& index_num);
+
   // ============================================================================
   // Consensus messages
   // ============================================================================
@@ -719,36 +755,17 @@ class Messenger {
       const std::vector<unsigned char>& blockHash, uint16_t& backupID,
       std::vector<unsigned char>& errorMsg,
       const std::deque<std::pair<PubKey, Peer>>& committeeKeys);
-  static bool SetBlockLink(
+
+  static bool SetConsensusConsensusFailure(
       std::vector<unsigned char>& dst, const unsigned int offset,
-      const std::tuple<uint64_t, uint64_t, BlockType, BlockHash>& blocklink);
-  static bool GetBlockLink(
+      const uint32_t consensusID, const uint64_t blockNumber,
+      const std::vector<unsigned char>& blockHash, const uint16_t leaderID,
+      const std::pair<PrivKey, PubKey>& leaderKey);
+  static bool GetConsensusConsensusFailure(
       const std::vector<unsigned char>& src, const unsigned int offset,
-      std::tuple<uint64_t, uint64_t, BlockType, BlockHash>& blocklink);
-  static bool SetFallbackBlockWShardingStructure(
-      std::vector<unsigned char>& dst, const unsigned int offset,
-      const FallbackBlock& fallbackblock, const DequeOfShard& shards);
-  static bool GetFallbackBlockWShardingStructure(
-      const std::vector<unsigned char>& src, const unsigned int offset,
-      FallbackBlock& fallbackblock, DequeOfShard& shards);
-  static bool GetLookupGetDirectoryBlocksFromSeed(
-      const std::vector<unsigned char>& src, const unsigned int offset,
-      uint32_t& portno, uint64_t& index_num);
-  static bool SetLookupGetDirectoryBlocksFromSeed(
-      std::vector<unsigned char>& dst, const unsigned int offset,
-      const uint32_t portno, const uint64_t& index_num);
-  static bool SetLookupSetDirectoryBlocksFromSeed(
-      std::vector<unsigned char>& dst, const unsigned int offset,
-      const std::vector<
-          boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
-          directoryBlocks,
-      const uint64_t& index_num);
-  static bool GetLookupSetDirectoryBlocksFromSeed(
-      const std::vector<unsigned char>& src, const unsigned int offset,
-      std::vector<
-          boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
-          directoryBlocks,
-      uint64_t& index_num);
+      const uint32_t consensusID, const uint64_t blockNumber,
+      const std::vector<unsigned char>& blockHash, uint16_t& leaderID,
+      const PubKey& leaderKey);
 
   // ============================================================================
   // View change pre check messages

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -650,23 +650,23 @@ class Messenger {
 
   static bool SetLookupGetDirectoryBlocksFromSeed(
       std::vector<unsigned char>& dst, const unsigned int offset,
-      const uint32_t portno, const uint64_t& index_num);
+      const uint32_t portNo, const uint64_t& indexNum);
   static bool GetLookupGetDirectoryBlocksFromSeed(
       const std::vector<unsigned char>& src, const unsigned int offset,
-      uint32_t& portno, uint64_t& index_num);
+      uint32_t& portNo, uint64_t& indexNum);
 
   static bool SetLookupSetDirectoryBlocksFromSeed(
       std::vector<unsigned char>& dst, const unsigned int offset,
       const std::vector<
           boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
           directoryBlocks,
-      const uint64_t& index_num);
+      const uint64_t& indexNum);
   static bool GetLookupSetDirectoryBlocksFromSeed(
       const std::vector<unsigned char>& src, const unsigned int offset,
       std::vector<
           boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>&
           directoryBlocks,
-      uint64_t& index_num);
+      uint64_t& indexNum);
 
   // ============================================================================
   // Consensus messages

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -299,6 +299,30 @@ message ProtoFallbackBlock
     required ProtoBlockBase blockbase        = 2;
 }
 
+message ProtoBlockLink
+{
+    required uint64 index       = 1;
+    required uint64 dsindex     = 2;
+    required uint32 blocktype   = 3;
+    required bytes blockhash    = 4;
+}
+
+message ProtoFallbackBlockWShardingStructure
+{
+    required ProtoFallbackBlock fallbackblock   = 1;
+    required ProtoShardingStructure sharding    = 2;
+}
+
+message ProtoSingleDirectoryBlock
+{
+    oneof directoryblock
+    {
+        ProtoDSBlock dsblock                                     = 1;
+        ProtoVCBlock vcblock                                     = 2;
+        ProtoFallbackBlockWShardingStructure fallbackblockwshard = 3;
+    }
+}
+
 // ============================================================================
 // Peer Manager messages
 // ============================================================================
@@ -635,6 +659,17 @@ message LookupSetTxnsFromLookup
     required ByteArray signature    = 3;
 }
 
+message LookupGetDirectoryBlocksFromSeed
+{
+    required uint32 portno      = 1;
+    required uint64 indexnum    = 2;
+}
+
+message LookupSetDirectoryBlocksFromSeed
+{
+    required uint64 indexnum                     = 1;
+    repeated ProtoSingleDirectoryBlock dirblocks = 2;
+}
 
 // ============================================================================
 // Consensus messages
@@ -736,41 +771,17 @@ message ConsensusCommitFailure
     required ByteArray signature         = 2;
 }
 
-message ProtoBlockLink
+message ConsensusConsensusFailure
 {
-    required uint64 index       = 1;
-    required uint64 dsindex     = 2;
-    required uint32 blocktype   = 3;
-    required bytes blockhash    = 4;
-}
-
-message ProtoFallbackBlockWShardingStructure
-{
-    required ProtoFallbackBlock fallbackblock   = 1;
-    required ProtoShardingStructure sharding    = 2;
-}
-
-
-message ProtoSingleDirectoryBlock
-{
-    oneof directoryblock
+    message ConsensusInfo
     {
-        ProtoDSBlock dsblock                                     = 1;
-        ProtoVCBlock vcblock                                     = 2;
-        ProtoFallbackBlockWShardingStructure fallbackblockwshard = 3;
+        required uint32 consensusid      = 1;
+        required uint64 blocknumber      = 2;
+        required bytes blockhash         = 3; // 32 bytes
+        required uint32 leaderid         = 4; // only lower 2 bytes used
     }
-}
-    
-message LookupGetDirectoryBlocksFromSeed
-{
-    required uint32 portno      = 1;
-    required uint64 indexnum    = 2;
-}
-
-message LookupSetDirectoryBlocksFromSeed
-{
-    required uint64 indexnum                     = 1;
-    repeated ProtoSingleDirectoryBlock dirblocks = 2;
+    required ConsensusInfo consensusinfo = 1;
+    required ByteArray signature         = 2;
 }
 
 // ============================================================================

--- a/tests/Message/Test_Messenger_Consensus.cpp
+++ b/tests/Message/Test_Messenger_Consensus.cpp
@@ -104,4 +104,24 @@ BOOST_AUTO_TEST_CASE(test_SetAndGetConsensusChallenge) {
   BOOST_CHECK(challenge == challengeDeserialized);
 }
 
+BOOST_AUTO_TEST_CASE(test_SetAndGetConsensusConsensusFailure) {
+  vector<unsigned char> dst;
+  unsigned int offset = 0;
+  uint32_t consensusID = TestUtils::DistUint32();
+  uint64_t blockNumber = TestUtils::DistUint32();
+  vector<unsigned char> blockHash(TestUtils::Dist1to99(),
+                                  TestUtils::DistUint8());
+  uint16_t leaderID = TestUtils::DistUint8();
+  pair<PrivKey, PubKey> leaderKey;
+  leaderKey.first = PrivKey();
+  leaderKey.second = PubKey(leaderKey.first);
+
+  BOOST_CHECK(Messenger::SetConsensusConsensusFailure(
+      dst, offset, consensusID, blockNumber, blockHash, leaderID, leaderKey));
+
+  BOOST_CHECK(Messenger::GetConsensusConsensusFailure(
+      dst, offset, consensusID, blockNumber, blockHash, leaderID,
+      leaderKey.second));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`ConsensusMessageType::CONSENSUSFAILURE` is currently not validated, and can be used by a malicious node to modify the state of backup nodes.

This PR does the following:
1. Protobuf the ConsensusFailure message
2. Add the basic fields (ID, block num, etc.) to the message
3. Add the leader's signature over the basic fields
4. Add signature validation when the backups get the message
5. Some re-ordering of existing functions/messages inside ZilliqaMessage.proto and Messenger.h/.cpp
6. Add unit test for ConsensusFailure

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
