### PR TITLE
Daemon should use correct port instead of hard-code 30303

### DIFF
--- a/tests/Zilliqa/daemon_restart.py
+++ b/tests/Zilliqa/daemon_restart.py
@@ -26,8 +26,6 @@ import signal
 from subprocess import Popen, PIPE
 
 IP_SITE = 'ifconfig.me'
-
-PORT_NUM = 30303
 PROJ_DIR = '/run/zilliqa'
 
 def main():
@@ -79,7 +77,7 @@ def run_restart(pubKey, privKey, port, typ, path):
 		keypair = keypairs[x].split(" ")
 
 		signal.signal(signal.SIGCHLD, signal.SIG_IGN)
-		os.system('cd ' + PROJ_DIR + '; ulimit -Sc unlimited; ulimit -Hc unlimited;' + path + 'zilliqa' + ' --privk ' + keypair[1] + ' --pubk ' + keypair[0] + ' --address ' + nodeIP + ' --port ' + str(PORT_NUM) + ' --loadconfig ' + ' --synctype ' + typ + ' --recovery >> ./error_log_zilliqa 2>&1')
+		os.system('cd ' + PROJ_DIR + '; ulimit -Sc unlimited; ulimit -Hc unlimited;' + path + 'zilliqa' + ' --privk ' + keypair[1] + ' --pubk ' + keypair[0] + ' --address ' + nodeIP + ' --port ' + str(port) + ' --loadconfig ' + ' --synctype ' + typ + ' --recovery >> ./error_log_zilliqa 2>&1')
 
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
For mainnet, the port would not be a fixed number. Thus daemon should follow correct port number instead of using a fixed port. (30303)

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
