### PR TITLE
Add timeout for waiting pow result from mining proxy

### DIFF
--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -261,6 +261,10 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
                     "requirement");
       }
     }
+  } else {
+    // If failed to do PoW, try to rejoin in next DS block
+    RejoinAsNormal();
+    return false;
   }
 
   if (m_state != MICROBLOCK_CONSENSUS_PREP && m_state != MICROBLOCK_CONSENSUS) {

--- a/src/libPOW/pow.h
+++ b/src/libPOW/pow.h
@@ -115,10 +115,10 @@ class POW {
   bool SendWorkToProxy(const PairOfKey& pairOfKey, uint64_t blockNum,
                        ethash_hash256 const& headerHash,
                        ethash_hash256 const& boundary);
-  bool CheckMiningResult(const PairOfKey& pairOfKey, uint64_t blockNum,
+  bool CheckMiningResult(const PairOfKey& pairOfKey,
                          ethash_hash256 const& headerHash,
-                         ethash_hash256 const& boundary,
-                         ethash_mining_result_t& miningResult);
+                         ethash_hash256 const& boundary, uint64_t& nonce,
+                         ethash_hash256& mixHash);
   bool VerifyRemoteSoln(uint64_t blockNum, ethash_hash256 const& boundary,
                         uint64_t nonce, const ethash_hash256& headerHash,
                         const ethash_hash256& mixHash,

--- a/tests/POW/test_RemoteMine.cpp
+++ b/tests/POW/test_RemoteMine.cpp
@@ -54,7 +54,7 @@ void TestRemoteMineCase_1() {
   PairOfKey keyPair(privKey, pubKey);
 
   // Light client mine and verify
-  uint8_t difficultyToUse = 3;
+  uint8_t difficultyToUse = POW_DIFFICULTY;
   uint64_t blockToUse = 1000;
   auto headerHash = POW::GenHeaderHash(rand1, rand2, ipAddr, pubKey, 0, 0);
   auto boundary = POW::DifficultyLevelInInt(difficultyToUse);
@@ -67,7 +67,7 @@ void TestRemoteMineCase_1() {
   std::cout << "Verify difficulty " << std::to_string(difficultyToUse)
             << " result " << verifyLight << std::endl;
 
-  difficultyToUse = 5;
+  difficultyToUse = DS_POW_DIFFICULTY;
   boundary = POW::DifficultyLevelInInt(difficultyToUse);
 
   winning_result =

--- a/tests/POW/test_RemoteMine.cpp
+++ b/tests/POW/test_RemoteMine.cpp
@@ -26,10 +26,20 @@
 #include <iostream>
 #include <vector>
 
+static std::array<uint8_t, 32> generateRandomArray() {
+  std::array<uint8_t, 32> randResult;
+  std::srand(
+      std::time(nullptr));  // use current time as seed for random generator
+  for (int i = 0; i < 32; ++i) {
+    randResult[i] = std::rand() % std::numeric_limits<uint8_t>::max();
+  }
+  return randResult;
+}
+
 void TestRemoteMineCase_1() {
   POW& POWClient = POW::GetInstance();
-  std::array<unsigned char, 32> rand1 = {{'0', '1'}};
-  std::array<unsigned char, 32> rand2 = {{'0', '2'}};
+  std::array<unsigned char, 32> rand1 = generateRandomArray();
+  std::array<unsigned char, 32> rand2 = generateRandomArray();
   boost::multiprecision::uint128_t ipAddr = 2307193356;
   PrivKey privKey(
       DataConversion::StringToCharArray(


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Add timeout for wating pow result from mining proxy
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
If mining proxy don't have the pow result, the node will check result forever. Need to add a timeout for it, if doesn't finish pow in time, then need to do rejoin.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
