### PR TITLE
Changes to method of identification of empty DS and Tx blocks

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1309,7 +1309,12 @@ bool Lookup::AddMicroBlockToStorage(const MicroBlock& microblock) {
                         << microblock.GetBlockHash());
   unsigned int i = 0;
 
-  if (txblk == TxBlock()) {
+  // TODO
+  // Workaround to identify dummy block as == comparator does not work on
+  // empty object for TxBlock and TxBlockheader().
+  // if (txblk == TxBlock()) {
+  if (txblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER &&
+      txblk.GetHeader().GetDSBlockNum() == INIT_BLOCK_NUMBER) {
     LOG_GENERAL(WARNING, "Failed to fetch Txblock");
     return false;
   }
@@ -1630,10 +1635,9 @@ bool Lookup::ProcessSetDSBlockFromSeed(const bytes& message,
       // empty object for DSBlock and DSBlockheader().
       // if (!(m_mediator.m_dsBlockChain.GetBlock(
       //           dsblock.GetHeader().GetBlockNum()) == DSBlock())) {
-      if (!(m_mediator.m_dsBlockChain
-                .GetBlock(dsblock.GetHeader().GetBlockNum())
-                .GetHeader()
-                .GetBlockNum() == INIT_BLOCK_NUMBER)) {
+      if (m_mediator.m_dsBlockChain.GetBlock(dsblock.GetHeader().GetBlockNum())
+              .GetHeader()
+              .GetBlockNum() != INIT_BLOCK_NUMBER) {
         continue;
       }
       m_mediator.m_dsBlockChain.AddBlock(dsblock);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -992,7 +992,8 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
       DSBlock dsblk = m_mediator.m_dsBlockChain.GetBlock(blockNum);
-      // TODO Hot fix to identify dummy block as == comparator does not work on
+      // TODO
+      // Workaround to identify dummy block as == comparator does not work on
       // empty object for DSBlock and DSBlockheader().
       if (dsblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER) {
         LOG_GENERAL(WARNING,
@@ -1129,7 +1130,8 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   for (blockNum = lowBlockNum; blockNum <= highBlockNum; blockNum++) {
     try {
       TxBlock txblk = m_mediator.m_txBlockChain.GetBlock(blockNum);
-      // TODO Hot fix to identify dummy block as == comparator does not work on
+      // TODO
+      // Workaround to identify dummy block as == comparator does not work on
       // empty object for TxBlock and TxBlockheader().
       if (txblk.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER &&
           txblk.GetHeader().GetDSBlockNum() == INIT_BLOCK_NUMBER) {
@@ -1623,8 +1625,15 @@ bool Lookup::ProcessSetDSBlockFromSeed(const bytes& message,
     }
 
     for (const auto& dsblock : dsBlocks) {
-      if (!(m_mediator.m_dsBlockChain.GetBlock(
-                dsblock.GetHeader().GetBlockNum()) == DSBlock())) {
+      // TODO
+      // Workaround to identify dummy block as == comparator does not work on
+      // empty object for DSBlock and DSBlockheader().
+      // if (!(m_mediator.m_dsBlockChain.GetBlock(
+      //           dsblock.GetHeader().GetBlockNum()) == DSBlock())) {
+      if (!(m_mediator.m_dsBlockChain
+                .GetBlock(dsblock.GetHeader().GetBlockNum())
+                .GetHeader()
+                .GetBlockNum() == INIT_BLOCK_NUMBER)) {
         continue;
       }
       m_mediator.m_dsBlockChain.AddBlock(dsblock);

--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -1120,7 +1120,12 @@ Json::Value Server::GetTransactionsForTxBlock(const string& txBlockNum,
 
   auto const& txBlock = m_mediator.m_txBlockChain.GetBlock(txNum);
 
-  if (txBlock == TxBlock()) {
+  // TODO
+  // Workaround to identify dummy block as == comparator does not work on
+  // empty object for TxBlock and TxBlockheader().
+  // if (txBlock == TxBlock()) {
+  if (txBlock.GetHeader().GetBlockNum() == INIT_BLOCK_NUMBER &&
+      txBlock.GetHeader().GetDSBlockNum() == INIT_BLOCK_NUMBER) {
     throw JsonRpcException(RPC_INVALID_PARAMS, "Tx Block does not exist");
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Due to a known issue, comparator for empty `TxBlock()` and `DSBlock()` is not working accurately. This PR implements a workaround to detect empty or dummy blocks. 

In addition, previous comments on hotfix have been renamed to workaround to reflect a more accurate description of the fix.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] ~local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test (commit: 389bdb5852e9cd320666ea6f546b979aec612375)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
