### PR TITLE
Daemon with new recover-all mode should send syncType = RECOVERY_ALL_SYNC

### DIFF
--- a/daemon/ZilliqaDaemon_AWS.cpp
+++ b/daemon/ZilliqaDaemon_AWS.cpp
@@ -59,6 +59,10 @@ enum SyncType : unsigned int {
   NORMAL_SYNC,
   DS_SYNC,
   LOOKUP_SYNC,
+  RECOVERY_ALL_SYNC,
+  NEW_LOOKUP_SYNC,
+  GUARD_DS_SYNC,
+  DB_VERIF
 };
 
 string ReadLastLine(string filePath, [[gnu::unused]] ofstream& log) {
@@ -95,8 +99,6 @@ string ReadLastLine(string filePath, [[gnu::unused]] ofstream& log) {
 
   return lastLine;
 }
-
-SyncType getRestartValue([[gnu::unused]] pid_t pid) { return NO_SYNC; }
 
 vector<pid_t> getProcIdByName(string procName, ofstream& log) {
   vector<pid_t> result;
@@ -237,8 +239,7 @@ void initialize(unordered_map<string, vector<pid_t>>& pids,
 }
 
 void StartNewProcess(const string pubKey, const string privKey, const string ip,
-                     const string port, const string syncType,
-                     const string path, ofstream& log) {
+                     const string port, const string path, ofstream& log) {
   log << "Create new Zilliqa process..." << endl;
   signal(SIGCHLD, SIG_IGN);
   pid_t pid;
@@ -255,6 +256,11 @@ void StartNewProcess(const string pubKey, const string privKey, const string ip,
       sleep(1);
     }
 
+    /// For recover-all scenario, a SUSPEND_LAUNCH file wil be created prior to
+    /// Zilliqa process being killed. Thus, we can use the variable 'bSuspend'
+    /// to distinguish syncType as RECOVERY_ALL_SYNC or NO_SYNC.
+    string syncType =
+        bSuspend ? to_string(RECOVERY_ALL_SYNC) : to_string(NO_SYNC);
     log << "\" "
         << execute(restart_zilliqa + " " + pubKey + " " + privKey + " " + ip +
                    " " + port + " " + syncType + " " + path + " 2>&1")
@@ -305,8 +311,8 @@ void MonitorProcess(unordered_map<string, vector<pid_t>>& pids,
         pids[name].erase(it);
       }
 
-      StartNewProcess(PubKey[pid], PrivKey[pid], IP[pid], Port[pid],
-                      to_string(getRestartValue(pid)), Path[pid], log);
+      StartNewProcess(PubKey[pid], PrivKey[pid], IP[pid], Port[pid], Path[pid],
+                      log);
       died.erase(pid);
       PrivKey.erase(pid);
       PubKey.erase(pid);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
With the new spec. of recovery-all nodes, the script will create SUSPEND_LAUNCH file first prior to killing ZIlliqa process. In this new scenario, the daemon should send RECOVERY_ALL_SYNC for bootstraping the new launched Zilliqa process.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
