### PR TITLE
DS difficulty mining start with shard difficulty winning nonce

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -322,11 +322,13 @@ bool DirectoryService::VerifyPoWWinner(
                                .GetDSDifficulty();
         }
 
-        bool result = POW::GetInstance().PoWVerify(
-            m_pendingDSBlock->GetHeader().GetBlockNum(), expectedDSDiff,
+        auto headerHash = POW::GenHeaderHash(
             m_mediator.m_dsBlockRand, m_mediator.m_txBlockRand,
             peer.m_ipAddress, DSPowWinner.first, dsPowSoln.lookupId,
-            dsPowSoln.gasPrice, dsPowSoln.nonce,
+            dsPowSoln.gasPrice);
+        bool result = POW::GetInstance().PoWVerify(
+            m_pendingDSBlock->GetHeader().GetBlockNum(), expectedDSDiff,
+            headerHash, dsPowSoln.nonce,
             DataConversion::charArrToHexStr(dsPowSoln.result),
             DataConversion::charArrToHexStr(dsPowSoln.mixhash));
         if (!result) {

--- a/src/libDirectoryService/PoWProcessing.cpp
+++ b/src/libDirectoryService/PoWProcessing.cpp
@@ -301,9 +301,10 @@ bool DirectoryService::ProcessPoWSubmissionFromPacket(
 
   m_timespec = r_timer_start();
 
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, submitterPeer.m_ipAddress,
+                                       submitterPubKey, lookupId, gasPrice);
   bool result = POW::GetInstance().PoWVerify(
-      blockNumber, difficultyLevel, rand1, rand2, submitterPeer.m_ipAddress,
-      submitterPubKey, lookupId, gasPrice, nonce, resultingHash, mixHash);
+      blockNumber, difficultyLevel, headerHash, nonce, resultingHash, mixHash);
 
   LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),
             "[POWSTAT] pow verify (microsec): " << r_timer_end(m_timespec));

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -35,8 +35,6 @@ class Messenger {
  public:
   template <class K, class V>
   static bool CopyWithSizeCheck(const K& arr, V& result) {
-    LOG_MARKER();
-
     // Fixed length copying.
     if (arr.size() != result.size()) {
       LOG_GENERAL(WARNING, "Size check while copying failed. Size expected = "

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1126,7 +1126,7 @@ bool Node::ProcessTxnPacketFromLookup([[gnu::unused]] const bytes& message,
   } else {
     LOG_GENERAL(INFO,
                 "Packet received from a non-lookup node, "
-                "should be from gossip neightor and process it");
+                "should be from gossip neighbor and process it");
     return ProcessTxnPacketFromLookupCore(message, epochNumber, dsBlockNum,
                                           shardId, lookupPubKey, transactions);
   }

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -115,18 +115,17 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
   ethash_mining_result winning_result;
 
   uint32_t shardGuardDiff = 1;
+  auto headerHash = POW::GenHeaderHash(
+      rand1, rand2, m_mediator.m_selfPeer.m_ipAddress,
+      m_mediator.m_selfKey.second, lookupId, m_proposedGasPrice);
   // Only in guard mode that shard guard can submit diffferent PoW
   if (GUARD_MODE && Guard::GetInstance().IsNodeInShardGuardList(
                         m_mediator.m_selfKey.second)) {
     winning_result = POW::GetInstance().PoWMine(
-        block_num, shardGuardDiff, rand1, rand2,
-        m_mediator.m_selfPeer.m_ipAddress, m_mediator.m_selfKey.second,
-        lookupId, m_proposedGasPrice, FULL_DATASET_MINE);
+        block_num, shardGuardDiff, headerHash, FULL_DATASET_MINE, std::time(0));
   } else {
     winning_result = POW::GetInstance().PoWMine(
-        block_num, difficulty, rand1, rand2, m_mediator.m_selfPeer.m_ipAddress,
-        m_mediator.m_selfKey.second, lookupId, m_proposedGasPrice,
-        FULL_DATASET_MINE);
+        block_num, difficulty, headerHash, FULL_DATASET_MINE, std::time(0));
   }
 
   if (winning_result.success) {
@@ -231,9 +230,8 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
                   "doing more pow");
 
       ethash_mining_result ds_pow_winning_result = POW::GetInstance().PoWMine(
-          block_num, ds_difficulty, rand1, rand2,
-          m_mediator.m_selfPeer.m_ipAddress, m_mediator.m_selfKey.second,
-          lookupId, m_proposedGasPrice, FULL_DATASET_MINE);
+          block_num, ds_difficulty, headerHash, FULL_DATASET_MINE,
+          winning_result.winning_nonce);
 
       if (ds_pow_winning_result.success) {
         LOG_GENERAL(INFO,

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -321,11 +321,11 @@ ethash_hash256 POW::GenHeaderHash(
     const std::array<unsigned char, UINT256_SIZE>& rand2,
     const boost::multiprecision::uint128_t& ipAddr, const PubKey& pubKey,
     uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice) {
-  bytes sha3_result =
+  bytes sha2_result =
       ConcatAndhash(rand1, rand2, ipAddr, pubKey, lookupId, gasPrice);
 
   // Let's hash the inputs before feeding to ethash
-  return StringToBlockhash(DataConversion::Uint8VecToHexStr(sha3_result));
+  return StringToBlockhash(DataConversion::Uint8VecToHexStr(sha2_result));
 }
 
 ethash_mining_result_t POW::PoWMine(uint64_t blockNum, uint8_t difficulty,

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -170,8 +170,9 @@ bool POW::EthashConfigureClient(uint64_t block_number, bool fullDataset) {
 }
 
 ethash_mining_result_t POW::MineLight(ethash_hash256 const& header_hash,
-                                      ethash_hash256 const& boundary) {
-  uint64_t nonce = std::time(0);
+                                      ethash_hash256 const& boundary,
+                                      uint64_t startNonce) {
+  uint64_t nonce = startNonce;
   while (m_shouldMine) {
     auto mineResult = ethash::hash(*m_epochContextLight, header_hash, nonce);
     if (ethash::is_less_or_equal(mineResult.final_hash, boundary)) {
@@ -188,8 +189,9 @@ ethash_mining_result_t POW::MineLight(ethash_hash256 const& header_hash,
 }
 
 ethash_mining_result_t POW::MineFull(ethash_hash256 const& header_hash,
-                                     ethash_hash256 const& boundary) {
-  uint64_t nonce = std::time(0);
+                                     ethash_hash256 const& boundary,
+                                     uint64_t startNonce) {
+  uint64_t nonce = startNonce;
   while (m_shouldMine) {
     auto mineResult = ethash::hash(*m_epochContextFull, header_hash, nonce);
     if (ethash::is_less_or_equal(mineResult.final_hash, boundary)) {
@@ -207,9 +209,10 @@ ethash_mining_result_t POW::MineFull(ethash_hash256 const& header_hash,
 
 ethash_mining_result_t POW::MineFullGPU(uint64_t blockNum,
                                         ethash_hash256 const& header_hash,
-                                        uint8_t difficulty) {
+                                        uint8_t difficulty,
+                                        uint64_t startNonce) {
   std::vector<std::unique_ptr<std::thread>> vecThread;
-  uint64_t nonce = std::time(0);
+  uint64_t nonce = startNonce;
   m_minerIndex = 0;
   // Clear old result
   for (auto& miningResult : m_vecMiningResult) {
@@ -313,13 +316,21 @@ bytes POW::ConcatAndhash(const std::array<unsigned char, UINT256_SIZE>& rand1,
   return sha2_result;
 }
 
-ethash_mining_result_t POW::PoWMine(
-    uint64_t blockNum, uint8_t difficulty,
+ethash_hash256 POW::GenHeaderHash(
     const std::array<unsigned char, UINT256_SIZE>& rand1,
     const std::array<unsigned char, UINT256_SIZE>& rand2,
     const boost::multiprecision::uint128_t& ipAddr, const PubKey& pubKey,
-    uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice,
-    bool fullDataset) {
+    uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice) {
+  bytes sha3_result =
+      ConcatAndhash(rand1, rand2, ipAddr, pubKey, lookupId, gasPrice);
+
+  // Let's hash the inputs before feeding to ethash
+  return StringToBlockhash(DataConversion::Uint8VecToHexStr(sha3_result));
+}
+
+ethash_mining_result_t POW::PoWMine(uint64_t blockNum, uint8_t difficulty,
+                                    const ethash_hash256& headerHash,
+                                    bool fullDataset, uint64_t startNonce) {
   LOG_MARKER();
   // mutex required to prevent a new mining to begin before previous mining
   // operation has ended(ie. m_shouldMine=false has been processed) and
@@ -327,41 +338,28 @@ ethash_mining_result_t POW::PoWMine(
   std::lock_guard<std::mutex> g(m_mutexPoWMine);
   EthashConfigureClient(blockNum, fullDataset);
   auto boundary = DifficultyLevelInInt(difficulty);
-  bytes sha3_result =
-      ConcatAndhash(rand1, rand2, ipAddr, pubKey, lookupId, gasPrice);
 
-  // Let's hash the inputs before feeding to ethash
-  auto headerHash =
-      StringToBlockhash(DataConversion::Uint8VecToHexStr(sha3_result));
   ethash_mining_result_t result;
 
   m_shouldMine = true;
 
   if (OPENCL_GPU_MINE || CUDA_GPU_MINE) {
-    result = MineFullGPU(blockNum, headerHash, difficulty);
+    result = MineFullGPU(blockNum, headerHash, difficulty, startNonce);
   } else if (fullDataset) {
-    result = MineFull(headerHash, boundary);
+    result = MineFull(headerHash, boundary, startNonce);
   } else {
-    result = MineLight(headerHash, boundary);
+    result = MineLight(headerHash, boundary, startNonce);
   }
   return result;
 }
 
 bool POW::PoWVerify(uint64_t blockNum, uint8_t difficulty,
-                    const std::array<unsigned char, UINT256_SIZE>& rand1,
-                    const std::array<unsigned char, UINT256_SIZE>& rand2,
-                    const boost::multiprecision::uint128_t& ipAddr,
-                    const PubKey& pubKey, uint32_t lookupId,
-                    const boost::multiprecision::uint128_t& gasPrice,
-                    uint64_t winning_nonce, const std::string& winning_result,
+                    const ethash_hash256& headerHash, uint64_t winning_nonce,
+                    const std::string& winning_result,
                     const std::string& winning_mixhash) {
   LOG_MARKER();
   EthashConfigureClient(blockNum);
   const auto boundary = DifficultyLevelInInt(difficulty);
-  bytes sha3_result =
-      ConcatAndhash(rand1, rand2, ipAddr, pubKey, lookupId, gasPrice);
-  auto headerHash =
-      StringToBlockhash(DataConversion::Uint8VecToHexStr(sha3_result));
   auto winnning_result = StringToBlockhash(winning_result);
   auto winningMixhash = StringToBlockhash(winning_mixhash);
 

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -73,32 +73,30 @@ class POW {
   /// Initializes the POW hash function for the specified block number.
   bool EthashConfigureClient(uint64_t block_number, bool fullDataset = false);
 
-  /// Triggers the proof-of-work mining.
-  ethash_mining_result_t PoWMine(
-      uint64_t blockNum, uint8_t difficulty,
+  static ethash_hash256 GenHeaderHash(
       const std::array<unsigned char, UINT256_SIZE>& rand1,
       const std::array<unsigned char, UINT256_SIZE>& rand2,
       const boost::multiprecision::uint128_t& ipAddr, const PubKey& pubKey,
-      uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice,
-      bool fullDataset);
+      uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice);
+
+  /// Triggers the proof-of-work mining.
+  ethash_mining_result_t PoWMine(uint64_t blockNum, uint8_t difficulty,
+                                 const ethash_hash256& headerHash,
+                                 bool fullDataset, uint64_t startNonce);
 
   /// Terminates proof-of-work mining.
   void StopMining();
 
   /// Verifies a proof-of-work submission.
   bool PoWVerify(uint64_t blockNum, uint8_t difficulty,
-                 const std::array<unsigned char, UINT256_SIZE>& rand1,
-                 const std::array<unsigned char, UINT256_SIZE>& rand2,
-                 const boost::multiprecision::uint128_t& ipAddr,
-                 const PubKey& pubKey, uint32_t lookupId,
-                 const boost::multiprecision::uint128_t& gasPrice,
-                 uint64_t winning_nonce, const std::string& winning_result,
+                 const ethash_hash256& headerHash, uint64_t winning_nonce,
+                 const std::string& winning_result,
                  const std::string& winning_mixhash);
-  bytes ConcatAndhash(const std::array<unsigned char, UINT256_SIZE>& rand1,
-                      const std::array<unsigned char, UINT256_SIZE>& rand2,
-                      const boost::multiprecision::uint128_t& ipAddr,
-                      const PubKey& pubKey, uint32_t lookupId,
-                      const boost::multiprecision::uint128_t& gasPrice);
+  static bytes ConcatAndhash(
+      const std::array<unsigned char, UINT256_SIZE>& rand1,
+      const std::array<unsigned char, UINT256_SIZE>& rand2,
+      const boost::multiprecision::uint128_t& ipAddr, const PubKey& pubKey,
+      uint32_t lookupId, const boost::multiprecision::uint128_t& gasPrice);
   ethash::result LightHash(uint64_t blockNum, ethash_hash256 const& header_hash,
                            uint64_t nonce);
   bool CheckSolnAgainstsTargetedDifficulty(const ethash_hash256& result,
@@ -119,12 +117,14 @@ class POW {
   std::mutex m_mutexMiningResult;
 
   ethash_mining_result_t MineLight(ethash_hash256 const& header_hash,
-                                   ethash_hash256 const& boundary);
+                                   ethash_hash256 const& boundary,
+                                   uint64_t startNonce);
   ethash_mining_result_t MineFull(ethash_hash256 const& header_hash,
-                                  ethash_hash256 const& boundary);
+                                  ethash_hash256 const& boundary,
+                                  uint64_t startNonce);
   ethash_mining_result_t MineFullGPU(uint64_t blockNum,
                                      ethash_hash256 const& header_hash,
-                                     uint8_t difficulty);
+                                     uint8_t difficulty, uint64_t startNonce);
   void MineFullGPUThread(uint64_t blockNum, ethash_hash256 const& header_hash,
                          uint8_t difficulty, uint64_t nonce);
   void InitOpenCL();

--- a/tests/POW/test_POW.cpp
+++ b/tests/POW/test_POW.cpp
@@ -279,35 +279,34 @@ BOOST_AUTO_TEST_CASE(mining_and_verification) {
   // Light client mine and verify
   uint8_t difficultyToUse = 10;
   uint64_t blockToUse = 0;
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   ethash_mining_result_t winning_result = POWClient.PoWMine(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0, false);
-  bool verifyLight =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, false, std::time(0));
+  bool verifyLight = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(verifyLight);
 
   rand1 = {{'0', '3'}};
+  auto wrongHeaderHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   bool verifyRand =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      POWClient.PoWVerify(blockToUse, difficultyToUse, wrongHeaderHash,
+                          winning_result.winning_nonce, winning_result.result,
+                          winning_result.mix_hash);
   BOOST_REQUIRE(!verifyRand);
 
   // Now let's adjust the difficulty expectation during verification
-  rand1 = {{'0', '1'}};
   difficultyToUse = 30;
-  bool verifyDifficulty =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+  bool verifyDifficulty = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyDifficulty);
 
   difficultyToUse = 10;
   uint64_t winning_nonce = 0;
   bool verifyWinningNonce = POWClient.PoWVerify(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0,
-      winning_nonce, winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyWinningNonce);
 }
 
@@ -321,35 +320,34 @@ BOOST_AUTO_TEST_CASE(mining_and_verification_big_block_number) {
   // Light client mine and verify
   uint8_t difficultyToUse = 10;
   uint64_t blockToUse = 34567;
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   ethash_mining_result_t winning_result = POWClient.PoWMine(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0, false);
-  bool verifyLight =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, false, std::time(0));
+  bool verifyLight = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(verifyLight);
 
   rand1 = {{'0', '3'}};
+  auto wrongHeaderHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   bool verifyRand =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      POWClient.PoWVerify(blockToUse, difficultyToUse, wrongHeaderHash,
+                          winning_result.winning_nonce, winning_result.result,
+                          winning_result.mix_hash);
   BOOST_REQUIRE(!verifyRand);
 
   // Now let's adjust the difficulty expectation during verification
-  rand1 = {{'0', '1'}};
   difficultyToUse = 30;
-  bool verifyDifficulty =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+  bool verifyDifficulty = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyDifficulty);
 
   difficultyToUse = 10;
   uint64_t winning_nonce = 0;
   bool verifyWinningNonce = POWClient.PoWVerify(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0,
-      winning_nonce, winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyWinningNonce);
 }
 
@@ -363,35 +361,34 @@ BOOST_AUTO_TEST_CASE(mining_and_verification_full) {
   // Light client mine and verify
   uint8_t difficultyToUse = 10;
   uint64_t blockToUse = 0;
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   ethash_mining_result_t winning_result = POWClient.PoWMine(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0, true);
-  bool verifyLight =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, true, std::time(0));
+  bool verifyLight = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(verifyLight);
 
   rand1 = {{'0', '3'}};
+  auto wrongHeaderHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   bool verifyRand =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      POWClient.PoWVerify(blockToUse, difficultyToUse, wrongHeaderHash,
+                          winning_result.winning_nonce, winning_result.result,
+                          winning_result.mix_hash);
   BOOST_REQUIRE(!verifyRand);
 
   // Now let's adjust the difficulty expectation during verification
-  rand1 = {{'0', '1'}};
   difficultyToUse = 30;
-  bool verifyDifficulty =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+  bool verifyDifficulty = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyDifficulty);
 
   difficultyToUse = 10;
   uint64_t winning_nonce = 0;
   bool verifyWinningNonce = POWClient.PoWVerify(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0,
-      winning_nonce, winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyWinningNonce);
 }
 
@@ -421,35 +418,34 @@ BOOST_AUTO_TEST_CASE(gpu_mining_and_verification_1) {
   // Light client mine and verify
   uint8_t difficultyToUse = 10;
   uint64_t blockToUse = 0;
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   ethash_mining_result_t winning_result = POWClient.PoWMine(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0, true);
-  bool verifyLight =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, true, std::time(0));
+  bool verifyLight = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(verifyLight);
 
   rand1 = {{'0', '3'}};
+  auto wrongHeaderHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   bool verifyRand =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      POWClient.PoWVerify(blockToUse, difficultyToUse, wrongHeaderHash,
+                          winning_result.winning_nonce, winning_result.result,
+                          winning_result.mix_hash);
   BOOST_REQUIRE(!verifyRand);
 
   // Now let's adjust the difficulty expectation during verification
-  rand1 = {{'0', '1'}};
   difficultyToUse = 30;
-  bool verifyDifficulty =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+  bool verifyDifficulty = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyDifficulty);
 
   difficultyToUse = 10;
   uint64_t winning_nonce = 0;
   bool verifyWinningNonce = POWClient.PoWVerify(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0,
-      winning_nonce, winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyWinningNonce);
 }
 
@@ -479,35 +475,34 @@ BOOST_AUTO_TEST_CASE(gpu_mining_and_verification_2) {
   // Light client mine and verify
   uint8_t difficultyToUse = 20;
   uint64_t blockToUse = 1234567;
+  auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   ethash_mining_result_t winning_result = POWClient.PoWMine(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0, true);
-  bool verifyLight =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, true, std::time(0));
+  bool verifyLight = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(verifyLight);
 
   rand1 = {{'0', '3'}};
+  auto wrongHeaderHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   bool verifyRand =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+      POWClient.PoWVerify(blockToUse, difficultyToUse, wrongHeaderHash,
+                          winning_result.winning_nonce, winning_result.result,
+                          winning_result.mix_hash);
   BOOST_REQUIRE(!verifyRand);
 
   // Now let's adjust the difficulty expectation during verification
-  rand1 = {{'0', '1'}};
   difficultyToUse = 30;
-  bool verifyDifficulty =
-      POWClient.PoWVerify(blockToUse, difficultyToUse, rand1, rand2, ipAddr,
-                          pubKey, 0, 0, winning_result.winning_nonce,
-                          winning_result.result, winning_result.mix_hash);
+  bool verifyDifficulty = POWClient.PoWVerify(
+      blockToUse, difficultyToUse, headerHash, winning_result.winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyDifficulty);
 
   difficultyToUse = 10;
   uint64_t winning_nonce = 0;
   bool verifyWinningNonce = POWClient.PoWVerify(
-      blockToUse, difficultyToUse, rand1, rand2, ipAddr, pubKey, 0, 0,
-      winning_nonce, winning_result.result, winning_result.mix_hash);
+      blockToUse, difficultyToUse, headerHash, winning_nonce,
+      winning_result.result, winning_result.mix_hash);
   BOOST_REQUIRE(!verifyWinningNonce);
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
DS difficulty mining start with shard difficulty winning nonce
<!-- What is the context of your pull request? -->
It is because the DS PoW start nonce use the current time, it has overlap with shard PoW nonce. The DS PoW should start from the nonce of the shard pow winning nonce, so more node can finish DS PoW, then there will be more nodes finish DS PoW, then the DS difficulty will be higher than shard difficulty.
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/389

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
