### PR TITLE
Pin the last working scilla image in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@
 # src/depends and tests/depends and which include a reference to GPLv3 in their
 # program files.
 #
-FROM zilliqa/scilla
+FROM zilliqa/scilla@sha256:094d63cf1a7247598ea9af7ede0023c96738600e0163f8f30a278209cb588251
 
 # Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -15,7 +15,7 @@
 # src/depends and tests/depends and which include a reference to GPLv3 in their
 # program files.
 #
-FROM zilliqa/scilla
+FROM zilliqa/scilla@sha256:094d63cf1a7247598ea9af7ede0023c96738600e0163f8f30a278209cb588251
 
 # Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -35,13 +35,13 @@ ubuntu-1804: check-commit
 	docker build -f dev/Dockerfile --build-arg COMMIT=$(commit) --build-arg BASE=ubuntu:18.04 .
 
 # build zilliqa docker image for Kubernetes usage
-k8s: check-commit get-scilla
+k8s: check-commit
 	cat dev/Dockerfile dev/Dockerfile.k8s | docker build -t zilliqa:$(commit) \
 		--build-arg COMMIT=$(commit) -
 
 # build release version docker image for public usage
-release: get-scilla
+release:
 	docker build -f Dockerfile -t zilliqa/zilliqa:v$(major).$(minor).$(fix) .
 
-release-cuda: get-scilla
+release-cuda:
 	docker build -f Dockerfile.cuda -t zilliqa/zilliqa:v$(major).$(minor).$(fix)-cuda .

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -15,7 +15,7 @@
 # src/depends and tests/depends and which include a reference to GPLv3 in their
 # program files.
 #
-ARG BASE=zilliqa/scilla
+ARG BASE=zilliqa/scilla@sha256:094d63cf1a7247598ea9af7ede0023c96738600e0163f8f30a278209cb588251
 FROM ${BASE}
 
 # Format guideline: one package per line and keep them alphabetically sorted


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The `zilliqa/scilla:latest` image has some issues. This PR pins the last working version of scilla image.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

try `make k8s COMMIT=a773cbe` from the directory `docker/`

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~~small-scale cloud test~~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
