### PR TITLE
Scilla upgrading should use ENABLE_SCILLA_MULTI_VERSION

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -124,6 +124,7 @@ constantArchivalLookupFile="$(realpath ${constantArchivalLookupFile})"
 versionFile="$(realpath ${versionFile})"
 accountName="$(grep -oPm1 "(?<=<UPGRADE_HOST_ACCOUNT>)[^<]+" ${constantFile})"
 repoName="$(grep -oPm1 "(?<=<UPGRADE_HOST_REPO>)[^<]+" ${constantFile})"
+scillaMultiVersion="$(grep -oPm1 "(?<=<ENABLE_SCILLA_MULTI_VERSION>)[^<]+" ${constantFile})"
 zilliqaMajor="$(sed -n ${zilliqaMajorLine}p ${versionFile})"
 zilliqaMinor="$(sed -n ${zilliqaMinorLine}p ${versionFile})"
 zilliqaFix="$(sed -n ${zilliqaFixLine}p ${versionFile})"
@@ -193,8 +194,13 @@ if [ "$scillaPath" != "" ]; then
     make
     cd -
     rm -rf ${scillaDebFolder}/scilla/*
-    mkdir ${scillaDebFolder}/scilla/${scillaMajor}
-    cp -rf ${scillaPath}/* ${scillaDebFolder}/scilla/${scillaMajor}/
+    if [ "$scillaMultiVersion" = "true" ]; then
+        mkdir ${scillaDebFolder}/scilla/${scillaMajor}
+        cp -rf ${scillaPath}/* ${scillaDebFolder}/scilla/${scillaMajor}/
+    else
+        mkdir ${scillaDebFolder}/scilla
+        cp -rf ${scillaPath}/* ${scillaDebFolder}/scilla/
+    fi
     sed -i "/Version: /c\Version: ${scillaMajor}.${scillaMinor}.${scillaFix}" ${scillaDebFolder}/DEBIAN/control
     echo -e "\n\033[0;32mMaking Scilla deb package...\033[0m\n"
     scillaDebFile=${packageName}-${scillaMajor}.${scillaMinor}.${scillaFix}.${scillaDS}.${scillaCommit}-Linux-Scilla.deb


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Since https://github.com/Zilliqa/Zilliqa/pull/1103 and https://github.com/Zilliqa/Zilliqa/pull/1191, scilla releasing should use ENABLE_SCILLA_MULTI_VERSION defined in constant file.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
