### PR TITLE
Protect consensus message buffer, prevent unlimited message

### DIFF
--- a/src/diagnostic/getnetworkhistory.cpp
+++ b/src/diagnostic/getnetworkhistory.cpp
@@ -57,7 +57,7 @@ void processShards(
 }
 
 void processDSCommittee(
-    const DequeOfDSNode& dsCommittee,
+    const DequeOfNode& dsCommittee,
     std::map<std::string, std::map<uint64_t, std::string>>& results,
     uint64_t dsEpochNo) {
   uint64_t dsCommitteeIndex = 0;

--- a/src/libConsensus/ConsensusBackup.h
+++ b/src/libConsensus/ConsensusBackup.h
@@ -94,13 +94,12 @@ class ConsensusBackup : public ConsensusCommon {
       uint16_t leader_id,      // leader's identifier (= index in some ordered
                                // lookup table shared by all nodes)
       const PrivKey& privkey,  // backup's private key
-      const std::deque<std::pair<PubKey, Peer>>&
-          committee,       // ordered lookup table of pubkeys for this committee
-                           // (includes leader)
-      uint8_t class_byte,  // class byte representing Executable class
-                           // using this instance of ConsensusBackup
-      uint8_t ins_byte,    // instruction byte representing consensus
-                           // messages for the Executable class
+      const DequeOfNode& committee,  // ordered lookup table of pubkeys for this
+                                     // committee (includes leader)
+      uint8_t class_byte,            // class byte representing Executable class
+                                     // using this instance of ConsensusBackup
+      uint8_t ins_byte,              // instruction byte representing consensus
+                                     // messages for the Executable class
       MsgContentValidatorFunc
           msg_validator  // function handler for validating the content of
                          // message for consensus (e.g., Tx block)

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -199,35 +199,41 @@ ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }
 
 bool ConsensusCommon::GetConsensusID(const bytes& message,
                                      const unsigned int offset,
+                                     const Peer& from,
                                      uint32_t& consensusID) const {
   if (message.size() > offset) {
     switch (message.at(offset)) {
       case ConsensusMessageType::ANNOUNCE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusAnnouncement>(
-            message, offset + 1, consensusID);
+        return Messenger::GetLeaderConsensusID<
+            ZilliqaMessage::ConsensusAnnouncement>(
+            message, offset + 1, m_committee, from, consensusID);
       case ConsensusMessageType::CONSENSUSFAILURE:
-        return true;
+        return Messenger::GetLeaderConsensusID<
+            ZilliqaMessage::ConsensusConsensusFailure>(
+            message, offset + 1, m_committee, from, consensusID);
       case ConsensusMessageType::COMMIT:
       case ConsensusMessageType::FINALCOMMIT:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusCommit>(
-            message, offset + 1, consensusID);
+        return Messenger::GetBackupConsensusID<ZilliqaMessage::ConsensusCommit>(
+            message, offset + 1, m_committee, from, consensusID);
       case ConsensusMessageType::COMMITFAILURE:
-        return Messenger::GetConsensusID<
-            ZilliqaMessage::ConsensusCommitFailure>(message, offset + 1,
-                                                    consensusID);
+        return Messenger::GetBackupConsensusID<
+            ZilliqaMessage::ConsensusCommitFailure>(
+            message, offset + 1, m_committee, from, consensusID);
       case ConsensusMessageType::CHALLENGE:
       case ConsensusMessageType::FINALCHALLENGE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusChallenge>(
-            message, offset + 1, consensusID);
+        return Messenger::GetLeaderConsensusID<
+            ZilliqaMessage::ConsensusChallenge>(message, offset + 1,
+                                                m_committee, from, consensusID);
       case ConsensusMessageType::RESPONSE:
       case ConsensusMessageType::FINALRESPONSE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusResponse>(
-            message, offset + 1, consensusID);
+        return Messenger::GetBackupConsensusID<
+            ZilliqaMessage::ConsensusResponse>(message, offset + 1, m_committee,
+                                               from, consensusID);
       case ConsensusMessageType::COLLECTIVESIG:
       case ConsensusMessageType::FINALCOLLECTIVESIG:
-        return Messenger::GetConsensusID<
-            ZilliqaMessage::ConsensusCollectiveSig>(message, offset + 1,
-                                                    consensusID);
+        return Messenger::GetLeaderConsensusID<
+            ZilliqaMessage::ConsensusCollectiveSig>(
+            message, offset + 1, m_committee, from, consensusID);
       default:
         LOG_GENERAL(WARNING, "Unknown consensus message received");
         break;

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -199,41 +199,41 @@ ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }
 
 bool ConsensusCommon::GetConsensusID(const bytes& message,
                                      const unsigned int offset,
-                                     const Peer& from,
-                                     uint32_t& consensusID) const {
+                                     const Peer& from, uint32_t& consensusID,
+                                     PubKey& senderPubKey) const {
   if (message.size() > offset) {
     switch (message.at(offset)) {
       case ConsensusMessageType::ANNOUNCE:
         return Messenger::GetLeaderConsensusID<
             ZilliqaMessage::ConsensusAnnouncement>(
-            message, offset + 1, m_committee, from, consensusID);
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       case ConsensusMessageType::CONSENSUSFAILURE:
         return Messenger::GetLeaderConsensusID<
             ZilliqaMessage::ConsensusConsensusFailure>(
-            message, offset + 1, m_committee, from, consensusID);
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       case ConsensusMessageType::COMMIT:
       case ConsensusMessageType::FINALCOMMIT:
         return Messenger::GetBackupConsensusID<ZilliqaMessage::ConsensusCommit>(
-            message, offset + 1, m_committee, from, consensusID);
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       case ConsensusMessageType::COMMITFAILURE:
         return Messenger::GetBackupConsensusID<
             ZilliqaMessage::ConsensusCommitFailure>(
-            message, offset + 1, m_committee, from, consensusID);
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       case ConsensusMessageType::CHALLENGE:
       case ConsensusMessageType::FINALCHALLENGE:
         return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusChallenge>(message, offset + 1,
-                                                m_committee, from, consensusID);
+            ZilliqaMessage::ConsensusChallenge>(
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       case ConsensusMessageType::RESPONSE:
       case ConsensusMessageType::FINALRESPONSE:
         return Messenger::GetBackupConsensusID<
             ZilliqaMessage::ConsensusResponse>(message, offset + 1, m_committee,
-                                               from, consensusID);
+                                               from, consensusID, senderPubKey);
       case ConsensusMessageType::COLLECTIVESIG:
       case ConsensusMessageType::FINALCOLLECTIVESIG:
         return Messenger::GetLeaderConsensusID<
             ZilliqaMessage::ConsensusCollectiveSig>(
-            message, offset + 1, m_committee, from, consensusID);
+            message, offset + 1, m_committee, from, consensusID, senderPubKey);
       default:
         LOG_GENERAL(WARNING, "Unknown consensus message received");
         break;

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -27,6 +27,7 @@
 
 #include "libCrypto/MultiSig.h"
 #include "libNetwork/PeerStore.h"
+#include "libNetwork/ShardStruct.h"
 #include "libUtils/TimeLockedFunction.h"
 
 /// Implements base functionality shared between all consensus committee members
@@ -118,7 +119,7 @@ class ConsensusCommon {
   PrivKey m_myPrivKey;
 
   /// List of <public keys, peers> for the committee.
-  std::deque<std::pair<PubKey, Peer>> m_committee;
+  DequeOfNode m_committee;
 
   /// The payload segment to be co-signed by the committee.
   bytes m_messageToCosign;
@@ -156,8 +157,7 @@ class ConsensusCommon {
   /// Constructor.
   ConsensusCommon(uint32_t consensus_id, uint64_t block_number,
                   const bytes& block_hash, uint16_t my_id,
-                  const PrivKey& privkey,
-                  const std::deque<std::pair<PubKey, Peer>>& committee,
+                  const PrivKey& privkey, const DequeOfNode& committee,
                   unsigned char class_byte, unsigned char ins_byte);
 
   /// Destructor.
@@ -207,7 +207,7 @@ class ConsensusCommon {
 
   /// Returns the consensus ID indicated in the message
   bool GetConsensusID(const bytes& message, const unsigned int offset,
-                      uint32_t& consensusID) const;
+                      const Peer& from, uint32_t& consensusID) const;
 
   /// Returns the consensus error code
   ConsensusErrorCode GetConsensusErrorCode() const;

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -207,7 +207,8 @@ class ConsensusCommon {
 
   /// Returns the consensus ID indicated in the message
   bool GetConsensusID(const bytes& message, const unsigned int offset,
-                      const Peer& from, uint32_t& consensusID) const;
+                      const Peer& from, uint32_t& consensusID,
+                      PubKey& senderPubKey) const;
 
   /// Returns the consensus error code
   ConsensusErrorCode GetConsensusErrorCode() const;

--- a/src/libConsensus/ConsensusLeader.h
+++ b/src/libConsensus/ConsensusLeader.h
@@ -137,14 +137,13 @@ class ConsensusLeader : public ConsensusCommon {
       const bytes& block_hash,  // unique identifier for this consensus session
       uint16_t node_id,  // leader's identifier (= index in some ordered lookup
                          // table shared by all nodes)
-      const PrivKey& privkey,  // leader's private key
-      const std::deque<std::pair<PubKey, Peer>>&
-          committee,  // ordered lookup table of pubkeys for this committee
-                      // (includes leader)
-      unsigned char class_byte,  // class byte representing Executable class
-                                 // using this instance of ConsensusLeader
-      unsigned char ins_byte,    // instruction byte representing consensus
-                                 // messages for the Executable class
+      const PrivKey& privkey,        // leader's private key
+      const DequeOfNode& committee,  // ordered lookup table of pubkeys for this
+                                     // committee (includes leader)
+      unsigned char class_byte,      // class byte representing Executable class
+                                     // using this instance of ConsensusLeader
+      unsigned char ins_byte,        // instruction byte representing consensus
+                                     // messages for the Executable class
       NodeCommitFailureHandlerFunc nodeCommitFailureHandlerFunc,
       ShardCommitFailureHandlerFunc shardCommitFailureHandlerFunc);
 

--- a/src/libData/BlockChainData/BlockLinkChain.h
+++ b/src/libData/BlockChainData/BlockLinkChain.h
@@ -38,7 +38,7 @@ enum BlockLinkIndex : unsigned char {
 class BlockLinkChain {
   CircularArray<BlockLink> m_blockLinkChain;
   std::mutex m_mutexBlockLinkChain;
-  std::deque<std::pair<PubKey, Peer>> m_builtDsCommittee;
+  DequeOfNode m_builtDsCommittee;
 
  public:
   BlockLink GetFromPersistentStorage(const uint64_t& index) {
@@ -118,11 +118,9 @@ class BlockLinkChain {
     return std::get<BlockLinkIndex::INDEX>(m_blockLinkChain.back());
   }
 
-  const std::deque<std::pair<PubKey, Peer>>& GetBuiltDSComm() {
-    return m_builtDsCommittee;
-  }
+  const DequeOfNode& GetBuiltDSComm() { return m_builtDsCommittee; }
 
-  void SetBuiltDSComm(const std::deque<std::pair<PubKey, Peer>>& dsComm) {
+  void SetBuiltDSComm(const DequeOfNode& dsComm) {
     m_builtDsCommittee = dsComm;
   }
 

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.h
@@ -41,7 +41,7 @@ class VCBlockHeader : public BlockHeaderBase {
   Peer m_CandidateLeaderNetworkInfo;
   PubKey m_CandidateLeaderPubKey;
   uint32_t m_VCCounter;
-  std::vector<std::pair<PubKey, Peer>> m_FaultyLeaders;
+  VectorOfNode m_FaultyLeaders;
 
  public:
   /// Default constructor.
@@ -57,8 +57,7 @@ class VCBlockHeader : public BlockHeaderBase {
                 const unsigned char viewChangeState,
                 const Peer& candidateLeaderNetworkInfo,
                 const PubKey& candidateLeaderPubKey, const uint32_t vcCounter,
-                const std::vector<std::pair<PubKey, Peer>>& faultyLeaders,
-                const uint32_t version = 0,
+                const VectorOfNode& faultyLeaders, const uint32_t version = 0,
                 const CommitteeHash& committeeHash = CommitteeHash(),
                 const BlockHash& prevHash = BlockHash());
 
@@ -90,7 +89,7 @@ class VCBlockHeader : public BlockHeaderBase {
   uint32_t GetViewChangeCounter() const;
 
   /// Return all the faulty leaders in the current round of view change
-  const std::vector<std::pair<PubKey, Peer>>& GetFaultyLeaders() const;
+  const VectorOfNode& GetFaultyLeaders() const;
 
   /// Equality operator.
   bool operator==(const VCBlockHeader& header) const;

--- a/src/libDirectoryService/Coinbase.cpp
+++ b/src/libDirectoryService/Coinbase.cpp
@@ -104,7 +104,7 @@ void DirectoryService::LookupCoinbase(
     [[gnu::unused]] const map<PubKey, Peer>& powDSWinner,
     [[gnu::unused]] const MapOfPubKeyPoW& dsPow) {
   LOG_MARKER();
-  VectorOfLookupNode vecLookup = m_mediator.m_lookup->GetLookupNodes();
+  VectorOfNode vecLookup = m_mediator.m_lookup->GetLookupNodes();
   const auto& epochNum = m_mediator.m_currentEpochNum;
 
   lock_guard<mutex> g(m_mutexCoinbaseRewardees);

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -419,7 +419,7 @@ void DirectoryService::StartFirstTxEpoch() {
     m_stopRecvNewMBSubmission = false;
 
     if (BROADCAST_GOSSIP_MODE) {
-      std::vector<std::pair<PubKey, Peer>> peers;
+      VectorOfNode peers;
       std::vector<PubKey> pubKeys;
       GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -569,7 +569,7 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone(
     };
 
     auto sendDSBlockToLookupNodesAndNewDSMembers =
-        [this]([[gnu::unused]] const VectorOfLookupNode& lookups,
+        [this]([[gnu::unused]] const VectorOfNode& lookups,
                const bytes& message) -> void {
       SendDSBlockToLookupNodesAndNewDSMembers(message);
     };

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -468,7 +468,7 @@ bool DirectoryService::CleanVariables() {
     m_missingMicroBlocks.clear();
     m_totalTxnFees = 0;
   }
-  CleanFinalblockConsensusBuffer();
+  CleanFinalBlockConsensusBuffer();
 
   m_finalBlock.reset();
   m_sharingAssignment.clear();
@@ -544,7 +544,7 @@ bool DirectoryService::FinishRejoinAsDS() {
   }
 
   m_mode = BACKUP_DS;
-  DequeOfDSNode dsComm;
+  DequeOfNode dsComm;
   {
     std::lock_guard<mutex> lock(m_mediator.m_mutexDSCommittee);
     LOG_GENERAL(INFO,
@@ -624,7 +624,7 @@ void DirectoryService::StartNewDSEpochConsensus(bool fromFallback,
   m_mediator.m_consensusID = 0;
   m_mediator.m_node->SetConsensusLeaderID(0);
 
-  CleanFinalblockConsensusBuffer();
+  CleanFinalBlockConsensusBuffer();
 
   m_mediator.m_node->CleanCreatedTransaction();
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -229,7 +229,7 @@ bool DirectoryService::ProcessSetPrimary(const bytes& message,
 
   // Lets start the gossip as earliest as possible
   if (BROADCAST_GOSSIP_MODE) {
-    std::vector<std::pair<PubKey, Peer>> peers;
+    VectorOfNode peers;
     std::vector<PubKey> pubKeys;
     GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -528,7 +528,7 @@ bool DirectoryService::FinishRejoinAsDS() {
     }
 
     if (BROADCAST_GOSSIP_MODE) {
-      std::vector<std::pair<PubKey, Peer>> peers;
+      VectorOfNode peers;
       std::vector<PubKey> pubKeys;
       GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -890,7 +890,7 @@ bool DirectoryService::ProcessNewDSGuardNetworkInfo(
     }
 
     if (foundDSGuardNode && BROADCAST_GOSSIP_MODE) {
-      std::vector<std::pair<PubKey, Peer>> peers;
+      VectorOfNode peers;
       std::vector<PubKey> pubKeys;
       GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -1116,8 +1116,8 @@ int64_t DirectoryService::GetAllPoWSize() const {
   return m_allPoWs.size();
 }
 
-void DirectoryService::GetEntireNetworkPeerInfo(
-    std::vector<std::pair<PubKey, Peer>>& peers, std::vector<PubKey>& pubKeys) {
+void DirectoryService::GetEntireNetworkPeerInfo(VectorOfNode& peers,
+                                                std::vector<PubKey>& pubKeys) {
   peers.clear();
   pubKeys.clear();
 

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -427,7 +427,10 @@ class DirectoryService : public Executable, public Broadcastable {
   bytes ComposeVCGetDSTxBlockMessage();
   bool ComposeVCBlockForSender(bytes& vcblock_message);
 
-  void CleanFinalblockConsensusBuffer();
+  void AddToFinalBlockConsensusBuffer(uint32_t consensusId,
+                                      const bytes& message, unsigned int offset,
+                                      const Peer& peer);
+  void CleanFinalBlockConsensusBuffer();
 
   uint8_t CalculateNewDifficulty(const uint8_t& currentDifficulty);
   uint8_t CalculateNewDSDifficulty(const uint8_t& dsDifficulty);

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -169,15 +169,14 @@ class DirectoryService : public Executable, public Broadcastable {
       m_MBSubmissionBuffer;
 
   std::mutex m_mutexFinalBlockConsensusBuffer;
-  std::unordered_map<uint32_t, std::vector<std::pair<Peer, bytes>>>
-      m_finalBlockConsensusBuffer;
+  std::unordered_map<uint32_t, VectorOfNodeMsg> m_finalBlockConsensusBuffer;
 
   std::mutex m_mutexCVMissingMicroBlock;
   std::condition_variable cv_MissingMicroBlock;
 
   // View Change
   std::atomic<uint16_t> m_candidateLeaderIndex;
-  std::vector<std::pair<PubKey, Peer>> m_cumulativeFaultyLeaders;
+  VectorOfNode m_cumulativeFaultyLeaders;
   std::shared_ptr<VCBlock> m_pendingVCBlock;
   std::mutex m_mutexPendingVCBlock;
   std::condition_variable cv_ViewChangeConsensusObj;
@@ -429,7 +428,8 @@ class DirectoryService : public Executable, public Broadcastable {
 
   void AddToFinalBlockConsensusBuffer(uint32_t consensusId,
                                       const bytes& message, unsigned int offset,
-                                      const Peer& peer);
+                                      const Peer& peer,
+                                      const PubKey& senderPubKey);
   void CleanFinalBlockConsensusBuffer();
 
   uint8_t CalculateNewDifficulty(const uint8_t& currentDifficulty);
@@ -636,7 +636,7 @@ class DirectoryService : public Executable, public Broadcastable {
   bool UpdateDSGuardIdentity();
 
   // Get entire network peer info
-  void GetEntireNetworkPeerInfo(std::vector<std::pair<PubKey, Peer>>& peers,
+  void GetEntireNetworkPeerInfo(VectorOfNode& peers,
                                 std::vector<PubKey>& pubKeys);
 
  private:

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -294,8 +294,10 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
   }
 
   uint32_t consensus_id = 0;
+  PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id)) {
+  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id,
+                                         senderPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
     return false;
   }
@@ -317,7 +319,8 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
       return false;
     }
 
-    AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from);
+    AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
+                                   senderPubKey);
 
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "Process final block arrived early, saved to buffer");
@@ -342,7 +345,8 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
                 "Buffer final block with larger consensus ID ("
                     << consensus_id << "), current ("
                     << m_mediator.m_consensusID << ")");
-      AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from);
+      AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
+                                     senderPubKey);
     } else {
       return ProcessFinalBlockConsensusCore(message, offset, from);
     }
@@ -356,16 +360,16 @@ void DirectoryService::CommitFinalBlockConsensusBuffer() {
 
   for (const auto& i : m_finalBlockConsensusBuffer[m_mediator.m_consensusID]) {
     auto runconsensus = [this, i]() {
-      ProcessFinalBlockConsensusCore(i.second, MessageOffset::BODY, i.first);
+      ProcessFinalBlockConsensusCore(std::get<NODE_MSG>(i), MessageOffset::BODY,
+                                     std::get<NODE_PEER>(i));
     };
     DetachedFunction(1, runconsensus);
   }
 }
 
-void DirectoryService::AddToFinalBlockConsensusBuffer(uint32_t consensusId,
-                                                      const bytes& message,
-                                                      unsigned int offset,
-                                                      const Peer& peer) {
+void DirectoryService::AddToFinalBlockConsensusBuffer(
+    uint32_t consensusId, const bytes& message, unsigned int offset,
+    const Peer& peer, const PubKey& senderPubKey) {
   if (message.size() <= offset) {
     LOG_GENERAL(WARNING, "The message size " << message.size()
                                              << " is less than the offset "
@@ -373,28 +377,28 @@ void DirectoryService::AddToFinalBlockConsensusBuffer(uint32_t consensusId,
     return;
   }
   lock_guard<mutex> h(m_mutexFinalBlockConsensusBuffer);
-  auto& vecPeerMsg = m_finalBlockConsensusBuffer[consensusId];
+  auto& vecNodeMsg = m_finalBlockConsensusBuffer[consensusId];
   const auto consensusMsgType = message[offset];
   // Check if the node send the same consensus message already, prevent
   // malicious node send unlimited message to crash the other nodes
-  if (vecPeerMsg.end() !=
-      std::find_if(vecPeerMsg.begin(), vecPeerMsg.end(),
-                   [peer, consensusMsgType,
-                    offset](const std::pair<Peer, bytes>& peerMsg) {
-                     return peer == peerMsg.first &&
-                            consensusMsgType == peerMsg.second[offset];
-                   })) {
+  if (vecNodeMsg.end() !=
+      std::find_if(
+          vecNodeMsg.begin(), vecNodeMsg.end(),
+          [senderPubKey, consensusMsgType, offset](const NodeMsg& nodeMsg) {
+            return senderPubKey == std::get<NODE_PUBKEY>(nodeMsg) &&
+                   consensusMsgType == std::get<NODE_MSG>(nodeMsg)[offset];
+          })) {
     LOG_GENERAL(
         WARNING,
         "The node "
-            << peer
+            << senderPubKey
             << " already send final block consensus message for consensus id "
             << consensusId << " message type "
             << std::to_string(consensusMsgType));
     return;
   }
 
-  vecPeerMsg.push_back(make_pair(peer, message));
+  vecNodeMsg.push_back(make_tuple(senderPubKey, peer, message));
 }
 
 void DirectoryService::CleanFinalBlockConsensusBuffer() {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -366,6 +366,12 @@ void DirectoryService::AddToFinalBlockConsensusBuffer(uint32_t consensusId,
                                                       const bytes& message,
                                                       unsigned int offset,
                                                       const Peer& peer) {
+  if (message.size() <= offset) {
+    LOG_GENERAL(WARNING, "The message size " << message.size()
+                                             << " is less than the offset "
+                                             << offset);
+    return;
+  }
   lock_guard<mutex> h(m_mutexFinalBlockConsensusBuffer);
   auto& vecPeerMsg = m_finalBlockConsensusBuffer[consensusId];
   const auto consensusMsgType = message[offset];

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1439,7 +1439,7 @@ bool Lookup::ProcessSetDSInfoFromSeed(const bytes& message, unsigned int offset,
   bool initialDS = false;
 
   PubKey senderPubKey;
-  std::deque<std::pair<PubKey, Peer>> dsNodes;
+  DequeOfNode dsNodes;
   uint32_t dsCommitteeVersion = 0;
   if (!Messenger::GetLookupSetDSInfoFromSeed(message, offset, senderPubKey,
                                              dsCommitteeVersion, dsNodes,

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -221,7 +221,7 @@ vector<Peer> Lookup::GetAboveLayer() {
   return seedNodePeer;
 }
 
-VectorOfLookupNode Lookup::GetSeedNodes() const {
+VectorOfNode Lookup::GetSeedNodes() const {
   lock_guard<mutex> g(m_mutexSeedNodes);
 
   return m_seedNodes;
@@ -369,14 +369,14 @@ bool Lookup::GenTxnToSend(size_t num_txn,
   return true;
 }
 
-VectorOfLookupNode Lookup::GetLookupNodes() const {
+VectorOfNode Lookup::GetLookupNodes() const {
   LOG_MARKER();
   lock_guard<mutex> lock(m_mutexLookupNodes);
   return m_lookupNodes;
 }
 
 bool Lookup::IsLookupNode(const PubKey& pubKey) const {
-  VectorOfLookupNode lookups = GetLookupNodes();
+  VectorOfNode lookups = GetLookupNodes();
   return std::find_if(lookups.begin(), lookups.end(),
                       [&pubKey](const std::pair<PubKey, Peer>& node) {
                         return node.first == pubKey;
@@ -384,7 +384,7 @@ bool Lookup::IsLookupNode(const PubKey& pubKey) const {
 }
 
 bool Lookup::IsLookupNode(const Peer& peerInfo) const {
-  VectorOfLookupNode lookups = GetLookupNodes();
+  VectorOfNode lookups = GetLookupNodes();
   return std::find_if(lookups.begin(), lookups.end(),
                       [&peerInfo](const std::pair<PubKey, Peer>& node) {
                         return node.second.GetIpAddress() ==
@@ -482,7 +482,7 @@ void Lookup::SendMessageToRandomLookupNode(const bytes& message) const {
   }
 
   // To avoid sending message to multiplier
-  VectorOfLookupNode tmp;
+  VectorOfNode tmp;
   std::copy_if(m_lookupNodes.begin(), m_lookupNodes.end(),
                std::back_inserter(tmp),
                [this](const std::pair<PubKey, Peer>& node) {
@@ -3332,7 +3332,7 @@ bool Lookup::GetIsServer() {
   return m_isServer;
 }
 
-bool Lookup::VerifySenderNode(const VectorOfLookupNode& vecLookupNodes,
+bool Lookup::VerifySenderNode(const VectorOfNode& vecLookupNodes,
                               const PubKey& pubKeyToVerify) {
   auto iter =
       std::find_if(vecLookupNodes.cbegin(), vecLookupNodes.cend(),

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -52,10 +52,10 @@ class Lookup : public Executable, public Broadcastable {
   Mediator& m_mediator;
 
   // Info about lookup node
-  VectorOfLookupNode m_lookupNodes;
-  VectorOfLookupNode m_lookupNodesOffline;
-  VectorOfLookupNode m_seedNodes;
-  VectorOfLookupNode m_multipliers;
+  VectorOfNode m_lookupNodes;
+  VectorOfNode m_lookupNodesOffline;
+  VectorOfNode m_seedNodes;
+  VectorOfNode m_multipliers;
   std::mutex mutable m_mutexSeedNodes;
   bool m_dsInfoWaitingNotifying = false;
   bool m_fetchedDSInfo = false;
@@ -148,10 +148,10 @@ class Lookup : public Executable, public Broadcastable {
   bool CheckStateRoot();
 
   // Getter for m_lookupNodes
-  VectorOfLookupNode GetLookupNodes() const;
+  VectorOfNode GetLookupNodes() const;
 
   // Getter for m_seedNodes
-  VectorOfLookupNode GetSeedNodes() const;
+  VectorOfNode GetSeedNodes() const;
 
   std::mutex m_txnShardMapMutex;
   std::map<uint32_t, std::vector<Transaction>> m_txnShardMap;
@@ -324,7 +324,7 @@ class Lookup : public Executable, public Broadcastable {
   void ComposeAndSendGetDirectoryBlocksFromSeed(const uint64_t& index_num,
                                                 bool toSendSeed = true);
 
-  static bool VerifySenderNode(const VectorOfLookupNode& vecLookupNodes,
+  static bool VerifySenderNode(const VectorOfNode& vecLookupNodes,
                                const PubKey& pubKeyToVerify);
 
   bool Execute(const bytes& message, unsigned int offset, const Peer& from);

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -71,7 +71,7 @@ class Mediator {
   // of queue (new leader) Oldest member will be pushed out from tail of queue
 
   /// The public keys and current members of the DS committee.
-  std::shared_ptr<DequeOfDSNode> m_DSCommittee;
+  std::shared_ptr<DequeOfNode> m_DSCommittee;
   std::mutex m_mutexDSCommittee;
 
   std::shared_ptr<std::vector<PubKey>> m_initialDSCommittee;

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -3214,7 +3214,7 @@ bool Messenger::SetDiagnosticData(bytes& dst, const unsigned int offset,
                                   const uint32_t& shardingStructureVersion,
                                   const DequeOfShard& shards,
                                   const uint32_t& dsCommitteeVersion,
-                                  const DequeOfDSNode& dsCommittee) {
+                                  const DequeOfNode& dsCommittee) {
   ProtoDiagnosticData result;
 
   ShardingStructureToProtobuf(shardingStructureVersion, shards,
@@ -3234,7 +3234,7 @@ bool Messenger::GetDiagnosticData(const bytes& src, const unsigned int offset,
                                   uint32_t& shardingStructureVersion,
                                   DequeOfShard& shards,
                                   uint32_t& dsCommitteeVersion,
-                                  DequeOfDSNode& dsCommittee) {
+                                  DequeOfNode& dsCommittee) {
   ProtoDiagnosticData result;
 
   result.ParseFromArray(src.data() + offset, src.size() - offset);

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -648,7 +648,8 @@ class Messenger {
   template <class T>
   static bool GetLeaderConsensusID(const bytes& src, const unsigned int offset,
                                    const DequeOfNode& commNodes,
-                                   const Peer& from, uint32_t& consensusID) {
+                                   const Peer& from, uint32_t& consensusID,
+                                   PubKey& senderPubKey) {
     LOG_MARKER();
 
     T consensus_message;
@@ -682,6 +683,7 @@ class Messenger {
     }
 
     consensusID = consensus_message.consensusinfo().consensusid();
+    senderPubKey = commNodes[leaderId].first;
 
     return true;
   }
@@ -689,7 +691,8 @@ class Messenger {
   template <class T>
   static bool GetBackupConsensusID(const bytes& src, const unsigned int offset,
                                    const DequeOfNode& commNodes,
-                                   const Peer& from, uint32_t& consensusID) {
+                                   const Peer& from, uint32_t& consensusID,
+                                   PubKey& senderPubKey) {
     LOG_MARKER();
 
     T consensus_message;
@@ -736,6 +739,7 @@ class Messenger {
     }
 
     consensusID = consensus_message.consensusinfo().consensusid();
+    senderPubKey = commNodes[backupId].first;
 
     return true;
   }

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -774,7 +774,7 @@ message ConsensusAnnouncement
         required uint32 consensusid           = 1;
         required uint64 blocknumber           = 2;
         required bytes blockhash              = 3; // 32 bytes
-        required uint32 leaderid              = 4; // only lower 2 bytes used    
+        required uint32 leaderid              = 4; // only lower 2 bytes used
     }
     required ConsensusInfo consensusinfo      = 1;
     oneof announcement

--- a/src/libNetwork/DataSender.cpp
+++ b/src/libNetwork/DataSender.cpp
@@ -26,7 +26,7 @@
 
 using namespace std;
 
-void SendDataToLookupNodesDefault(const VectorOfLookupNode& lookups,
+void SendDataToLookupNodesDefault(const VectorOfNode& lookups,
                                   const bytes& message) {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
@@ -85,8 +85,7 @@ void SendDataToShardNodesDefault(
 }
 
 SendDataToLookupFunc SendDataToLookupFuncDefault =
-    [](const VectorOfLookupNode& lookups,
-       const bytes& message) mutable -> void {
+    [](const VectorOfNode& lookups, const bytes& message) mutable -> void {
   SendDataToLookupNodesDefault(lookups, message);
 };
 
@@ -236,7 +235,7 @@ bool DataSender::SendDataToOthers(
     const deque<pair<PubKey, Peer>>& sendercommittee,
     const DequeOfShard& shards,
     const std::unordered_map<uint32_t, BlockBase>& blockswcosigRecver,
-    const VectorOfLookupNode& lookups, const BlockHash& hashForRandom,
+    const VectorOfNode& lookups, const BlockHash& hashForRandom,
     const uint16_t& consensusMyId,
     const ComposeMessageForSenderFunc& composeMessageForSenderFunc,
     const SendDataToLookupFunc& sendDataToLookupFunc,

--- a/src/libNetwork/DataSender.h
+++ b/src/libNetwork/DataSender.h
@@ -50,11 +50,12 @@ class DataSender : Singleton<DataSender> {
 
   static DataSender& GetInstance();
 
-  void DetermineShardToSendDataTo(
-      unsigned int& my_cluster_num, unsigned int& my_shards_lo,
-      unsigned int& my_shards_hi, const DequeOfShard& shards,
-      const std::deque<std::pair<PubKey, Peer>>& tmpCommittee,
-      const uint16_t& indexB2);
+  void DetermineShardToSendDataTo(unsigned int& my_cluster_num,
+                                  unsigned int& my_shards_lo,
+                                  unsigned int& my_shards_hi,
+                                  const DequeOfShard& shards,
+                                  const DequeOfNode& tmpCommittee,
+                                  const uint16_t& indexB2);
 
   void DetermineNodesToSendDataTo(
       const DequeOfShard& shards,
@@ -64,8 +65,7 @@ class DataSender : Singleton<DataSender> {
       std::deque<std::vector<Peer>>& sharded_receivers);
 
   bool SendDataToOthers(
-      const BlockBase& blockwcosig,
-      const std::deque<std::pair<PubKey, Peer>>& sendercommittee,
+      const BlockBase& blockwcosig, const DequeOfNode& sendercommittee,
       const DequeOfShard& shards,
       const std::unordered_map<uint32_t, BlockBase>& blockswcosigRecver,
       const VectorOfLookupNode& lookups, const BlockHash& hashForRandom,

--- a/src/libNetwork/DataSender.h
+++ b/src/libNetwork/DataSender.h
@@ -27,8 +27,7 @@
 #include "libData/BlockData/Block/BlockBase.h"
 
 typedef std::function<bool(bytes& message)> ComposeMessageForSenderFunc;
-typedef std::function<void(const VectorOfLookupNode& lookups,
-                           const bytes& message)>
+typedef std::function<void(const VectorOfNode& lookups, const bytes& message)>
     SendDataToLookupFunc;
 typedef std::function<void(const bytes& message, const DequeOfShard& shards,
                            const unsigned int& my_shards_lo,
@@ -68,7 +67,7 @@ class DataSender : Singleton<DataSender> {
       const BlockBase& blockwcosig, const DequeOfNode& sendercommittee,
       const DequeOfShard& shards,
       const std::unordered_map<uint32_t, BlockBase>& blockswcosigRecver,
-      const VectorOfLookupNode& lookups, const BlockHash& hashForRandom,
+      const VectorOfNode& lookups, const BlockHash& hashForRandom,
       const uint16_t& consensusMyId, const ComposeMessageForSenderFunc&,
       const SendDataToLookupFunc& sendDataToLookupFunc =
           SendDataToLookupFuncDefault,

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -955,8 +955,7 @@ void P2PComm::SetSelfPeer(const Peer& self) { m_selfPeer = self; }
 void P2PComm::SetSelfKey(const PairOfKey& self) { m_selfKey = self; }
 
 void P2PComm::InitializeRumorManager(
-    const std::vector<std::pair<PubKey, Peer>>& peers,
-    const std::vector<PubKey>& fullNetworkKeys) {
+    const VectorOfNode& peers, const std::vector<PubKey>& fullNetworkKeys) {
   LOG_MARKER();
 
   m_rumorManager.StopRounds();

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -124,7 +124,7 @@ class P2PComm {
   using BroadcastListFunc = std::function<std::vector<Peer>(
       unsigned char msg_type, unsigned char ins_type, const Peer&)>;
 
-  void InitializeRumorManager(const std::vector<std::pair<PubKey, Peer>>& peers,
+  void InitializeRumorManager(const VectorOfNode& peers,
                               const std::vector<PubKey>& fullNetworkKeys);
   inline static bool IsHostHavingNetworkIssue();
 

--- a/src/libNetwork/PeerStore.h
+++ b/src/libNetwork/PeerStore.h
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include "Peer.h"
+#include "ShardStruct.h"
 #include "common/Constants.h"
 #include "common/Serializable.h"
 #include "libCrypto/Schnorr.h"
@@ -48,7 +49,7 @@ class PeerStore {
   Peer GetPeer(const PubKey& key);
 
   /// Returns a list of all public keys and peers in the table.
-  std::vector<std::pair<PubKey, Peer>> GetAllPeerPairs() const;
+  VectorOfNode GetAllPeerPairs() const;
 
   /// Returns a list of all peers in the table.
   std::vector<Peer> GetAllPeers() const;

--- a/src/libNetwork/RumorManager.cpp
+++ b/src/libNetwork/RumorManager.cpp
@@ -113,8 +113,8 @@ void RumorManager::StopRounds() {
 }
 
 // PUBLIC METHODS
-bool RumorManager::Initialize(const std::vector<std::pair<PubKey, Peer>>& peers,
-                              const Peer& myself, const PairOfKey& myKeys,
+bool RumorManager::Initialize(const VectorOfNode& peers, const Peer& myself,
+                              const PairOfKey& myKeys,
                               const std::vector<PubKey>& fullNetworkKeys) {
   LOG_MARKER();
   {

--- a/src/libNetwork/RumorManager.h
+++ b/src/libNetwork/RumorManager.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #include "Peer.h"
+#include "ShardStruct.h"
 #include "libCrypto/Schnorr.h"
 #include "libRumorSpreading/RumorHolder.h"
 
@@ -87,8 +88,8 @@ class RumorManager {
   ~RumorManager();
 
   // METHODS
-  bool Initialize(const std::vector<std::pair<PubKey, Peer>>& peers,
-                  const Peer& myself, const PairOfKey& myKeys,
+  bool Initialize(const VectorOfNode& peers, const Peer& myself,
+                  const PairOfKey& myKeys,
                   const std::vector<PubKey>& fullNetworkKeys);
 
   bool AddRumor(const RawBytes& message);

--- a/src/libNetwork/ShardStruct.h
+++ b/src/libNetwork/ShardStruct.h
@@ -33,8 +33,13 @@ using Shard = std::vector<std::tuple<PubKey, Peer, uint16_t>>;
 using DequeOfShard = std::deque<Shard>;
 
 using PairOfNode = std::pair<PubKey, Peer>;
-using VectorOfLookupNode = std::vector<std::pair<PubKey, Peer>>;
 
+using VectorOfNode = std::vector<PairOfNode>;
 using DequeOfNode = std::deque<PairOfNode>;
+
+enum NodeMessage { NODE_PUBKEY, NODE_PEER, NODE_MSG };
+
+using NodeMsg = std::tuple<PubKey, Peer, bytes>;
+using VectorOfNodeMsg = std::vector<NodeMsg>;
 
 #endif /*__SHARD_STRUCT__*/

--- a/src/libNetwork/ShardStruct.h
+++ b/src/libNetwork/ShardStruct.h
@@ -32,8 +32,9 @@ enum ShardData {
 using Shard = std::vector<std::tuple<PubKey, Peer, uint16_t>>;
 using DequeOfShard = std::deque<Shard>;
 
+using PairOfNode = std::pair<PubKey, Peer>;
 using VectorOfLookupNode = std::vector<std::pair<PubKey, Peer>>;
 
-using DequeOfDSNode = std::deque<std::pair<PubKey, Peer>>;
+using DequeOfNode = std::deque<PairOfNode>;
 
 #endif /*__SHARD_STRUCT__*/

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -304,7 +304,7 @@ void Node::StartFirstTxEpoch() {
   m_justDidFallback = false;
 
   if (BROADCAST_GOSSIP_MODE) {
-    std::vector<std::pair<PubKey, Peer>> peers;
+    VectorOfNode peers;
     std::vector<PubKey> pubKeys;
     GetEntireNetworkPeerInfo(peers, pubKeys);
 

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -141,6 +141,12 @@ void Node::AddToMicroBlockConsensusBuffer(uint32_t consensusId,
                                           const bytes& message,
                                           unsigned int offset,
                                           const Peer& peer) {
+  if (message.size() <= offset) {
+    LOG_GENERAL(WARNING, "The message size " << message.size()
+                                             << " is less than the offset "
+                                             << offset);
+    return;
+  }
   lock_guard<mutex> h(m_mutexMicroBlockConsensusBuffer);
   auto& vecPeerMsg = m_microBlockConsensusBuffer[consensusId];
   const auto consensusMsgType = message[offset];

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -752,7 +752,7 @@ void Node::WakeupAtDSEpoch() {
                                            .GetBlockNum() +
                                        1);
     if (BROADCAST_GOSSIP_MODE) {
-      std::vector<std::pair<PubKey, Peer>> peers;
+      VectorOfNode peers;
       std::vector<PubKey> pubKeys;
       m_mediator.m_ds->GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -842,7 +842,7 @@ void Node::WakeupAtTxEpoch() {
 
   if (DirectoryService::IDLE != m_mediator.m_ds->m_mode) {
     if (BROADCAST_GOSSIP_MODE) {
-      std::vector<std::pair<PubKey, Peer>> peers;
+      VectorOfNode peers;
       std::vector<PubKey> pubKeys;
       m_mediator.m_ds->GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -858,7 +858,7 @@ void Node::WakeupAtTxEpoch() {
   }
 
   if (BROADCAST_GOSSIP_MODE) {
-    std::vector<std::pair<PubKey, Peer>> peers;
+    VectorOfNode peers;
     std::vector<PubKey> pubKeys;
     GetEntireNetworkPeerInfo(peers, pubKeys);
 
@@ -2080,7 +2080,7 @@ std::string Node::GetActionString(Action action) const {
   return true;
 }
 
-void Node::GetEntireNetworkPeerInfo(std::vector<std::pair<PubKey, Peer>>& peers,
+void Node::GetEntireNetworkPeerInfo(VectorOfNode& peers,
                                     std::vector<PubKey>& pubKeys) {
   peers.clear();
   pubKeys.clear();

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -224,7 +224,7 @@ void Node::Init() {
   AccountStore::GetInstance().Init();
 
   {
-    std::deque<std::pair<PubKey, Peer>> buildDSComm;
+    DequeOfNode buildDSComm;
     lock_guard<mutex> lock(m_mediator.m_mutexInitialDSCommittee);
     if (m_mediator.m_initialDSCommittee->size() != 0) {
       for (const auto& initDSCommKey : *m_mediator.m_initialDSCommittee) {
@@ -422,7 +422,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
   m_mediator.m_dsBlockChain.Reset();
   m_mediator.m_blocklinkchain.Reset();
   {
-    std::deque<std::pair<PubKey, Peer>> buildDSComm;
+    DequeOfNode buildDSComm;
     lock_guard<mutex> lock(m_mediator.m_mutexInitialDSCommittee);
     if (m_mediator.m_initialDSCommittee->size() != 0) {
       for (const auto& initDSCommKey : *m_mediator.m_initialDSCommittee) {
@@ -1960,7 +1960,7 @@ bool Node::Execute(const bytes& message, unsigned int offset,
       &Node::ProcessStartPoW,
       &Node::ProcessVCDSBlocksMessage,
       &Node::ProcessSubmitTransaction,
-      &Node::ProcessMicroblockConsensus,
+      &Node::ProcessMicroBlockConsensus,
       &Node::ProcessFinalBlock,
       &Node::ProcessMBnForwardTransaction,
       &Node::ProcessVCBlock,
@@ -2038,7 +2038,7 @@ std::string Node::GetActionString(Action action) const {
 
 /*static*/ bool Node::GetDSLeader(const BlockLink& lastBlockLink,
                                   const DSBlock& latestDSBlock,
-                                  const DequeOfDSNode& dsCommittee,
+                                  const DequeOfNode& dsCommittee,
                                   const uint64_t epochNumber,
                                   pair<PubKey, Peer>& dsLeader) {
   const auto& blocktype = get<BlockLinkIndex::BLOCKTYPE>(lastBlockLink);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -139,8 +139,7 @@ class Node : public Executable, public Broadcastable {
   std::vector<bytes> m_txnPacketBuffer;
 
   std::mutex m_mutexMicroBlockConsensusBuffer;
-  std::unordered_map<uint32_t, std::vector<std::pair<Peer, bytes>>>
-      m_microBlockConsensusBuffer;
+  std::unordered_map<uint32_t, VectorOfNodeMsg> m_microBlockConsensusBuffer;
 
   // Fallback Consensus
   std::mutex m_mutexFallbackTimer;
@@ -223,7 +222,7 @@ class Node : public Executable, public Broadcastable {
                                 const Peer& from);
   bool ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
                                   const Peer& from);
-  bool ProcessMicroblockConsensusCore(const bytes& message, unsigned int offset,
+  bool ProcessMicroBlockConsensusCore(const bytes& message, unsigned int offset,
                                       const Peer& from);
   bool ProcessFinalBlock(const bytes& message, unsigned int offset,
                          const Peer& from);
@@ -470,7 +469,8 @@ class Node : public Executable, public Broadcastable {
 
   void AddToMicroBlockConsensusBuffer(uint32_t consensusId,
                                       const bytes& message, unsigned int offset,
-                                      const Peer& peer);
+                                      const Peer& peer,
+                                      const PubKey& senderPubKey);
   void CleanMicroblockConsensusBuffer();
 
   void CallActOnFinalblock();
@@ -565,7 +565,7 @@ class Node : public Executable, public Broadcastable {
                           std::pair<PubKey, Peer>& dsLeader);
 
   // Get entire network peer info
-  void GetEntireNetworkPeerInfo(std::vector<std::pair<PubKey, Peer>>& peers,
+  void GetEntireNetworkPeerInfo(VectorOfNode& peers,
                                 std::vector<PubKey>& pubKeys);
 
  private:

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -221,7 +221,7 @@ class Node : public Executable, public Broadcastable {
                        const Peer& from);
   bool ProcessSubmitTransaction(const bytes& message, unsigned int offset,
                                 const Peer& from);
-  bool ProcessMicroblockConsensus(const bytes& message, unsigned int offset,
+  bool ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
                                   const Peer& from);
   bool ProcessMicroblockConsensusCore(const bytes& message, unsigned int offset,
                                       const Peer& from);
@@ -364,7 +364,7 @@ class Node : public Executable, public Broadcastable {
   // bool m_allMicroBlocksRecvd = true;
 
   std::mutex m_mutexShardMember;
-  std::shared_ptr<std::deque<std::pair<PubKey, Peer>>> m_myShardMembers;
+  std::shared_ptr<DequeOfNode> m_myShardMembers;
 
   std::shared_ptr<MicroBlock> m_microblock;
 
@@ -456,18 +456,21 @@ class Node : public Executable, public Broadcastable {
   /// Add new block into tx blockchain
   void AddBlock(const TxBlock& block);
 
-  void UpdateDSCommiteeComposition(std::deque<std::pair<PubKey, Peer>>& dsComm,
-                                   const DSBlock& dsblock);
+  void UpdateDSCommiteeComposition(DequeOfNode& dsComm, const DSBlock& dsblock);
 
-  void UpdateDSCommitteeAfterFallback(
-      const uint32_t& shard_id, const PubKey& leaderPubKey,
-      const Peer& leaderNetworkInfo,
-      std::deque<std::pair<PubKey, Peer>>& dsComm, const DequeOfShard& shards);
+  void UpdateDSCommitteeAfterFallback(const uint32_t& shard_id,
+                                      const PubKey& leaderPubKey,
+                                      const Peer& leaderNetworkInfo,
+                                      DequeOfNode& dsComm,
+                                      const DequeOfShard& shards);
 
   void CommitMBnForwardedTransactionBuffer();
 
   void CleanCreatedTransaction();
 
+  void AddToMicroBlockConsensusBuffer(uint32_t consensusId,
+                                      const bytes& message, unsigned int offset,
+                                      const Peer& peer);
   void CleanMicroblockConsensusBuffer();
 
   void CallActOnFinalblock();
@@ -545,10 +548,10 @@ class Node : public Executable, public Broadcastable {
   /// Fetch latest ds block with a counter for retrying
   bool GetLatestDSBlock();
 
-  void UpdateDSCommiteeCompositionAfterVC(
-      const VCBlock& vcblock, std::deque<std::pair<PubKey, Peer>>& dsComm);
-  void UpdateRetrieveDSCommiteeCompositionAfterVC(
-      const VCBlock& vcblock, std::deque<std::pair<PubKey, Peer>>& dsComm);
+  void UpdateDSCommiteeCompositionAfterVC(const VCBlock& vcblock,
+                                          DequeOfNode& dsComm);
+  void UpdateRetrieveDSCommiteeCompositionAfterVC(const VCBlock& vcblock,
+                                                  DequeOfNode& dsComm);
 
   void UpdateProcessedTransactions();
 
@@ -557,7 +560,7 @@ class Node : public Executable, public Broadcastable {
 
   static bool GetDSLeader(const BlockLink& lastBlockLink,
                           const DSBlock& latestDSBlock,
-                          const DequeOfDSNode& dsCommittee,
+                          const DequeOfNode& dsCommittee,
                           const uint64_t epochNumber,
                           std::pair<PubKey, Peer>& dsLeader);
 

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -516,7 +516,7 @@ bool BlockStorage::GetMetadata(MetaType type, bytes& data) {
   return true;
 }
 
-bool BlockStorage::PutDSCommittee(const shared_ptr<DequeOfDSNode>& dsCommittee,
+bool BlockStorage::PutDSCommittee(const shared_ptr<DequeOfNode>& dsCommittee,
                                   const uint16_t& consensusLeaderID) {
   LOG_MARKER();
 
@@ -678,7 +678,7 @@ bool BlockStorage::GetStateDelta(const uint64_t& finalBlockNum,
 
 bool BlockStorage::PutDiagnosticData(const uint64_t& dsBlockNum,
                                      const DequeOfShard& shards,
-                                     const DequeOfDSNode& dsCommittee) {
+                                     const DequeOfNode& dsCommittee) {
   LOG_MARKER();
 
   bytes data;
@@ -703,7 +703,7 @@ bool BlockStorage::PutDiagnosticData(const uint64_t& dsBlockNum,
 
 bool BlockStorage::GetDiagnosticData(const uint64_t& dsBlockNum,
                                      DequeOfShard& shards,
-                                     DequeOfDSNode& dsCommittee) {
+                                     DequeOfNode& dsCommittee) {
   LOG_MARKER();
 
   string dataStr;

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -41,7 +41,7 @@ typedef std::shared_ptr<TransactionWithReceipt> TxBodySharedPtr;
 
 struct DiagnosticData {
   DequeOfShard shards;
-  DequeOfDSNode dsCommittee;
+  DequeOfNode dsCommittee;
 };
 
 /// Manages persistent storage of DS and Tx blocks.
@@ -203,13 +203,12 @@ class BlockStorage : public Singleton<BlockStorage> {
   bool GetMetadata(MetaType type, bytes& data);
 
   /// Save DS committee
-  bool PutDSCommittee(const std::shared_ptr<DequeOfDSNode>& dsCommittee,
+  bool PutDSCommittee(const std::shared_ptr<DequeOfNode>& dsCommittee,
                       const uint16_t& consensusLeaderID);
 
   /// Retrieve DS committee
-  bool GetDSCommittee(
-      std::shared_ptr<std::deque<std::pair<PubKey, Peer>>>& dsCommittee,
-      uint16_t& consensusLeaderID);
+  bool GetDSCommittee(std::shared_ptr<DequeOfNode>& dsCommittee,
+                      uint16_t& consensusLeaderID);
 
   /// Save shard structure
   bool PutShardStructure(const DequeOfShard& shards, const uint32_t myshardId);
@@ -225,11 +224,11 @@ class BlockStorage : public Singleton<BlockStorage> {
 
   /// Save data for diagnostic / monitoring purposes
   bool PutDiagnosticData(const uint64_t& dsBlockNum, const DequeOfShard& shards,
-                         const DequeOfDSNode& dsCommittee);
+                         const DequeOfNode& dsCommittee);
 
   /// Retrieve diagnostic data for specific block number
   bool GetDiagnosticData(const uint64_t& dsBlockNum, DequeOfShard& shards,
-                         DequeOfDSNode& dsCommittee);
+                         DequeOfNode& dsCommittee);
 
   /// Retrieve diagnostic data
   void GetDiagnosticData(std::map<uint64_t, DiagnosticData>& diagnosticDataMap);

--- a/src/libValidator/Validator.h
+++ b/src/libValidator/Validator.h
@@ -46,12 +46,10 @@ class ValidatorBase {
   virtual bool CheckDirBlocks(
       const std::vector<boost::variant<
           DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
-      const std::deque<std::pair<PubKey, Peer>>& initDsComm,
-      const uint64_t& index_num,
-      std::deque<std::pair<PubKey, Peer>>& newDSComm) = 0;
+      const DequeOfNode& initDsComm, const uint64_t& index_num,
+      DequeOfNode& newDSComm) = 0;
   virtual TxBlockValidationMsg CheckTxBlocks(
-      const std::vector<TxBlock>& txblocks,
-      const std::deque<std::pair<PubKey, Peer>>& dsComm,
+      const std::vector<TxBlock>& txblocks, const DequeOfNode& dsComm,
       const BlockLink& latestBlockLink) = 0;
 };
 
@@ -74,14 +72,12 @@ class Validator : public ValidatorBase {
   bool CheckDirBlocks(
       const std::vector<boost::variant<
           DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
-      const std::deque<std::pair<PubKey, Peer>>& initDsComm,
-      const uint64_t& index_num,
-      std::deque<std::pair<PubKey, Peer>>& newDSComm) override;
+      const DequeOfNode& initDsComm, const uint64_t& index_num,
+      DequeOfNode& newDSComm) override;
   // TxBlocks must be in increasing order or it will fail
-  TxBlockValidationMsg CheckTxBlocks(
-      const std::vector<TxBlock>& txBlocks,
-      const std::deque<std::pair<PubKey, Peer>>& dsComm,
-      const BlockLink& latestBlockLink) override;
+  TxBlockValidationMsg CheckTxBlocks(const std::vector<TxBlock>& txBlocks,
+                                     const DequeOfNode& dsComm,
+                                     const BlockLink& latestBlockLink) override;
   Mediator& m_mediator;
 };
 

--- a/tests/Persistence/Test_Diagnostic.cpp
+++ b/tests/Persistence/Test_Diagnostic.cpp
@@ -39,7 +39,7 @@ void PrintShard(const DequeOfShard& shards) {
   }
 }
 
-void PrintDSCommittee(const DequeOfDSNode& dsCommittee) {
+void PrintDSCommittee(const DequeOfNode& dsCommittee) {
   LOG_GENERAL(INFO, "DS Committee:")
   for (const auto& dsnode : dsCommittee) {
     LOG_GENERAL(INFO, "  Node: " << dsnode.second << " " << dsnode.first);
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(testDiagnostic) {
 
   vector<uint64_t> histDSBlockNum;
   vector<DequeOfShard> histShards;
-  vector<DequeOfDSNode> histDSCommittee;
+  vector<DequeOfNode> histDSCommittee;
 
   const unsigned int NUM_ENTRIES = 15;
 
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(testDiagnostic) {
   // Look-up by block number
   for (unsigned int i = 0; i < NUM_ENTRIES; i++) {
     DequeOfShard shardsDeserialized;
-    DequeOfDSNode dsCommitteeDeserialized;
+    DequeOfNode dsCommitteeDeserialized;
 
     BOOST_CHECK(BlockStorage::GetBlockStorage().GetDiagnosticData(
         histDSBlockNum.at(i), shardsDeserialized, dsCommitteeDeserialized));
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(testDiagnostic) {
   for (unsigned int i = 0; i < NUM_ENTRIES; i++) {
     // First, check the entry is still there
     DequeOfShard shardsDeserialized;
-    DequeOfDSNode dsCommitteeDeserialized;
+    DequeOfNode dsCommitteeDeserialized;
 
     BOOST_CHECK(BlockStorage::GetBlockStorage().GetDiagnosticData(
         histDSBlockNum.at(i), shardsDeserialized, dsCommitteeDeserialized));

--- a/tests/libTestUtils/TestUtils.cpp
+++ b/tests/libTestUtils/TestUtils.cpp
@@ -183,8 +183,8 @@ FallbackBlockHeader GenerateRandomFallbackBlockHeader() {
                              prevHash);
 }
 
-DS_Comitte_t GenerateRandomDSCommittee(uint32_t size) {
-  DS_Comitte_t ds_c;
+DequeOfNode GenerateRandomDSCommittee(uint32_t size) {
+  DequeOfNode ds_c;
   for (uint32_t i = 1; i <= size; i++) {
     ds_c.push_front(
         std::make_pair(GenerateRandomPubKey(), GenerateRandomPeer()));

--- a/tests/libTestUtils/TestUtils.h
+++ b/tests/libTestUtils/TestUtils.h
@@ -66,7 +66,7 @@ CoSignatures GenerateRandomCoSignatures();
 Signature GetSignature(const bytes&, const PrivKey&, const PubKey&);
 Signature GenerateRandomSignature();
 
-using DS_Comitte_t = std::deque<std::pair<PubKey, Peer>>;
+using DS_Comitte_t = DequeOfNode;
 DS_Comitte_t GenerateRandomDSCommittee(uint32_t);
 
 Shard GenerateRandomShard(size_t);

--- a/tests/libTestUtils/TestUtils.h
+++ b/tests/libTestUtils/TestUtils.h
@@ -26,10 +26,7 @@
 #include <tuple>
 #include "common/BaseType.h"
 #include "libCrypto/Schnorr.h"
-#include "libData/BlockData/BlockHeader/DSBlockHeader.h"
-#include "libData/BlockData/BlockHeader/MicroBlockHeader.h"
-#include "libData/BlockData/BlockHeader/TxBlockHeader.h"
-#include "libMessage/Messenger.h"
+#include "libData/BlockData/Block.h"
 #include "libNetwork/Peer.h"
 
 static std::mt19937 rng;
@@ -66,8 +63,7 @@ CoSignatures GenerateRandomCoSignatures();
 Signature GetSignature(const bytes&, const PrivKey&, const PubKey&);
 Signature GenerateRandomSignature();
 
-using DS_Comitte_t = DequeOfNode;
-DS_Comitte_t GenerateRandomDSCommittee(uint32_t);
+DequeOfNode GenerateRandomDSCommittee(uint32_t);
 
 Shard GenerateRandomShard(size_t);
 DequeOfShard GenerateDequeueOfShard(size_t);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Protect consensus message buffer, prevent unlimited message
<!-- What is the context of your pull request? -->
Check the sender id and ip address is in my committee member list, and check if the same message already saved in the buffer before add it.
<!-- What are the related issues and pull requests? -->
From security audit report issue 32 and 33.
`Node::ProcessMicroBlockConsensus`
    - an attacker can cause an out-of-memory condition by sending bogus Node micro block consensus messages. These are buffered in an unbounded map `m_microBlockConsensusBuffer`
`Node::ProcessMicroBlockConsensusCore`
    - an attacker can cause an arbitrary number of threads to get temporarily stuck this method. This is limited to certain phases of the consensus protocol

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
