### PR TITLE
CommitTxnPacketBuffer after InitializeRumorManager

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -310,7 +310,6 @@ void Node::StartFirstTxEpoch() {
   }
 
   m_justDidFallback = false;
-  CommitTxnPacketBuffer();
 
   if (BROADCAST_GOSSIP_MODE) {
     std::vector<Peer> peers;
@@ -324,7 +323,7 @@ void Node::StartFirstTxEpoch() {
     P2PComm::GetInstance().InitializeRumorManager(peers);
   }
 
-  SetState(MICROBLOCK_CONSENSUS_PREP);
+  CommitTxnPacketBuffer();
 
   auto main_func3 = [this]() mutable -> void { RunConsensusOnMicroBlock(); };
 


### PR DESCRIPTION
## Description
This PR fixes following:

- Removed duplicate SetState
- CommitTxnPacketBuffer after InitlializeRumorManager. Incase where CommitTxnBuffer takes too long , we will be delaying Initializing RumorManager otherwise.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
