### PR TITLE
Roll back OpenSSL to 1.0.2g

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,17 +56,20 @@ find_program(HOMEBREW NAMES brew PATH /usr/local/bin)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND HOMEBREW)
     execute_process(
-        COMMAND ${HOMEBREW} --prefix openssl@1.1
+        #TODO: upgrade to OpenSSL 1.1.1a
+        COMMAND ${HOMEBREW} --prefix openssl
         OUTPUT_VARIABLE OPENSSL_ROOT_DIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    include(InstallOpenSSL)
-    set(OPENSSL_USE_STATIC_LIBS TRUE)
-    set(OPENSSL_ROOT_DIR ${CMAKE_BINARY_DIR}/openssl)
+    #TODO: upgrade to OpenSSL 1.1.1a
+    # include(InstallOpenSSL)
+    # set(OPENSSL_USE_STATIC_LIBS TRUE)
+    # set(OPENSSL_ROOT_DIR ${CMAKE_BINARY_DIR}/openssl)
 endif()
 
-find_package(OpenSSL 1.1 REQUIRED)
+#TODO: upgrade to OpenSSL 1.1.1a
+find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 find_package(LevelDB REQUIRED)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To run Zilliqa, we recommend the following minimum system requirements:
 * macOS:
 
     ```bash
-    brew install boost pkg-config jsoncpp leveldb libjson-rpc-cpp libevent miniupnpc protobuf openssl@1.1
+    brew install boost pkg-config jsoncpp leveldb libjson-rpc-cpp libevent miniupnpc protobuf
     ```
 
 ## Running Zilliqa locally

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To run Zilliqa, we recommend the following minimum system requirements:
     sudo apt-get install git libboost-system-dev libboost-filesystem-dev libboost-test-dev \
         libssl-dev libleveldb-dev libjsoncpp-dev libsnappy-dev cmake libmicrohttpd-dev \
         libjsonrpccpp-dev build-essential pkg-config libevent-dev libminiupnpc-dev \
-        libprotobuf-dev protobuf-compiler libcurl4-openssl-dev
+        libprotobuf-dev protobuf-compiler libcurl4-openssl-dev libssl-dev
     ```
 
 * macOS:

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -71,6 +71,7 @@ apt-get install -y \
     cmake \
     build-essential \
     pkg-config \
+    libssl-dev \
     libboost-system-dev \
     libboost-filesystem-dev \
     libboost-test-dev \

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -622,7 +622,8 @@ bool Schnorr::Sign(const bytes& message, unsigned int offset, unsigned int size,
 
       // 1. Generate a random k from [1,..., order-1]
       do {
-        err = (BN_rand(k.get(), BN_num_bits(m_curve.m_order.get()), -1, 0) == 0);
+        err =
+            (BN_rand(k.get(), BN_num_bits(m_curve.m_order.get()), -1, 0) == 0);
         if (err) {
           LOG_GENERAL(WARNING, "Random generation failed");
           return false;

--- a/src/libCrypto/Schnorr.cpp
+++ b/src/libCrypto/Schnorr.cpp
@@ -622,10 +622,7 @@ bool Schnorr::Sign(const bytes& message, unsigned int offset, unsigned int size,
 
       // 1. Generate a random k from [1,..., order-1]
       do {
-        err = (BN_generate_dsa_nonce(
-                   k.get(), m_curve.m_order.get(), privkey.m_d.get(),
-                   static_cast<const unsigned char*>(message.data()),
-                   message.size(), ctx.get()) == 0);
+        err = (BN_rand(k.get(), BN_num_bits(m_curve.m_order.get()), -1, 0) == 0);
         if (err) {
           LOG_GENERAL(WARNING, "Random generation failed");
           return false;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR downgrade the OpenSSL version to 1.1.1a until it can be correctly integrated. It involves the following changes:
- revert the only used 1.1.1a function introduced by https://github.com/Zilliqa/Zilliqa/pull/1034
- make the other changes in CMake

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] ~~local machine test~~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
