### PR TITLE
Zilliqa and Scilla should be released and upgraded separately

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -11,20 +11,20 @@
 
 ### DO NOT MODIFY FOLLOWING SECTION! IT WILL BE AUTOMATICALLY GENERATED. ###
 === [Scilla]Major Version ===
-
+0
 === [Scilla]Minor Version ===
-
+0
 === [Scilla]Fix Version ===
-
+0
 === [Zilliqa] Git Commit ID ===
-
+0
 === [Zilliqa] SHA-256 ===
-
+0
 === [Zilliqa] Schnorr Signature ===
-
+0
 === [Scilla] Git Commit ID ===
-
+0
 === [Scilla] SHA-256 ===
-
+0
 === [Scilla] Schnorr Signature ===
-
+0


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Since https://github.com/Zilliqa/Zilliqa/pull/1103, Scilla could be upgraded as well as Zilliqa. For more user-friendly, Zilliqa and Scilla should be able to releasing and upgrading separately.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
