### PR TITLE
Clear subscriber list of rumor manager

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -334,6 +334,11 @@ bool DirectoryService::ProcessSetPrimary(const bytes& message,
             "Starting consensus on ds block");
   RunConsensusOnDSBlock();
 
+  {
+    lock_guard<mutex> g(m_mutexPowSolution);
+    m_powSolutions.clear();
+  }
+
   return true;
 }
 
@@ -694,15 +699,14 @@ void DirectoryService::StartNewDSEpochConsensus(bool fromFallback,
     }
 
     RunConsensusOnDSBlock(isRejoin);
-
-    // now that we already run DSBlock Consensus, lets clear the buffered pow
-    // solutions. why not clear it at start of new ds epoch - becoz sometimes
-    // node is too late to start new ds epoch and and it already receives pow
-    // solution for next ds epoch. so we buffer them instead.
-    {
-      lock_guard<mutex> g(m_mutexPowSolution);
-      m_powSolutions.clear();
-    }
+  }
+  // now that we already run DSBlock Consensus, lets clear the buffered pow
+  // solutions. why not clear it at start of new ds epoch - becoz sometimes
+  // node is too late to start new ds epoch and and it already receives pow
+  // solution for next ds epoch. so we buffer them instead.
+  {
+    lock_guard<mutex> g(m_mutexPowSolution);
+    m_powSolutions.clear();
   }
 }
 

--- a/src/libNetwork/RumorManager.cpp
+++ b/src/libNetwork/RumorManager.cpp
@@ -144,6 +144,7 @@ bool RumorManager::Initialize(const std::vector<std::pair<PubKey, Peer>>& peers,
   m_rumorRawMsgTimestamp.clear();
   m_fullNetworkKeys.clear();
   m_pubKeyPeerBiMap.clear();
+  m_hashesSubscriberMap.clear();
 
   int peerIdGenerator = 0;
   for (const auto& p : peers) {


### PR DESCRIPTION
## Description
This PR fixed the missing clearance of subscriber list during relinitialization of Rumor Manager.
In general, it get clear itself one required message is sent to subscriber in list. However, it should always clear during initialization as well.

## Review Suggestion
Please check file changed.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
