### PR TITLE
Make UpdateProcessedTxn called early for DSCommittee

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -139,6 +139,10 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
 
   bool isVacuousEpoch = m_mediator.GetIsVacuousEpoch();
 
+  if (m_mediator.m_node->m_microblock != nullptr && !isVacuousEpoch) {
+    m_mediator.m_node->UpdateProcessedTransactions();
+  }
+
   // StoreMicroBlocksToDisk();
   StoreFinalBlockToDisk();
 
@@ -192,7 +196,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       << "] AFTER SENDING FLBLK");
 
   if (m_mediator.m_node->m_microblock != nullptr && !isVacuousEpoch) {
-    m_mediator.m_node->UpdateProcessedTransactions();
     if (m_mediator.m_node->m_microblock->GetHeader().GetTxRootHash() !=
         TxnHash()) {
       m_mediator.m_node->CallActOnFinalblock();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Thanks for @sandipbhoir 's finding, we found:

Some ds node may finish the finalblock consensus late,
if a txn packet from a gossip neighbor is reached between the StoreFinalBlock and UpdateProcessedTxn, it will process it and insert into m_createdTxn, because we only check the EpochNum and is the packet from lookup when receiving the packet, then decides whether should buffer or process.
But when the UpdateProcessedTxn function was called, it may clean the m_createdTxn, then the txn just received will be cleaned.
And duplicate gossip is ignored, so the missed txn was always missed. 
Thus Txn Missing happened. 

So, to put UpdateProcessedTxn early before the FinalBlock storing, should solve this problem.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
