### PR TITLE
Add signature and DS block number to ProcessGetStartPoWFromSeed

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1893,7 +1893,7 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
               m_mediator.m_selfPeer.m_listenPortHost,
               m_mediator.m_dsBlockChain.GetLastBlock()
                   .GetHeader()
-                  .GetEpochNum(),
+                  .GetBlockNum(),
               m_mediator.m_selfKey)) {
         LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
                   "Messenger::SetLookupGetStartPoWFromSeed failed.");

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1890,7 +1890,11 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
 
       if (!Messenger::SetLookupGetStartPoWFromSeed(
               getpowsubmission_message, MessageOffset::BODY,
-              m_mediator.m_selfPeer.m_listenPortHost)) {
+              m_mediator.m_selfPeer.m_listenPortHost,
+              m_mediator.m_dsBlockChain.GetLastBlock()
+                  .GetHeader()
+                  .GetEpochNum(),
+              m_mediator.m_selfKey)) {
         LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
                   "Messenger::SetLookupGetStartPoWFromSeed failed.");
         return false;
@@ -2451,10 +2455,24 @@ bool Lookup::ProcessGetStartPoWFromSeed(const bytes& message,
   }
 
   uint32_t portNo = 0;
+  uint64_t blockNumber = 0;
 
-  if (!Messenger::GetLookupGetStartPoWFromSeed(message, offset, portNo)) {
+  if (!Messenger::GetLookupGetStartPoWFromSeed(message, offset, portNo,
+                                               blockNumber)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Messenger::GetLookupGetStartPoWFromSeed failed.");
+    return false;
+  }
+
+  if (blockNumber !=
+      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum()) {
+    LOG_EPOCH(
+        WARNING, m_mediator.m_currentEpochNum,
+        "DS block " << blockNumber
+                    << " in GetStartPoWFromSeed not equal to current DS block "
+                    << m_mediator.m_dsBlockChain.GetLastBlock()
+                           .GetHeader()
+                           .GetBlockNum());
     return false;
   }
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -554,10 +554,13 @@ class Messenger {
                                         const PairOfKey& dsKey);
   static bool SetLookupGetStartPoWFromSeed(bytes& dst,
                                            const unsigned int offset,
-                                           const uint32_t listenPort);
+                                           const uint32_t listenPort,
+                                           const uint64_t blockNumber,
+                                           const PairOfKey& keys);
   static bool GetLookupGetStartPoWFromSeed(const bytes& src,
                                            const unsigned int offset,
-                                           uint32_t& listenPort);
+                                           uint32_t& listenPort,
+                                           uint64_t& blockNumber);
   static bool SetLookupSetStartPoWFromSeed(bytes& dst,
                                            const unsigned int offset,
                                            const uint64_t blockNumber,

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -699,7 +699,14 @@ message LookupRaiseStartPoW
 
 message LookupGetStartPoWFromSeed
 {
-    required uint32 listenport = 1;
+    message Data
+    {
+        required uint32 listenport  = 1;
+        required uint64 blocknumber = 2;
+    }
+    required Data data           = 1;
+    required ByteArray pubkey    = 2;
+    required ByteArray signature = 3;
 }
 
 message LookupSetStartPoWFromSeed


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
To prevent abuse of `GETSTARTPOWFROMSEED`, which can be sent by any new node, this PR adds a signature to it, with the signature generated over both the `listenport` and the current DS block number, to mitigate message replay.

Extra Fix: I noticed `SetLookupSetRaiseStartPoW` protobuf-ed the `signature` twice so I removed the duplicate call.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
