### PR TITLE
Removed excess LOG_MARKER to prevent lookup log bloat

### DIFF
--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -213,7 +213,7 @@ bool BlockStorage::GetDSBlock(const uint64_t& blockNum,
   }
 
   // LOG_GENERAL(INFO, blockString);
-  LOG_GENERAL(INFO, blockString.length());
+  // LOG_GENERAL(INFO, blockString.length());
   block = DSBlockSharedPtr(
       new DSBlock(bytes(blockString.begin(), blockString.end()), 0));
 
@@ -229,7 +229,7 @@ bool BlockStorage::GetVCBlock(const BlockHash& blockhash,
   }
 
   // LOG_GENERAL(INFO, blockString);
-  LOG_GENERAL(INFO, blockString.length());
+  // LOG_GENERAL(INFO, blockString.length());
   block = VCBlockSharedPtr(
       new VCBlock(bytes(blockString.begin(), blockString.end()), 0));
 
@@ -257,7 +257,7 @@ bool BlockStorage::GetFallbackBlock(
   }
 
   // LOG_GENERAL(INFO, blockString);
-  LOG_GENERAL(INFO, blockString.length());
+  // LOG_GENERAL(INFO, blockString.length());
 
   fallbackblockwsharding =
       FallbackBlockSharedPtr(new FallbackBlockWShardingStructure(
@@ -275,7 +275,7 @@ bool BlockStorage::GetBlockLink(const uint64_t& index,
   }
 
   // LOG_GENERAL(INFO, blockString);
-  LOG_GENERAL(INFO, blockString.length());
+  // LOG_GENERAL(INFO, blockString.length());
   BlockLink blnk;
   if (!Messenger::GetBlockLink(bytes(blockString.begin(), blockString.end()), 0,
                                blnk)) {

--- a/src/libUtils/SWInfo.cpp
+++ b/src/libUtils/SWInfo.cpp
@@ -68,7 +68,7 @@ SWInfo::~SWInfo(){};
 
 /// Implements the Serialize function inherited from Serializable.
 unsigned int SWInfo::Serialize(bytes& dst, unsigned int offset) const {
-  LOG_MARKER();
+  // LOG_MARKER();
 
   if ((offset + SIZE) > dst.size()) {
     dst.resize(offset + SIZE);
@@ -102,7 +102,7 @@ unsigned int SWInfo::Serialize(bytes& dst, unsigned int offset) const {
 
 /// Implements the Deserialize function inherited from Serializable.
 int SWInfo::Deserialize(const bytes& src, unsigned int offset) {
-  LOG_MARKER();
+  // LOG_MARKER();
 
   unsigned int curOffset = offset;
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
From previous testnet run, it seems lookup logs roll over very quickly, mostly because of these:
```
[INFO][ 1105][19-01-13T03:17:31.140][ProcessGetDirectoryBlocksFromS] BEGIN
[INFO][ 1105][19-01-13T03:17:31.140][GetBlockLink                  ] 41
[INFO][  534][19-01-13T03:17:31.140][Serialize                     ] BEGIN
[INFO][  534][19-01-13T03:17:31.140][Serialize                     ] END
[INFO][ 1105][19-01-13T03:17:31.141][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.141][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.141][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.141][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.141][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.141][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.141][GetBlockLink                  ] 41
...
```
```
[INFO][  705][19-01-13T03:17:31.167][SetLookupSetTxBlockFromSeed   ] END
[INFO][ 1105][19-01-13T03:17:31.167][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.167][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.167][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.167][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.167][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.167][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.167][GetVCBlock                    ] 1258
[INFO][ 1105][19-01-13T03:17:31.167][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.167][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.168][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.168][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.168][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.168][GetVCBlock                    ] 1195
[INFO][ 1328][19-01-13T03:17:31.171][writeMsg                      ] DEBUG: Sent a total of 4837256 bytes
[INFO][ 1105][19-01-13T03:17:31.172][GetBlockLink                  ] 41
[INFO][  437][19-01-13T03:17:31.172][GetBlockLink                  ] 40
[INFO][ 1105][19-01-13T03:17:31.172][GetBlockLink                  ] 41
[INFO][ 1105][19-01-13T03:17:31.172][GetBlockLink                  ] 41
[INFO][  437][19-01-13T03:17:31.172][GetDSBlock                    ] 1954
[INFO][  437][19-01-13T03:17:31.172][Deserialize                   ] BEGIN
[INFO][  437][19-01-13T03:17:31.172][Deserialize                   ] END
[INFO][  437][19-01-13T03:17:31.173][Serialize                     ] BEGIN
[INFO][  437][19-01-13T03:17:31.173][Serialize                     ] END
[INFO][ 1105][19-01-13T03:17:31.172][GetVCBlock                    ] 1195
[INFO][ 1105][19-01-13T03:17:31.174][GetBlockLink                  ] 41
[INFO][  437][19-01-13T03:17:31.174][GetBlockLink                  ] 40
[INFO][  437][19-01-13T03:17:31.175][GetVCBlock                    ] 1195
...
```
I'm removing the messages in this PR to avoid the logs being unreadable.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
