### PR TITLE
Add pubkey to the consensus message, verify signature before buffer it

### DIFF
--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -199,41 +199,38 @@ ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }
 
 bool ConsensusCommon::GetConsensusID(const bytes& message,
                                      const unsigned int offset,
-                                     const Peer& from, uint32_t& consensusID,
+                                     uint32_t& consensusID,
                                      PubKey& senderPubKey) const {
   if (message.size() > offset) {
     switch (message.at(offset)) {
       case ConsensusMessageType::ANNOUNCE:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusAnnouncement>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusAnnouncement>(
+            message, offset + 1, consensusID, senderPubKey);
       case ConsensusMessageType::CONSENSUSFAILURE:
-        return Messenger::GetLeaderConsensusID<
+        return Messenger::GetConsensusID<
             ZilliqaMessage::ConsensusConsensusFailure>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+            message, offset + 1, consensusID, senderPubKey);
       case ConsensusMessageType::COMMIT:
       case ConsensusMessageType::FINALCOMMIT:
-        return Messenger::GetBackupConsensusID<ZilliqaMessage::ConsensusCommit>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusCommit>(
+            message, offset + 1, consensusID, senderPubKey);
       case ConsensusMessageType::COMMITFAILURE:
-        return Messenger::GetBackupConsensusID<
-            ZilliqaMessage::ConsensusCommitFailure>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<
+            ZilliqaMessage::ConsensusCommitFailure>(message, offset + 1,
+                                                    consensusID, senderPubKey);
       case ConsensusMessageType::CHALLENGE:
       case ConsensusMessageType::FINALCHALLENGE:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusChallenge>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusChallenge>(
+            message, offset + 1, consensusID, senderPubKey);
       case ConsensusMessageType::RESPONSE:
       case ConsensusMessageType::FINALRESPONSE:
-        return Messenger::GetBackupConsensusID<
-            ZilliqaMessage::ConsensusResponse>(message, offset + 1, m_committee,
-                                               from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusResponse>(
+            message, offset + 1, consensusID, senderPubKey);
       case ConsensusMessageType::COLLECTIVESIG:
       case ConsensusMessageType::FINALCOLLECTIVESIG:
-        return Messenger::GetLeaderConsensusID<
-            ZilliqaMessage::ConsensusCollectiveSig>(
-            message, offset + 1, m_committee, from, consensusID, senderPubKey);
+        return Messenger::GetConsensusID<
+            ZilliqaMessage::ConsensusCollectiveSig>(message, offset + 1,
+                                                    consensusID, senderPubKey);
       default:
         LOG_GENERAL(WARNING, "Unknown consensus message received");
         break;

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -207,8 +207,7 @@ class ConsensusCommon {
 
   /// Returns the consensus ID indicated in the message
   bool GetConsensusID(const bytes& message, const unsigned int offset,
-                      const Peer& from, uint32_t& consensusID,
-                      PubKey& senderPubKey) const;
+                      uint32_t& consensusID, PubKey& senderPubKey) const;
 
   /// Returns the consensus error code
   ConsensusErrorCode GetConsensusErrorCode() const;

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -290,7 +290,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
   uint32_t consensus_id = 0;
   PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id,
+  if (!m_consensusObject->GetConsensusID(message, offset, consensus_id,
                                          senderPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
     return false;

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -650,10 +650,8 @@ class Messenger {
   // ============================================================================
 
   template <class T>
-  static bool GetLeaderConsensusID(const bytes& src, const unsigned int offset,
-                                   const DequeOfNode& commNodes,
-                                   const Peer& from, uint32_t& consensusID,
-                                   PubKey& senderPubKey) {
+  static bool GetConsensusID(const bytes& src, const unsigned int offset,
+                             uint32_t& consensusID, PubKey& senderPubKey) {
     LOG_MARKER();
 
     T consensus_message;
@@ -665,85 +663,27 @@ class Messenger {
       return false;
     }
 
-    const auto leaderId = consensus_message.consensusinfo().leaderid();
-    if (leaderId >= commNodes.size()) {
-      LOG_GENERAL(WARNING, "The leader id "
-                               << leaderId
-                               << " is out of my committee member size "
-                               << commNodes.size());
-      return false;
-    }
-
-    if (commNodes.end() ==
-        std::find_if(commNodes.begin(), commNodes.end(),
-                     [from](const PairOfNode& pairOfNode) {
-                       return from.GetIpAddress() ==
-                              pairOfNode.second.GetIpAddress();
-                     })) {
-      LOG_GENERAL(WARNING, "The sender address "
-                               << from
-                               << " is not in my committee member list");
-      return false;
-    }
-
-    consensusID = consensus_message.consensusinfo().consensusid();
-    senderPubKey = commNodes[leaderId].first;
-
-    return true;
-  }
-
-  template <class T>
-  static bool GetBackupConsensusID(const bytes& src, const unsigned int offset,
-                                   const DequeOfNode& commNodes,
-                                   const Peer& from, uint32_t& consensusID,
-                                   PubKey& senderPubKey) {
-    LOG_MARKER();
-
-    T consensus_message;
-
-    consensus_message.ParseFromArray(src.data() + offset, src.size() - offset);
-
-    if (!consensus_message.IsInitialized()) {
-      LOG_GENERAL(WARNING, "Consensus message initialization failed.");
-      return false;
-    }
-
-    const auto backupId = consensus_message.consensusinfo().backupid();
-    if (backupId >= commNodes.size()) {
-      LOG_GENERAL(WARNING, "The backup id "
-                               << backupId
-                               << " is out of my committee member size "
-                               << commNodes.size());
-      return false;
-    }
-
-    if (commNodes.end() ==
-        std::find_if(commNodes.begin(), commNodes.end(),
-                     [from](const PairOfNode& pairOfNode) {
-                       return from.GetIpAddress() ==
-                              pairOfNode.second.GetIpAddress();
-                     })) {
-      LOG_GENERAL(WARNING, "The sender address "
-                               << from
-                               << " is not in my committee member list");
+    if (!consensus_message.consensusinfo().IsInitialized()) {
+      LOG_GENERAL(WARNING,
+                  "Consensus message consensusinfo initialization failed.");
       return false;
     }
 
     bytes tmp(consensus_message.consensusinfo().ByteSize());
     consensus_message.consensusinfo().SerializeToArray(tmp.data(), tmp.size());
 
+    ProtobufByteArrayToSerializable(consensus_message.pubkey(), senderPubKey);
+
     Signature signature;
 
     ProtobufByteArrayToSerializable(consensus_message.signature(), signature);
 
-    if (!Schnorr::GetInstance().Verify(tmp, signature,
-                                       commNodes[backupId].first)) {
+    if (!Schnorr::GetInstance().Verify(tmp, signature, senderPubKey)) {
       LOG_GENERAL(WARNING, "Invalid signature in ConsensusConsensusFailure.");
       return false;
     }
 
     consensusID = consensus_message.consensusinfo().consensusid();
-    senderPubKey = commNodes[backupId].first;
 
     return true;
   }

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -800,15 +800,17 @@ message ConsensusAnnouncement
         required uint32 leaderid              = 4; // only lower 2 bytes used
     }
     required ConsensusInfo consensusinfo      = 1;
+    required ByteArray pubkey                 = 2;
+    required ByteArray signature              = 3; // The signature of the consensus info
     oneof announcement
     {
-        DSDSBlockAnnouncement dsblock         = 2;
-        NodeMicroBlockAnnouncement microblock = 3;
-        DSFinalBlockAnnouncement finalblock   = 4;
-        DSVCBlockAnnouncement vcblock         = 5;
-        NodeFallbackBlockAnnouncement fallbackblock = 6;
+        DSDSBlockAnnouncement dsblock         = 4;
+        NodeMicroBlockAnnouncement microblock = 5;
+        DSFinalBlockAnnouncement finalblock   = 6;
+        DSVCBlockAnnouncement vcblock         = 7;
+        NodeFallbackBlockAnnouncement fallbackblock = 8;
     }
-    required ByteArray signature              = 7;
+    required ByteArray finalsignature         = 9;
 }
 
 message ConsensusCommit
@@ -823,7 +825,8 @@ message ConsensusCommit
         required ByteArray commitpointhash = 6;
     }
     required ConsensusInfo consensusinfo   = 1;
-    required ByteArray signature           = 2;
+    required ByteArray pubkey              = 2;
+    required ByteArray signature           = 3;
 }
 
 message ConsensusChallenge
@@ -840,7 +843,8 @@ message ConsensusChallenge
         required ByteArray challenge        = 8;
     }
     required ConsensusInfo consensusinfo    = 1;
-    required ByteArray signature            = 2;
+    required ByteArray pubkey               = 2;
+    required ByteArray signature            = 3;
 }
 
 message ConsensusResponse
@@ -855,7 +859,8 @@ message ConsensusResponse
         required ByteArray response      = 6;
     }
     required ConsensusInfo consensusinfo = 1;
-    required ByteArray signature         = 2;
+    required ByteArray pubkey            = 2;
+    required ByteArray signature         = 3;
 }
 
 message ConsensusCollectiveSig
@@ -870,7 +875,8 @@ message ConsensusCollectiveSig
         repeated bool bitmap             = 6 [packed=true];
     }
     required ConsensusInfo consensusinfo = 1;
-    required ByteArray signature         = 2;
+    required ByteArray pubkey            = 2;
+    required ByteArray signature         = 3;
 }
 
 message ConsensusCommitFailure
@@ -884,7 +890,8 @@ message ConsensusCommitFailure
         required bytes errormsg          = 5;
     }
     required ConsensusInfo consensusinfo = 1;
-    required ByteArray signature         = 2;
+    required ByteArray pubkey            = 2;
+    required ByteArray signature         = 3;
 }
 
 message ConsensusConsensusFailure
@@ -897,7 +904,8 @@ message ConsensusConsensusFailure
         required uint32 leaderid         = 4; // only lower 2 bytes used
     }
     required ConsensusInfo consensusinfo = 1;
-    required ByteArray signature         = 2;
+    required ByteArray pubkey            = 2;
+    required ByteArray signature         = 3;
 }
 
 // ============================================================================

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -96,7 +96,7 @@ bool Node::ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
   uint32_t consensus_id = 0;
   PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, from, consensus_id,
+  if (!m_consensusObject->GetConsensusID(message, offset, consensus_id,
                                          senderPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
     return false;

--- a/tests/Message/Test_Messenger_Consensus.cpp
+++ b/tests/Message/Test_Messenger_Consensus.cpp
@@ -102,6 +102,36 @@ BOOST_AUTO_TEST_CASE(test_SetAndGetConsensusChallenge) {
   BOOST_CHECK(challenge == challengeDeserialized);
 }
 
+BOOST_AUTO_TEST_CASE(test_SetAndGetConsensusCommitFailure) {
+  bytes dst;
+  unsigned int offset = 0;
+  uint32_t consensusID = TestUtils::DistUint32();
+  uint64_t blockNumber = TestUtils::DistUint32();
+  bytes blockHash(TestUtils::Dist1to99(), TestUtils::DistUint8());
+  uint16_t backupID = max((uint16_t)2, (uint16_t)TestUtils::Dist1to99());
+  PairOfKey backupKey;
+  backupKey.first = PrivKey();
+  backupKey.second = PubKey(backupKey.first);
+  bytes errorMsg = DataConversion::StringToCharArray("Commit failture");
+
+  BOOST_CHECK(Messenger::SetConsensusCommitFailure(
+      dst, offset, consensusID, blockNumber, blockHash, backupID, errorMsg,
+      backupKey));
+
+  DequeOfNode committeeKeys;
+  for (unsigned int i = 0, count = max((unsigned int)backupID + 1,
+                                       (unsigned int)TestUtils::Dist1to99());
+       i < count; i++) {
+    committeeKeys.emplace_back(
+        (i == backupID) ? backupKey.second : TestUtils::GenerateRandomPubKey(),
+        TestUtils::GenerateRandomPeer());
+  }
+
+  BOOST_CHECK(Messenger::GetConsensusCommitFailure(
+      dst, offset, consensusID, blockNumber, blockHash, backupID, errorMsg,
+      committeeKeys));
+}
+
 BOOST_AUTO_TEST_CASE(test_SetAndGetConsensusConsensusFailure) {
   bytes dst;
   unsigned int offset = 0;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Add pubkey to the consensus message, verify signature before buffer it. It is alternate approach for PR https://github.com/Zilliqa/Zilliqa/pull/1245
<!-- What is the context of your pull request? -->
This PR adjusts the fix made in #1214.
The issue with #1214 is that it needs to access committee to retrieve senderPubKey.  But at the time of receipt of this consensus message, it is possible that the consensus object is not yet generated.
Now put the pubkey in the message, even consensus object not generated, still can verify the sender.

<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/419

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
