### PR TITLE
Fix bug for retrieving sharding structure crash

### DIFF
--- a/scripts/validateBackupDB.sh
+++ b/scripts/validateBackupDB.sh
@@ -15,36 +15,17 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # [MUST BE FILLED IN] User configuration settings
-aws_access_key_id=""
-aws_secret_access_key=""
-
+backupDBName=""
 
 # Validate input argument
-if [ "$#" -ne 1 ]; then
-    echo -e "\n\n\033[0;31mUsage: source ./scripts/validateBackupDB.sh backupDBName\033[0m\n"
-    return 0
+if [ ! -f "${backupDBName}" ]; then
+    echo -e "\n\n\033[0;31mUsage: source ./scripts/validateBackupDB.sh\033[0m\n"
+    return 1
 fi
-
-if [ "$aws_access_key_id" = "" ]; then
-    echo -e "\n\n\033[0;31m*ERROR* Please enter your own AWS_ACCESS_KEY_ID in validateBackupDB.sh!\033[0m\n"
-    return 0
-fi
-
-if [ "$aws_secret_access_key" = "" ]; then
-    echo -e "\n\n\033[0;31m*ERROR* Please enter your own AWS_SECRET_ACCESS_KEY in validateBackupDB.sh!\033[0m\n"
-    return 0
-fi
-
 
 # Download persistence from Amazon S3 database
-backupDBName="$1"
-export AWS_ACCESS_KEY_ID=${aws_access_key_id}
-export AWS_SECRET_ACCESS_KEY=${aws_secret_access_key}
-pip install awscli
-aws s3 cp s3://zilliqa-persistence/${backupDBName}.tar.gz ${backupDBName}.tar.gz
 rm -rf persistence
-tar xzvf ${backupDBName}.tar.gz
-echo -e "\n\033[0;32mDownload ${backupDBName}.tar.gz from Amazon S3 database successfully.\033[0m\n"
+tar xzvf ${backupDBName}
 
 
 # Configure testing environment

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -635,40 +635,42 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         }
       }
     }
+  }
 
-    bool bInShardStructure = false;
+  bool bInShardStructure = false;
 
-    if (bDS) {
-      m_myshardId = m_mediator.m_ds->m_shards.size();
-    } else {
-      for (unsigned int i = 0;
-           i < m_mediator.m_ds->m_shards.size() && !bInShardStructure; ++i) {
-        for (const auto& shardNode : m_mediator.m_ds->m_shards.at(i)) {
-          if (get<SHARD_NODE_PUBKEY>(shardNode) ==
-              m_mediator.m_selfKey.second) {
-            SetMyshardId(i);
-            bInShardStructure = true;
-            break;
-          }
+  if (bDS) {
+    m_myshardId = m_mediator.m_ds->m_shards.size();
+  } else {
+    for (unsigned int i = 0;
+         i < m_mediator.m_ds->m_shards.size() && !bInShardStructure; ++i) {
+      for (const auto& shardNode : m_mediator.m_ds->m_shards.at(i)) {
+        if (get<SHARD_NODE_PUBKEY>(shardNode) == m_mediator.m_selfKey.second) {
+          SetMyshardId(i);
+          LOG_GENERAL(
+              INFO, "This node belongs to sharding structure #" << m_myshardId);
+          bInShardStructure = true;
+          break;
         }
       }
     }
+  }
 
-    if (LOOKUP_NODE_MODE) {
-      m_mediator.m_lookup->ProcessEntireShardingStructure();
-    } else {
-      LoadShardingStructure(true);
-      m_mediator.m_ds->ProcessShardingStructure(
-          m_mediator.m_ds->m_shards, m_mediator.m_ds->m_publicKeyToshardIdMap,
-          m_mediator.m_ds->m_mapNodeReputation);
-    }
+  if (LOOKUP_NODE_MODE) {
+    m_mediator.m_lookup->ProcessEntireShardingStructure();
+  } else {
+    LoadShardingStructure(true);
+    m_mediator.m_ds->ProcessShardingStructure(
+        m_mediator.m_ds->m_shards, m_mediator.m_ds->m_publicKeyToshardIdMap,
+        m_mediator.m_ds->m_mapNodeReputation);
+  }
 
-    if (REJOIN_NODE_NOT_IN_NETWORK && !LOOKUP_NODE_MODE && !bDS &&
-        !bInShardStructure) {
-      LOG_GENERAL(WARNING,
-                  "Node is not in network, apply re-join process instead");
-      return false;
-    }
+  if (REJOIN_NODE_NOT_IN_NETWORK && !LOOKUP_NODE_MODE && !bDS &&
+      !bInShardStructure) {
+    LOG_GENERAL(WARNING,
+                "Node " << m_mediator.m_selfKey.second
+                        << " is not in network, apply re-join process instead");
+    return false;
   }
 
   m_mediator.m_consensusID =

--- a/tests/Zilliqa/test_zilliqa_local.py
+++ b/tests/Zilliqa/test_zilliqa_local.py
@@ -304,7 +304,7 @@ def run_start_validateBackupDB():
 	shutil.copyfile('constants_local.xml', LOCAL_RUN_FOLDER + testfolders_list[0] + '/constants.xml')
 	shutil.copyfile('dsnodes.xml', LOCAL_RUN_FOLDER + testfolders_list[0] + '/dsnodes.xml')
 	shutil.copyfile('config_normal.xml', LOCAL_RUN_FOLDER + testfolders_list[0] + '/config.xml')
-	os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[0] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + keypair[1] + ' ' + keypair[0] + ' ' + '127.0.0.1' +' ' + str(NODE_LISTEN_PORT + 0) + ' 1 5 1 > ./error_log_zilliqa 2>&1 &')
+	os.system('cd ' + LOCAL_RUN_FOLDER + testfolders_list[0] + '; echo \"' + keypair[0] + ' ' + keypair[1] + '\" > mykey.txt' + '; ulimit -n 65535; ulimit -Sc unlimited; ulimit -Hc unlimited; $(pwd)/zilliqa ' + ' --privk ' + keypair[1] + ' --pubk ' + keypair[0] + ' --address ' + '127.0.0.1' + ' --port ' + str(NODE_LISTEN_PORT + 0) + ' --loadconfig 1 --synctype 5 --recovery 1 > ./error_log_zilliqa 2>&1 &')
 
 def run_connect(numnodes):
 	testfolders_list = get_immediate_subdirectories(LOCAL_RUN_FOLDER)


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
When retrieving sharding structure without ip-mapping file (using the same pod), fetching will cause coredump. This PR fixed this issue, and also fixed validateBackupDB problem caused by Zilliqa command foramt change.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
