### PR TITLE
Fix recovery issue for node not joining network

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1608,7 +1608,6 @@ bool Lookup::ProcessSetDSInfoFromSeed(const bytes& message, unsigned int offset,
     m_fetchedDSInfo = true;
   }
   cv_dsInfoUpdate.notify_all();
-
   return true;
 }
 
@@ -3102,7 +3101,6 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
   }
 
   CheckBufferTxBlocks();
-
   return true;
 }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -442,8 +442,10 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
 
   uint16_t ds_consensusLeaderID = 0;
 
-  BlockStorage::GetBlockStorage().GetDSCommittee(m_mediator.m_DSCommittee,
-                                                 ds_consensusLeaderID);
+  if (!BlockStorage::GetBlockStorage().GetDSCommittee(m_mediator.m_DSCommittee,
+                                                      ds_consensusLeaderID)) {
+    return false;
+  }
 
   m_mediator.m_ds->SetConsensusLeaderID(ds_consensusLeaderID);
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -444,6 +444,8 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
 
   if (!BlockStorage::GetBlockStorage().GetDSCommittee(m_mediator.m_DSCommittee,
                                                       ds_consensusLeaderID)) {
+    LOG_GENERAL(WARNING,
+                "Retrieve history error due to failed to get ds committee.");
     return false;
   }
 

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -283,8 +283,6 @@ bool Validator::CheckDirBlocks(
           dsblock.GetHeader().GetBlockNum(), serializedDSBlock);
       m_mediator.m_node->UpdateDSCommiteeComposition(mutable_ds_comm, dsblock);
       totalIndex++;
-      BlockStorage::GetBlockStorage().PutDSCommittee(
-          m_mediator.m_DSCommittee, m_mediator.m_ds->GetConsensusLeaderID());
       BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
     } else if (typeid(VCBlock) == dirBlock.type()) {
       const auto& vcblock = get<VCBlock>(dirBlock);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
For the nodes not joining network yet, some database would be missing. Then the recovery/upgrading would be failed. For this kind of situation, we always need to copy database from lookup node before applying recovery/upgrading.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
