### PR TITLE
Set member variable after all checks in ProcessGetDSTxBlockMessage

### DIFF
--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -737,8 +737,10 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
   lock_guard<mutex> g(m_MutexCVViewChangePrecheckBlocks);
 
   PubKey lookupPubKey;
+  vector<DSBlock> VCPreCheckDSBlocks;
+  vector<TxBlock> VCPreCheckTxBlocks;
   if (!Messenger::GetVCNodeSetDSTxBlockFromSeed(
-          message, offset, m_vcPreCheckDSBlocks, m_vcPreCheckTxBlocks,
+          message, offset, VCPreCheckDSBlocks, VCPreCheckTxBlocks,
           lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Messenger::GetVCNodeSetDSTxBlockFromSeed failed.");
@@ -752,6 +754,9 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
                   << lookupPubKey << " is not in my lookup node list.");
     return false;
   }
+
+  m_vcPreCheckDSBlocks = VCPreCheckDSBlocks;
+  m_vcPreCheckTxBlocks = VCPreCheckTxBlocks;
 
   cv_viewChangePrecheck.notify_all();
   return true;

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -737,10 +737,10 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
   lock_guard<mutex> g(m_MutexCVViewChangePrecheckBlocks);
 
   PubKey lookupPubKey;
-  vector<DSBlock> VCPreCheckDSBlocks;
-  vector<TxBlock> VCPreCheckTxBlocks;
+  vector<DSBlock> vcPreCheckDSBlocks;
+  vector<TxBlock> vcPreCheckTxBlocks;
   if (!Messenger::GetVCNodeSetDSTxBlockFromSeed(
-          message, offset, VCPreCheckDSBlocks, VCPreCheckTxBlocks,
+          message, offset, vcPreCheckDSBlocks, vcPreCheckTxBlocks,
           lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Messenger::GetVCNodeSetDSTxBlockFromSeed failed.");
@@ -755,8 +755,8 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
     return false;
   }
 
-  m_vcPreCheckDSBlocks = VCPreCheckDSBlocks;
-  m_vcPreCheckTxBlocks = VCPreCheckTxBlocks;
+  m_vcPreCheckDSBlocks = vcPreCheckDSBlocks;
+  m_vcPreCheckTxBlocks = vcPreCheckTxBlocks;
 
   cv_viewChangePrecheck.notify_all();
   return true;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In ProcessGetDSTxBlockMessage, member variables are set before all checks are fully completed. This may result in inconsistent state. This PR change the way it is handled and only set member variables after all checks have been passed.


## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] ~local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] ~small-scale cloud test~
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
