### PR TITLE
Read hostname from constant.xml only for lookup and seednodes

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -159,9 +159,12 @@ void Lookup::SetLookupNodes() {
                     }) != m_lookupNodes.end()) {
           continue;
         }
-        string url = v.second.get<string>("hostname");
-        if (!url.empty()) {
-          lookup_node.SetHostname(url);
+        // check for hostname only for lookup nodes
+        if (lookupType == "node.lookups") {
+          string url = v.second.get<string>("hostname");
+          if (!url.empty()) {
+            lookup_node.SetHostname(url);
+          }
         }
         if (lookupType == "node.multipliers") {
           m_multipliers.emplace_back(pubKey, lookup_node);


### PR DESCRIPTION
## Description
This PR fix the exception caused due missing ```<hostname>``` for multiplier in constants.xml.
```<hostname>``` will be read only for ```node.lookups```

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
