### PR TITLE
Debian Stretch compile fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To run Zilliqa, we recommend the following minimum system requirements:
         libssl-dev libleveldb-dev libjsoncpp-dev libsnappy-dev cmake libmicrohttpd-dev \
         libjsonrpccpp-dev build-essential pkg-config libevent-dev libminiupnpc-dev \
         libprotobuf-dev protobuf-compiler libcurl4-openssl-dev libboost-program-options-dev \
-        libssl-dev
+        libssl-dev libssl1.0-dev
     ```
 
 * macOS:


### PR DESCRIPTION


Fix: "apt install libssl1.0-dev"

## Description
Fixes compile warnings for Debian Stretch (clean VM/new install) that appear as:

`libcrypto.so.1.0.2, needed by /usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libcurl.so, may conflict with libcrypto.so.1.1`

## Review Suggestion
I would see if you can just use `libssl1.0-dev` instead of `libssl-dev` on Ubuntu and others?

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
