### PR TITLE
Use Peer IP instead of PubKey to prevent unlimited consensus buffer messages

### DIFF
--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -199,41 +199,38 @@ ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }
 
 bool ConsensusCommon::GetConsensusID(const bytes& message,
                                      const unsigned int offset,
-                                     const Peer& from, uint32_t& consensusID,
-                                     PubKey& senderPubKey) const {
+                                     const Peer& from,
+                                     uint32_t& consensusID) const {
   if (message.size() > offset) {
     switch (message.at(offset)) {
       case ConsensusMessageType::ANNOUNCE:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusAnnouncement>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusAnnouncement>(
+            message, offset + 1, from, consensusID);
       case ConsensusMessageType::CONSENSUSFAILURE:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusConsensusFailure>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<
+            ZilliqaMessage::ConsensusConsensusFailure>(message, offset + 1,
+                                                       from, consensusID);
       case ConsensusMessageType::COMMIT:
       case ConsensusMessageType::FINALCOMMIT:
-        return Messenger::GetBackupConsensusID<ZilliqaMessage::ConsensusCommit>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusCommit>(
+            message, offset + 1, from, consensusID);
       case ConsensusMessageType::COMMITFAILURE:
-        return Messenger::GetBackupConsensusID<
-            ZilliqaMessage::ConsensusCommitFailure>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<
+            ZilliqaMessage::ConsensusCommitFailure>(message, offset + 1, from,
+                                                    consensusID);
       case ConsensusMessageType::CHALLENGE:
       case ConsensusMessageType::FINALCHALLENGE:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusChallenge>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusChallenge>(
+            message, offset + 1, from, consensusID);
       case ConsensusMessageType::RESPONSE:
       case ConsensusMessageType::FINALRESPONSE:
-        return Messenger::GetBackupConsensusID<
-            ZilliqaMessage::ConsensusResponse>(message, offset + 1, m_committee,
-                                               from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusResponse>(
+            message, offset + 1, from, consensusID);
       case ConsensusMessageType::COLLECTIVESIG:
       case ConsensusMessageType::FINALCOLLECTIVESIG:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusCollectiveSig>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<
+            ZilliqaMessage::ConsensusCollectiveSig>(message, offset + 1, from,
+                                                    consensusID);
       default:
         LOG_GENERAL(WARNING, "Unknown consensus message received");
         break;

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -207,8 +207,7 @@ class ConsensusCommon {
 
   /// Returns the consensus ID indicated in the message
   bool GetConsensusID(const bytes& message, const unsigned int offset,
-                      const Peer& from, uint32_t& consensusID,
-                      PubKey& senderPubKey) const;
+                      const Peer& from, uint32_t& consensusID) const;
 
   /// Returns the consensus error code
   ConsensusErrorCode GetConsensusErrorCode() const;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -428,8 +428,7 @@ class DirectoryService : public Executable, public Broadcastable {
 
   void AddToFinalBlockConsensusBuffer(uint32_t consensusId,
                                       const bytes& message, unsigned int offset,
-                                      const Peer& peer,
-                                      const PubKey& senderPubKey);
+                                      const Peer& peer);
   void CleanFinalBlockConsensusBuffer();
 
   uint8_t CalculateNewDifficulty(const uint8_t& currentDifficulty);

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -288,10 +288,8 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
   }
 
   uint32_t consensus_id = 0;
-  PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id,
-                                         senderPubKey)) {
+  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
     return false;
   }
@@ -313,8 +311,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
       return false;
     }
 
-    AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
-                                   senderPubKey);
+    AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from);
 
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "Process final block arrived early, saved to buffer");
@@ -339,8 +336,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
                 "Buffer final block with larger consensus ID ("
                     << consensus_id << "), current ("
                     << m_mediator.m_consensusID << ")");
-      AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
-                                     senderPubKey);
+      AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from);
     } else {
       return ProcessFinalBlockConsensusCore(message, offset, from);
     }
@@ -354,16 +350,16 @@ void DirectoryService::CommitFinalBlockConsensusBuffer() {
 
   for (const auto& i : m_finalBlockConsensusBuffer[m_mediator.m_consensusID]) {
     auto runconsensus = [this, i]() {
-      ProcessFinalBlockConsensusCore(std::get<NODE_MSG>(i), MessageOffset::BODY,
-                                     std::get<NODE_PEER>(i));
+      ProcessFinalBlockConsensusCore(i.second, MessageOffset::BODY, i.first);
     };
     DetachedFunction(1, runconsensus);
   }
 }
 
-void DirectoryService::AddToFinalBlockConsensusBuffer(
-    uint32_t consensusId, const bytes& message, unsigned int offset,
-    const Peer& peer, const PubKey& senderPubKey) {
+void DirectoryService::AddToFinalBlockConsensusBuffer(uint32_t consensusId,
+                                                      const bytes& message,
+                                                      unsigned int offset,
+                                                      const Peer& peer) {
   if (message.size() <= offset) {
     LOG_GENERAL(WARNING, "The message size " << message.size()
                                              << " is less than the offset "
@@ -376,23 +372,23 @@ void DirectoryService::AddToFinalBlockConsensusBuffer(
   // Check if the node send the same consensus message already, prevent
   // malicious node send unlimited message to crash the other nodes
   if (vecNodeMsg.end() !=
-      std::find_if(
-          vecNodeMsg.begin(), vecNodeMsg.end(),
-          [senderPubKey, consensusMsgType, offset](const NodeMsg& nodeMsg) {
-            return senderPubKey == std::get<NODE_PUBKEY>(nodeMsg) &&
-                   consensusMsgType == std::get<NODE_MSG>(nodeMsg)[offset];
-          })) {
+      std::find_if(vecNodeMsg.begin(), vecNodeMsg.end(),
+                   [peer, consensusMsgType, offset](const NodeMsg& nodeMsg) {
+                     return peer.GetIpAddress() ==
+                                nodeMsg.first.GetIpAddress() &&
+                            consensusMsgType == nodeMsg.second[offset];
+                   })) {
     LOG_GENERAL(
         WARNING,
         "The node "
-            << senderPubKey
+            << peer
             << " already send final block consensus message for consensus id "
             << consensusId << " message type "
             << std::to_string(consensusMsgType));
     return;
   }
 
-  vecNodeMsg.push_back(make_tuple(senderPubKey, peer, message));
+  vecNodeMsg.emplace_back(make_pair(peer, message));
 }
 
 void DirectoryService::CleanFinalBlockConsensusBuffer() {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -368,25 +368,29 @@ void DirectoryService::AddToFinalBlockConsensusBuffer(uint32_t consensusId,
   }
   lock_guard<mutex> h(m_mutexFinalBlockConsensusBuffer);
   auto& vecNodeMsg = m_finalBlockConsensusBuffer[consensusId];
-  const auto consensusMsgType = message[offset];
-  // Check if the node send the same consensus message already, prevent
-  // malicious node send unlimited message to crash the other nodes
-  if (vecNodeMsg.end() !=
-      std::find_if(vecNodeMsg.begin(), vecNodeMsg.end(),
-                   [peer, consensusMsgType, offset](const NodeMsg& nodeMsg) {
-                     return peer.GetIpAddress() ==
-                                nodeMsg.first.GetIpAddress() &&
-                            consensusMsgType == nodeMsg.second[offset];
-                   })) {
-    LOG_GENERAL(
-        WARNING,
-        "The node "
-            << peer
-            << " already send final block consensus message for consensus id "
-            << consensusId << " message type "
-            << std::to_string(consensusMsgType));
-    return;
-  }
+
+  // TODO: See #1245
+
+  // const auto consensusMsgType = message[offset];
+  // // Check if the node send the same consensus message already, prevent
+  // // malicious node send unlimited message to crash the other nodes
+  // if (vecNodeMsg.end() !=
+  //     std::find_if(vecNodeMsg.begin(), vecNodeMsg.end(),
+  //                  [peer, consensusMsgType, offset](const NodeMsg& nodeMsg) {
+  //                    return peer.GetIpAddress() ==
+  //                               nodeMsg.first.GetIpAddress() &&
+  //                           consensusMsgType == nodeMsg.second[offset];
+  //                  })) {
+  //   LOG_GENERAL(
+  //       WARNING,
+  //       "The node "
+  //           << peer
+  //           << " already send final block consensus message for consensus id
+  //           "
+  //           << consensusId << " message type "
+  //           << std::to_string(consensusMsgType));
+  //   return;
+  // }
 
   vecNodeMsg.emplace_back(make_pair(peer, message));
 }

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -651,7 +651,8 @@ class Messenger {
 
   template <class T>
   static bool GetConsensusID(const bytes& src, const unsigned int offset,
-                             const Peer& from, uint32_t& consensusID) {
+                             [[gnu::unused]] const Peer& from,
+                             uint32_t& consensusID) {
     LOG_MARKER();
 
     T consensus_message;

--- a/src/libNetwork/ShardStruct.h
+++ b/src/libNetwork/ShardStruct.h
@@ -39,7 +39,7 @@ using DequeOfNode = std::deque<PairOfNode>;
 
 enum NodeMessage { NODE_PUBKEY, NODE_PEER, NODE_MSG };
 
-using NodeMsg = std::tuple<PubKey, Peer, bytes>;
+using NodeMsg = std::pair<Peer, bytes>;
 using VectorOfNodeMsg = std::vector<NodeMsg>;
 
 #endif /*__SHARD_STRUCT__*/

--- a/src/libNetwork/ShardStruct.h
+++ b/src/libNetwork/ShardStruct.h
@@ -37,8 +37,6 @@ using PairOfNode = std::pair<PubKey, Peer>;
 using VectorOfNode = std::vector<PairOfNode>;
 using DequeOfNode = std::deque<PairOfNode>;
 
-enum NodeMessage { NODE_PUBKEY, NODE_PEER, NODE_MSG };
-
 using NodeMsg = std::pair<Peer, bytes>;
 using VectorOfNodeMsg = std::vector<NodeMsg>;
 

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -149,25 +149,29 @@ void Node::AddToMicroBlockConsensusBuffer(uint32_t consensusId,
   }
   lock_guard<mutex> h(m_mutexMicroBlockConsensusBuffer);
   auto& vecNodeMsg = m_microBlockConsensusBuffer[consensusId];
-  const auto consensusMsgType = message[offset];
-  // Check if the node send the same consensus message already, prevent
-  // malicious node send unlimited message to crash the other nodes
-  if (vecNodeMsg.end() !=
-      std::find_if(vecNodeMsg.begin(), vecNodeMsg.end(),
-                   [peer, consensusMsgType, offset](const NodeMsg& nodeMsg) {
-                     return peer.GetIpAddress() ==
-                                nodeMsg.first.GetIpAddress() &&
-                            consensusMsgType == nodeMsg.second[offset];
-                   })) {
-    LOG_GENERAL(
-        WARNING,
-        "The node "
-            << peer
-            << " already send micro block consensus message for consensus id "
-            << consensusId << " message type "
-            << std::to_string(consensusMsgType));
-    return;
-  }
+
+  // TODO: See #1245
+
+  // const auto consensusMsgType = message[offset];
+  // // Check if the node send the same consensus message already, prevent
+  // // malicious node send unlimited message to crash the other nodes
+  // if (vecNodeMsg.end() !=
+  //     std::find_if(vecNodeMsg.begin(), vecNodeMsg.end(),
+  //                  [peer, consensusMsgType, offset](const NodeMsg& nodeMsg) {
+  //                    return peer.GetIpAddress() ==
+  //                               nodeMsg.first.GetIpAddress() &&
+  //                           consensusMsgType == nodeMsg.second[offset];
+  //                  })) {
+  //   LOG_GENERAL(
+  //       WARNING,
+  //       "The node "
+  //           << peer
+  //           << " already send micro block consensus message for consensus id
+  //           "
+  //           << consensusId << " message type "
+  //           << std::to_string(consensusMsgType));
+  //   return;
+  // }
 
   vecNodeMsg.emplace_back(make_pair(peer, message));
 }

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -474,8 +474,7 @@ class Node : public Executable, public Broadcastable {
 
   void AddToMicroBlockConsensusBuffer(uint32_t consensusId,
                                       const bytes& message, unsigned int offset,
-                                      const Peer& peer,
-                                      const PubKey& senderPubKey);
+                                      const Peer& peer);
   void CleanMicroblockConsensusBuffer();
 
   void CallActOnFinalblock();


### PR DESCRIPTION
**Update**
This PR needs to be revisited.  For now, checking of IP or PubKey has been removed.  See https://github.com/Zilliqa/Issues/issues/419.

---

This PR adjusts the fix made in #1214.

The issue with #1214 is that it needs to access committee to retrieve senderPubKey.  But at the time of receipt of this consensus message, it is possible that the consensus object is not yet generated.

So instead of using senderPubKey, the best we can do at this point is use the sender peer's IP address.

https://github.com/Zilliqa/Issues/issues/419

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
