### PR TITLE
Remove redundant check on consensudID for FinalBlockProcessing

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -582,14 +582,6 @@ bool Node::ProcessFinalBlock(const bytes& message, unsigned int offset,
     return false;
   }
 
-  if (consensusID != m_mediator.m_consensusID) {
-    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-              "Consensus ID is not correct. Expected ID: "
-                  << consensusID
-                  << " My Consensus ID: " << m_mediator.m_consensusID);
-    return false;
-  }
-
   // Verify the CommitteeHash member of the BlockHeaderBase
   CommitteeHash committeeHash;
   if (!Messenger::GetDSCommitteeHash(*m_mediator.m_DSCommittee,


### PR DESCRIPTION
## Description
This PR addresses issue - https://github.com/Zilliqa/Issues/issues/412 

## Review Suggestion
Please check file changed.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
