### PR TITLE
Fix DS Forwarding Processed Transaction Too Early

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -245,11 +245,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
   m_mediator.UpdateDSBlockRand();
   m_mediator.UpdateTxBlockRand();
 
-  if (m_mediator.m_node->m_microblock != nullptr && !isVacuousEpoch) {
-    m_mediator.m_node->UpdateProcessedTransactions();
-    m_mediator.m_node->CallActOnFinalblock();
-  }
-
   auto composeFinalBlockMessageForSender =
       [this](vector<unsigned char>& message) -> bool {
     return ComposeFinalBlockMessageForSender(message);
@@ -275,6 +270,14 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       << "]["
       << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
       << "] AFTER SENDING FLBLK");
+
+  if (m_mediator.m_node->m_microblock != nullptr && !isVacuousEpoch) {
+    m_mediator.m_node->UpdateProcessedTransactions();
+    if (m_mediator.m_node->m_microblock->GetHeader().GetTxRootHash() !=
+        TxnHash()) {
+      m_mediator.m_node->CallActOnFinalblock();
+    }
+  }
 
   {
     lock_guard<mutex> g(m_mediator.m_mutexCurSWInfo);

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1032,7 +1032,7 @@ bool Node::ProcessMBnForwardTransaction(const vector<unsigned char>& message,
       << entry.m_microBlock.GetHeader().GetEpochNum() << " shard "
       << entry.m_microBlock.GetHeader().GetShardId());
 
-  if (m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1 <
+  if (m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() <
       entry.m_microBlock.GetHeader().GetEpochNum()) {
     lock_guard<mutex> g(m_mutexMBnForwardedTxnBuffer);
     m_mbnForwardedTxnBuffer[entry.m_microBlock.GetHeader().GetEpochNum()]


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The current issue is that the DS committee is sending forwarding transaction before sending the finalblock, and the `+1` makes the lookup failed bufferring the message. So the change here includes:
1. Move the sending of forwarding transaction later than broadcasting finalblock
2. Remove the `+1` so that the message can get buffered.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
