### PR TITLE
Drop duplicate microblocks and remove DS microblock before viewchange

### DIFF
--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -281,6 +281,17 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
     return false;
   }
 
+  auto& microBlocksAtEpoch = m_microBlocks[m_mediator.m_currentEpochNum];
+
+  // Check if we already received a validated microblock with the same shard id
+  if (find_if(microBlocksAtEpoch.begin(), microBlocksAtEpoch.end(),
+              [this, shardId](const MicroBlock& mb) -> bool {
+                return mb.GetHeader().GetShardId() == shardId;
+              }) != microBlocksAtEpoch.end()) {
+    LOG_GENERAL(WARNING, "Duplicate microblock received for shard " << shardId);
+    return false;
+  }
+
   if (!SaveCoinbase(microBlock.GetB1(), microBlock.GetB2(),
                     microBlock.GetHeader().GetShardId(),
                     m_mediator.m_currentEpochNum)) {
@@ -303,7 +314,6 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
     }
   }
 
-  auto& microBlocksAtEpoch = m_microBlocks[m_mediator.m_currentEpochNum];
   microBlocksAtEpoch.emplace(microBlock);
 
   LOG_EPOCH(INFO, to_string(m_mediator.m_currentEpochNum).c_str(),

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -285,7 +285,7 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
 
   // Check if we already received a validated microblock with the same shard id
   if (find_if(microBlocksAtEpoch.begin(), microBlocksAtEpoch.end(),
-              [this, shardId](const MicroBlock& mb) -> bool {
+              [shardId](const MicroBlock& mb) -> bool {
                 return mb.GetHeader().GetShardId() == shardId;
               }) != microBlocksAtEpoch.end()) {
     LOG_GENERAL(WARNING, "Duplicate microblock received for shard " << shardId);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
During testing, it was observed that a DS node can accept microblocks repeatedly from the same shard. This PR discards those microblocks once a microblock from the same shard has already been accepted.

It was also observed that after a viewchange, a DS backup that was previously a DS leader (before viewchange) pushed the new DS leader's DS microblock on top of its own proposed DS microblock (for the failed consensus before viewchange).  This PR will erase any DS microblock that is in the set of microblocks before a viewchange occurs.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
