### PR TITLE
Resolve build errored issue on Travis

### DIFF
--- a/cmake/InstallG3log.cmake
+++ b/cmake/InstallG3log.cmake
@@ -1,5 +1,6 @@
 set(G3LOG_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/depends/g3log)
 set(G3LOG_BINARY_DIR ${CMAKE_BINARY_DIR}/src/depends/g3log)
+set(G3LOG_INSTALL_DIR ${CMAKE_BINARY_DIR}/g3log)
 set(G3LOG_INSTALL_LOG ${CMAKE_BINARY_DIR}/install_g3log.log)
 
 message(STATUS "Building and installing g3log")
@@ -28,7 +29,7 @@ execute_process(
         -B${G3LOG_BINARY_DIR}
         -DUSE_DYNAMIC_LOGGING_LEVELS=ON
         -DG3_SHARED_LIB=OFF
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}
+        -DCMAKE_INSTALL_PREFIX=${G3LOG_INSTALL_DIR}
         -DADD_FATAL_EXAMPLE=OFF
         -DENABLE_FATAL_SIGNALHANDLING=OFF
         -Wno-dev
@@ -64,5 +65,6 @@ if(NOT "${G3LOG_INSTALL_RET}" STREQUAL "0")
     message(FATAL_ERROR "Error when building and installing g3log, see more in log ${G3LOG_INSTALL_LOG}")
 endif()
 
-list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/lib/cmake/g3logger")
+list(APPEND CMAKE_PREFIX_PATH ${G3LOG_INSTALL_DIR})
+list(APPEND CMAKE_MODULE_PATH "${G3LOG_INSTALL_DIR}/lib/cmake/g3logger")
+link_directories(${G3LOG_INSTALL_DIR}/lib)

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -64,7 +64,7 @@ then
     ./scripts/ci_xml_checker.sh constants_local.xml || exit 1
     ./scripts/license_checker.sh || exit 1
     cmake --build ${dir} --target clang-format || exit 1
-    cmake --build ${dir} --target clang-tidy 2>/dev/null || exit 1
+    cmake --build ${dir} --target clang-tidy || exit 1
     # The target Zilliqa_coverage already includes "ctest" command, see cmake/CodeCoverage.cmake
     cmake --build ${dir} --target Zilliqa_coverage || exit 1
 else


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The clang-tidy output was redirected to reduce the output. However, Travis would get timeout error when no output is detected. So the output is now printed in Travis log to avoid the timeout.

This PR also includes a fix to use a separate install folder for g3log. The install targets of g3log will not be added to Zilliqa install target any more.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
