### PR TITLE
Fix issue where query very high number non-existence blocks can result in OOM

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -988,6 +988,16 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
   uint64_t blockNum;
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
+      DSBlock dsblk = m_mediator.m_dsBlockChain.GetBlock(blockNum);
+      // Internal issue #415
+      // TODO Hot fix to identify dummy block as == comparator does not work on
+      // empty object for TxBlock and TxBlockheader().
+      if (dsblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER) {
+        LOG_GENERAL(WARNING,
+                    "Block Number " << blockNum << " does not exists.");
+        break;
+      }
+
       dsBlocks.emplace_back(m_mediator.m_dsBlockChain.GetBlock(blockNum));
     } catch (const char* e) {
       LOG_GENERAL(INFO, "Block Number " << blockNum
@@ -1116,7 +1126,17 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   uint64_t blockNum;
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
-      txBlocks.emplace_back(m_mediator.m_txBlockChain.GetBlock(blockNum));
+      TxBlock txblk = m_mediator.m_txBlockChain.GetBlock(blockNum);
+      // Internal issue #415
+      // TODO Hot fix to identify dummy block as == comparator does not work on
+      // empty object for TxBlock and TxBlockheader().
+      if (txblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER &&
+          txblk.GetHeader().GetDSBlockNum() == INIT_BLOCK_NUMBER) {
+        LOG_GENERAL(WARNING,
+                    "Block Number " << blockNum << " does not exists.");
+        break;
+      }
+      txBlocks.emplace_back(txblk);
     } catch (const char* e) {
       LOG_GENERAL(INFO, "Block Number " << blockNum
                                         << " absent. Didn't include it in "

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -989,7 +989,6 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
       DSBlock dsblk = m_mediator.m_dsBlockChain.GetBlock(blockNum);
-      // Internal issue #415
       // TODO Hot fix to identify dummy block as == comparator does not work on
       // empty object for TxBlock and TxBlockheader().
       if (dsblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER) {
@@ -1127,7 +1126,6 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
       TxBlock txblk = m_mediator.m_txBlockChain.GetBlock(blockNum);
-      // Internal issue #415
       // TODO Hot fix to identify dummy block as == comparator does not work on
       // empty object for TxBlock and TxBlockheader().
       if (txblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER &&

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -990,7 +990,7 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
     try {
       DSBlock dsblk = m_mediator.m_dsBlockChain.GetBlock(blockNum);
       // TODO Hot fix to identify dummy block as == comparator does not work on
-      // empty object for TxBlock and TxBlockheader().
+      // empty object for DSBlock and DSBlockheader().
       if (dsblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER) {
         LOG_GENERAL(WARNING,
                     "Block Number " << blockNum << " does not exists.");


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Let's say if a node query a very big range of blocks say (1 to n) and there are no such blocks from (m to n), (n-m) empty dummy block will be created and return. Setting n to be a very large int will cause a node to go OOM.

This PR fix this issue by stopping the retrieval of blocks once the dummy block is returned. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test (commit: 91dd5a46e90f4b40fe0d406ce2bcb6065e378354)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
