### PR TITLE
 Change shardStructure db to store shards for every DS block number

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -560,8 +560,11 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
     ClearReputationOfNodeFailToJoin(m_shards, m_mapNodeReputation);
   }
 
-  BlockStorage::GetBlockStorage().PutShardStructure(
-      m_shards, m_mediator.m_node->m_myshardId);
+  if (!BlockStorage::GetBlockStorage().PutShardStructure(
+          m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
+          m_shards, m_mediator.m_node->m_myshardId)) {
+    LOG_GENERAL(WARNING, "PutShardStructure failed");
+  }
 
   {
     // USe mutex during the composition and sending of vcds block message

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -736,8 +736,11 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
     return false;
   }
 
-  BlockStorage::GetBlockStorage().PutShardStructure(
-      m_shards, m_mediator.m_node->m_myshardId);
+  if (!BlockStorage::GetBlockStorage().PutShardStructure(
+          m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
+          m_shards, m_mediator.m_node->m_myshardId)) {
+    LOG_GENERAL(WARNING, "PutShardStructure failed");
+  }
 
   // Compute the CommitteeHash member of the BlockHeaderBase
   CommitteeHash committeeHash;

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -661,6 +661,8 @@ bool ProtobufToShardingStructure(
     return false;
   }
 
+  shards.clear();
+
   for (const auto& proto_shard : protoShardingStructure.shards()) {
     if (!CheckRequiredFieldsProtoShardingStructureShard(proto_shard)) {
       LOG_GENERAL(WARNING,

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -476,8 +476,11 @@ bool Node::ProcessVCDSBlocksMessage(const bytes& message,
   m_mediator.m_ds->m_shards = move(t_shards);
 
   m_myshardId = shardId;
-  BlockStorage::GetBlockStorage().PutShardStructure(m_mediator.m_ds->m_shards,
-                                                    m_myshardId);
+  if (!BlockStorage::GetBlockStorage().PutShardStructure(
+          m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
+          m_mediator.m_ds->m_shards, m_myshardId)) {
+    LOG_GENERAL(WARNING, "PutShardStructure failed");
+  }
 
   LogReceivedDSBlockDetails(dsblock);
 

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -187,7 +187,8 @@ class BlockStorage : public Singleton<BlockStorage> {
       uint16_t& consensusLeaderID);
 
   /// Save shard structure
-  bool PutShardStructure(const DequeOfShard& shards, const uint32_t myshardId);
+  bool PutShardStructure(const uint64_t& blockNum, const DequeOfShard& shards,
+                         const uint32_t& myshardId);
 
   /// Retrieve shard structure
   bool GetShardStructure(DequeOfShard& shards);

--- a/tests/Persistence/CMakeLists.txt
+++ b/tests/Persistence/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable(Test_TxBody Test_TxBody.cpp)
 target_include_directories(Test_TxBody PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(Test_TxBody PUBLIC Crypto AccountData Utils Persistence Message)
 
+add_executable(Test_ShardStructure Test_ShardStructure.cpp)
+target_include_directories(Test_ShardStructure PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
+target_link_libraries(Test_ShardStructure PUBLIC Crypto AccountData Utils Persistence Message TestUtils)
+
 #FIXME: built but not enabled
 add_executable(ReadBlock ReadBlock.cpp)
 target_include_directories(ReadBlock PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/tests/Persistence/Test_ShardStructure.cpp
+++ b/tests/Persistence/Test_ShardStructure.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018 Zilliqa
+ * This source code is being disclosed to you solely for the purpose of your
+ * participation in testing Zilliqa. You may view, compile and run the code for
+ * that purpose and pursuant to the protocols and algorithms that are programmed
+ * into, and intended by, the code. You may not do anything else with the code
+ * without express permission from Zilliqa Research Pte. Ltd., including
+ * modifying or publishing the code (or any part of it), and developing or
+ * forming another public or private blockchain network. This source code is
+ * provided 'as is' and no warranties are given as to title or non-infringement,
+ * merchantability or fitness for purpose and, to the extent permitted by law,
+ * all liability for your use of the code is disclaimed. Some programs in this
+ * code are governed by the GNU General Public License v3.0 (available at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html) ('GPLv3'). The programs that
+ * are governed by GPLv3.0 are those programs that are located in the folders
+ * src/depends and tests/depends and which include a reference to GPLv3 in their
+ * program files.
+ */
+
+#include <array>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "libPersistence/BlockStorage.h"
+#include "libPersistence/DB.h"
+#include "libTestUtils/TestUtils.h"
+
+#define BOOST_TEST_MODULE persistencetest
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+void PrintShard(const DequeOfShard& shards) {
+  for (const auto& shard : shards) {
+    LOG_GENERAL(INFO, "Shard:")
+    for (const auto& node : shard) {
+      LOG_GENERAL(INFO, "  Node: " << get<SHARD_NODE_PEER>(node) << " "
+                                   << get<SHARD_NODE_PUBKEY>(node));
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE(persistencetest)
+
+BOOST_AUTO_TEST_CASE(testShardStructure) {
+  INIT_STDOUT_LOGGER();
+
+  // Put key (blockNum) = 1->5->3, then check that latest entry is always what
+  // we retrieve (i.e., not sorted by key)
+
+  DequeOfShard shards = TestUtils::GenerateDequeueOfShard(3);
+  DequeOfShard shardsDeserialized;
+
+  BOOST_CHECK(BlockStorage::GetBlockStorage().PutShardStructure(
+      1, shards, TestUtils::DistUint32()));
+  BOOST_CHECK(
+      BlockStorage::GetBlockStorage().GetShardStructure(shardsDeserialized));
+  BOOST_CHECK(shards == shardsDeserialized);
+
+  PrintShard(shardsDeserialized);
+
+  shards = TestUtils::GenerateDequeueOfShard(4);
+
+  BOOST_CHECK(BlockStorage::GetBlockStorage().PutShardStructure(
+      5, shards, TestUtils::DistUint32()));
+  BOOST_CHECK(
+      BlockStorage::GetBlockStorage().GetShardStructure(shardsDeserialized));
+  BOOST_CHECK(shards == shardsDeserialized);
+
+  PrintShard(shardsDeserialized);
+
+  shards = TestUtils::GenerateDequeueOfShard(2);
+
+  BOOST_CHECK(BlockStorage::GetBlockStorage().PutShardStructure(
+      3, shards, TestUtils::DistUint32()));
+  BOOST_CHECK(
+      BlockStorage::GetBlockStorage().GetShardStructure(shardsDeserialized));
+  BOOST_CHECK(shards == shardsDeserialized);
+
+  PrintShard(shardsDeserialized);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
To have an easier way to retrieve sharding structure and track the history of each node across DS epochs, this PR modifies the shardStructure db:

`PutShardStructure`:
Previously: key = 0, value = my shard ID | key = 1, value = shards
Now: key = DS block number, value = my shard ID + shards

`GetShardStructure`:
Previously: returns value (shards) from key = 1
Now: returns value (shards) from latest entry in the db

A unit test has also been added: tests/Persistence/Test_ShardStructure.cpp

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
