### PR TITLE
Remove DS microblock before retrying consensus due to MISSINGMICROBLOCK

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -657,6 +657,7 @@ class DirectoryService : public Executable, public Broadcastable {
       const RunFinalBlockConsensusOptions& options);
   bool CheckIfDSNode(const PubKey& submitterPubKey);
   bool CheckIfShardNode(const PubKey& submitterPubKey);
+  void RemoveDSMicroBlock();
 };
 
 #endif  // __DIRECTORYSERVICE_H__

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -483,6 +483,8 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
             ConsensusCommon::INITIAL);
 
         auto rerunconsensus = [this, message, offset, from]() {
+          RemoveDSMicroBlock();  // Remove DS microblock from my list of
+                                 // microblocks
           PrepareRunConsensusOnFinalBlockNormal();
           ProcessFinalBlockConsensusCore(message, offset, from);
         };

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -511,6 +511,8 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
             ConsensusCommon::INITIAL);
 
         auto reprocessconsensus = [this, message, offset, from]() {
+          RemoveDSMicroBlock();  // Remove DS microblock from my list of
+                                 // microblocks
           ProcessFinalBlockConsensusCore(message, offset, from);
         };
         DetachedFunction(1, reprocessconsensus);

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1221,21 +1221,8 @@ void DirectoryService::RunConsensusOnFinalBlock(
       LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
                 "Initiated final block view change.");
       auto func2 = [this]() -> void {
-        // Remove DS microblock from my list of microblocks
-        {
-          lock_guard<mutex> g(m_mutexMicroBlocks);
-          auto& microBlocksAtEpoch =
-              m_microBlocks[m_mediator.m_currentEpochNum];
-          auto dsmb =
-              find_if(microBlocksAtEpoch.begin(), microBlocksAtEpoch.end(),
-                      [this](const MicroBlock& mb) -> bool {
-                        return mb.GetHeader().GetShardId() == m_shards.size();
-                      });
-          if (dsmb != microBlocksAtEpoch.end()) {
-            LOG_GENERAL(INFO, "Removed DS microblock from list of microblocks");
-            microBlocksAtEpoch.erase(dsmb);
-          }
-        }
+        RemoveDSMicroBlock();  // Remove DS microblock from my list of
+                               // microblocks
         RunConsensusOnViewChange();
       };
       DetachedFunction(1, func2);
@@ -1243,4 +1230,20 @@ void DirectoryService::RunConsensusOnFinalBlock(
   };
 
   DetachedFunction(1, func1);
+}
+
+void DirectoryService::RemoveDSMicroBlock() {
+  LOG_MARKER();
+
+  lock_guard<mutex> g(m_mutexMicroBlocks);
+
+  auto& microBlocksAtEpoch = m_microBlocks[m_mediator.m_currentEpochNum];
+  auto dsmb = find_if(microBlocksAtEpoch.begin(), microBlocksAtEpoch.end(),
+                      [this](const MicroBlock& mb) -> bool {
+                        return mb.GetHeader().GetShardId() == m_shards.size();
+                      });
+  if (dsmb != microBlocksAtEpoch.end()) {
+    LOG_GENERAL(INFO, "Removed DS microblock from list of microblocks");
+    microBlocksAtEpoch.erase(dsmb);
+  }
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR is similar to #1176, where we should remove the DS microblock from `m_microBlocks[m_currentEpochNum]` before retrying consensus.

Tested in local by making the backups drop the microblock from shard 0, and then checking if the backup was able to fetch the missing mb and re-process the announcement successfully.

@kaikawaliu I also put the same call to `RemoveDSMicroBlock` for `MISSING_TXN`, please help me review if it is ok to do so.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
