### PR TITLE
Fix node crash because mod zero

### DIFF
--- a/src/libNetwork/DataSender.cpp
+++ b/src/libNetwork/DataSender.cpp
@@ -284,7 +284,7 @@ bool DataSender::SendDataToOthers(
 
     uint16_t randomDigits =
         DataConversion::charArrTo16Bits(hashForRandom.asBytes());
-    bool committeeTooSmall = tmpCommittee.size() < TX_SHARING_CLUSTER_SIZE;
+    bool committeeTooSmall = tmpCommittee.size() <= TX_SHARING_CLUSTER_SIZE;
     uint16_t nodeToSendToLookUpLo =
         committeeTooSmall
             ? 0

--- a/src/libNetwork/DataSender.cpp
+++ b/src/libNetwork/DataSender.cpp
@@ -128,9 +128,12 @@ void DataSender::DetermineShardToSendDataTo(
     num_clusters++;
   }
   LOG_GENERAL(INFO, "DEBUG num of clusters " << num_clusters)
-  unsigned int shard_groups_count = shards.size() / num_clusters;
-  if ((shards.size() % num_clusters) > 0) {
-    shard_groups_count++;
+  unsigned int shard_groups_count = 0;
+  if (num_clusters != 0) {
+    shard_groups_count = shards.size() / num_clusters;
+    if ((shards.size() % num_clusters) > 0) {
+      shard_groups_count++;
+    }
   }
   LOG_GENERAL(INFO, "DEBUG num of shard group count " << shard_groups_count)
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix node crash because mod zero
<!-- What is the context of your pull request? -->
Previous, if tmpCommittee.size() is equal to TX_SHARING_CLUSTER_SIZE, committeeTooSmall will be false, then randomDigits % (tmpCommittee.size() - TX_SHARING_CLUSTER_SIZE) will crash.
<!-- What are the related issues and pull requests? -->
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `zilliqa --privk 4D2BC288A046BD9AB174DF4E7CDA3486BFC5A8B724A0D7B23CFFA94E9131EF0'.
Program terminated with signal SIGFPE, Arithmetic exception.
#0  0x0000000000812c9f in DataSender::SendDataToOthers(BlockBase const&, std::deque<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, std::deque<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > >, std::allocator<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > > > > const&, std::unordered_map<unsigned int, BlockBase, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, BlockBase> > > const&, std::vector<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, dev::FixedHash<32u> const&, unsigned short const&, std::function<bool (std::vector<unsigned char, std::allocator<unsigned char> >&)> const&, std::function<void (std::vector<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, std::vector<unsigned char, std::allocator<unsigned char> > const&)> const&, std::function<void (std::vector<unsigned char, std::allocator<unsigned char> > const&, std::deque<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > >, std::allocator<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > > > > const&, unsigned int const&, unsigned int const&)> const&) (
    this=0xd9f9a0 <DataSender::GetInstance()::datasender>, blockwcosigSender=..., sendercommittee=..., shards=..., blockswcosigRecver=..., lookups=..., hashForRandom=..., 
    consensusMyId=@0x7f4bc07bbf20: 3, composeMessageForSenderFunc=..., sendDataToLookupFunc=..., sendDataToShardFunc=...) at /zilliqa/src/libNetwork/DataSender.cpp:291
291	            : (randomDigits % (tmpCommittee.size() - TX_SHARING_CLUSTER_SIZE));
[Current thread is 1 (Thread 0x7f4bc07c0700 (LWP 168))]
(gdb) bt
#0  0x0000000000812c9f in DataSender::SendDataToOthers(BlockBase const&, std::deque<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, std::deque<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > >, std::allocator<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > > > > const&, std::unordered_map<unsigned int, BlockBase, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, BlockBase> > > const&, std::vector<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, dev::FixedHash<32u> const&, unsigned short const&, std::function<bool (std::vector<unsigned char, std::allocator<unsigned char> >&)> const&, std::function<void (std::vector<std::pair<PubKey, Peer>, std::allocator<std::pair<PubKey, Peer> > > const&, std::vector<unsigned char, std::allocator<unsigned char> > const&)> const&, std::function<void (std::vector<unsigned char, std::allocator<unsigned char> > const&, std::deque<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > >, std::allocator<std::vector<std::tuple<PubKey, Peer, unsigned short>, std::allocator<std::tuple<PubKey, Peer, unsigned short> > > > > const&, unsigned int const&, unsigned int const&)> const&) (
    this=0xd9f9a0 <DataSender::GetInstance()::datasender>, blockwcosigSender=..., sendercommittee=..., shards=std::deque with 1 elements = {...}, 
    blockswcosigRecver=std::unordered_map with 1 elements = {...}, lookups=std::vector of length 1, capacity 1 = {...}, hashForRandom=..., consensusMyId=@0x7f4bc07bbf20: 3, 
    composeMessageForSenderFunc=..., sendDataToLookupFunc=..., sendDataToShardFunc=...) at /zilliqa/src/libNetwork/DataSender.cpp:291
#1  0x000000000065db0b in Node::ProcessMicroblockConsensusCore (this=this@entry=0x7ffe18f4d720, message=std::vector of length 151, capacity 151 = {...}, offset=offset@entry=2, from=...)
    at /zilliqa/src/libNode/MicroBlockPostProcessing.cpp:265
#2  0x00000000006616c8 in Node::ProcessMicroBlockConsensus (this=0x7ffe18f4d720, message=std::vector of length 151, capacity 151 = {...}, offset=2, from=...)
    at /zilliqa/src/libNode/MicroBlockPostProcessing.cpp:122
#3  0x000000000066ce48 in Node::Execute (this=0x7ffe18f4d720, message=std::vector of length 151, capacity 151 = {...}, offset=1, from=...) at /zilliqa/src/libNode/Node.cpp:1987
#4  0x00000000004aee70 in Zilliqa::ProcessMessage (this=0x7ffe18f4c170, message=0x2da7480) at /zilliqa/src/libZilliqa/Zilliqa.cpp:108
#5  0x000000000046da64 in std::function<void ()>::operator()() const (this=0x7f4bc07bfe00) at /usr/include/c++/5/functional:2267
#6  ThreadPool::Task (this=0x7ffe18f4e2f0) at /zilliqa/src/libUtils/ThreadPool.h:166
#7  ThreadPool::ThreadPool(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1}::operator()() const (__closure=<optimized out>)
    at /zilliqa/src/libUtils/ThreadPool.h:63
#8  std::_Bind_simple<ThreadPool::ThreadPool(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1} ()>::_M_invoke<>(std::_Index_tuple<>) (
    this=<optimized out>) at /usr/include/c++/5/functional:1531
#9  std::_Bind_simple<ThreadPool::ThreadPool(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1} ()>::operator()() (this=<optimized out>)
    at /usr/include/c++/5/functional:1520
#10 std::thread::_Impl<std::_Bind_simple<ThreadPool::ThreadPool(unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1} ()> >::_M_run() (
    this=<optimized out>) at /usr/include/c++/5/thread:115
#11 0x00007f4bf4ee0c80 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#12 0x00007f4bf46f36ba in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#13 0x00007f4bf442941d in clone () from /lib/x86_64-linux-gnu/libc.so.6

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
