### PR TITLE
Fix extra StateDelta being retrieved if TxBlock from DB is inconsistent

### DIFF
--- a/src/libData/BlockChainData/BlockChain.h
+++ b/src/libData/BlockChainData/BlockChain.h
@@ -104,9 +104,9 @@ class BlockChain {
 
     if (blockNumOfExistingBlock < blockNumOfNewBlock ||
         INIT_BLOCK_NUMBER == blockNumOfExistingBlock) {
-      if (m_blocks.size() != 0) {
+      if (m_blocks.size() > 0) {
         uint64_t blockNumOfLastBlock =
-            m_blocks[blockNumOfNewBlock - 1].GetHeader().GetBlockNum();
+            m_blocks.back().GetHeader().GetBlockNum();
         uint64_t blockNumMissed = blockNumOfNewBlock - blockNumOfLastBlock - 1;
         if (blockNumMissed > 0) {
           LOG_GENERAL(INFO,

--- a/src/libData/BlockChainData/BlockChain.h
+++ b/src/libData/BlockChainData/BlockChain.h
@@ -104,6 +104,18 @@ class BlockChain {
 
     if (blockNumOfExistingBlock < blockNumOfNewBlock ||
         INIT_BLOCK_NUMBER == blockNumOfExistingBlock) {
+      if (m_blocks.size() != 0) {
+        uint64_t blockNumOfLastBlock =
+            m_blocks[blockNumOfNewBlock - 1].GetHeader().GetBlockNum();
+        uint64_t blockNumMissed = blockNumOfNewBlock - blockNumOfLastBlock - 1;
+        if (blockNumMissed > 0) {
+          LOG_GENERAL(INFO,
+                      "block number inconsistent, increase the size of "
+                      "CircularArray, blockNumMissed: "
+                          << blockNumMissed);
+          m_blocks.increase_size(blockNumMissed);
+        }
+      }
       m_blocks.insert_new(blockNumOfNewBlock, block);
     } else {
       LOG_GENERAL(WARNING, "Failed to add " << blockNumOfNewBlock << " "

--- a/src/libData/DataStructures/CircularArray.h
+++ b/src/libData/DataStructures/CircularArray.h
@@ -98,6 +98,9 @@ class CircularArray {
   /// Returns the number of elements stored till now in the array.
   uint64_t size() { return m_size; }
 
+  /// Increase size
+  void increase_size(uint64_t size) { m_size += size; }
+
   /// Returns the storage capacity of the array.
   size_t capacity() { return m_capacity; }
 };

--- a/src/libDirectoryService/Coinbase.cpp
+++ b/src/libDirectoryService/Coinbase.cpp
@@ -33,7 +33,7 @@ template <class Container>
 bool DirectoryService::SaveCoinbaseCore(const vector<bool>& b1,
                                         const vector<bool>& b2,
                                         const Container& shard,
-                                        const uint32_t& shard_id,
+                                        const int32_t& shard_id,
                                         const uint64_t& epochNum) {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -593,7 +593,7 @@ class DirectoryService : public Executable, public Broadcastable {
   template <class Container>
   bool SaveCoinbaseCore(const std::vector<bool>& b1,
                         const std::vector<bool>& b2, const Container& shard,
-                        const uint32_t& shard_id, const uint64_t& epochNum);
+                        const int32_t& shard_id, const uint64_t& epochNum);
 
   /// Implements the Execute function inherited from Executable.
   bool Execute(const std::vector<unsigned char>& message, unsigned int offset,

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1110,7 +1110,8 @@ bool Node::ProcessTxnPacketFromLookup(
     }
   }
 
-  if (m_mediator.m_lookup->IsLookupNode(from)) {
+  if (m_mediator.m_lookup->IsLookupNode(from) &&
+      from.GetPrintableIPAddress() != "127.0.0.1") {
     if (epochNumber < m_mediator.m_currentEpochNum) {
       LOG_GENERAL(WARNING, "Txn packet from older epoch, discard");
       return false;

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -48,14 +48,14 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
     return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
   });
 
-  unsigned int totalSize = blocks.size();
+  unsigned int lastBlockNum = blocks.back()->GetHeader().GetBlockNum();
 
-  unsigned int extra_txblocks = totalSize % NUM_FINAL_BLOCK_PER_POW;
+  unsigned int extra_txblocks = (lastBlockNum + 1) % NUM_FINAL_BLOCK_PER_POW;
 
   if (trimIncompletedBlocks) {
     // truncate the extra final blocks at last
     for (unsigned int i = 0; i < extra_txblocks; ++i) {
-      BlockStorage::GetBlockStorage().DeleteTxBlock(totalSize - 1 - i);
+      BlockStorage::GetBlockStorage().DeleteTxBlock(lastBlockNum - i);
       blocks.pop_back();
     }
   }
@@ -68,7 +68,8 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
   /// current TX epoch
   if (!ARCHIVAL_NODE) {
     for (const auto& block : blocks) {
-      if (block->GetHeader().GetBlockNum() >= totalSize - extra_txblocks) {
+      if (block->GetHeader().GetBlockNum() >=
+          lastBlockNum + 1 - extra_txblocks) {
         std::vector<unsigned char> stateDelta;
         BlockStorage::GetBlockStorage().GetStateDelta(
             block->GetHeader().GetBlockNum(), stateDelta);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
1. Fix extra StateDelta being retrieved if TxBlock from DB is inconsistent
2. Fix GetBlock error e.g. `BlockNum : 3401 != GetBlockNum() : 3451, a dummy block will be used and abnormal behavior may happen!`
3. Fix unmatched type for shard_id when calling `SaveCoinBaseCore` in `SaveCoinBase` which caused integer underflow

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (tested with new node join and rejoin after several ds epoch to replicate the scenario)
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
