### PR TITLE
Revert Contract State If Chain Call Failed

### DIFF
--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -223,13 +223,13 @@ bool Account::SetStorage(const vector<StateEntry>& state_entries, bool temp) {
 
 bool Account::SetStorage(const Address& addr,
                          const vector<pair<dev::h256, bytes>>& entries,
-                         bool temp, bool reversible) {
+                         bool temp, bool revertible) {
   if (!isContract()) {
     return false;
   }
 
   if (!ContractStorage::GetContractStorage().PutContractState(
-          addr, entries, m_storageRoot, temp, reversible)) {
+          addr, entries, m_storageRoot, temp, revertible)) {
     LOG_GENERAL(WARNING, "PutContractState failed");
     return false;
   }

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -212,13 +212,13 @@ bool Account::DeserializeBase(const bytes& src, unsigned int offset) {
   return AccountBase::Deserialize(src, offset);
 }
 
-bool Account::SetStorage(const vector<StateEntry>& state_entries, bool temp) {
+bool Account::SetStorage(const vector<StateEntry>& state_entries) {
   if (!isContract()) {
     return false;
   }
 
   return ContractStorage::GetContractStorage().PutContractState(
-      m_address, state_entries, m_storageRoot, temp);
+      m_address, state_entries, m_storageRoot, true);
 }
 
 bool Account::SetStorage(const Address& addr,
@@ -229,7 +229,7 @@ bool Account::SetStorage(const Address& addr,
   }
 
   if (!ContractStorage::GetContractStorage().PutContractState(
-          addr, entries, m_storageRoot, temp, revertible)) {
+          addr, entries, m_storageRoot, temp, revertible, {}, false)) {
     LOG_GENERAL(WARNING, "PutContractState failed");
     return false;
   }

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -166,6 +166,7 @@ class Account : public AccountBase {
                   const std::vector<std::pair<dev::h256, bytes>>& entries,
                   bool temp, bool revertible = false);
 
+  /// Only called during UpdateAccountsTemp
   bool SetStorage(const std::vector<Contract::StateEntry>& state_entries);
 
   std::string GetRawStorage(const dev::h256& k_hash, bool temp) const;

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -164,7 +164,7 @@ class Account : public AccountBase {
 
   bool SetStorage(const Address& addr,
                   const std::vector<std::pair<dev::h256, bytes>>& entries,
-                  bool temp, bool reversible = false);
+                  bool temp, bool revertible = false);
 
   bool SetStorage(const std::vector<Contract::StateEntry>& state_entries,
                   bool temp);

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -166,8 +166,7 @@ class Account : public AccountBase {
                   const std::vector<std::pair<dev::h256, bytes>>& entries,
                   bool temp, bool revertible = false);
 
-  bool SetStorage(const std::vector<Contract::StateEntry>& state_entries,
-                  bool temp);
+  bool SetStorage(const std::vector<Contract::StateEntry>& state_entries);
 
   std::string GetRawStorage(const dev::h256& k_hash, bool temp) const;
 

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -85,8 +85,8 @@ class AccountStore
   mutable std::shared_timed_mutex m_mutexPrimary;
   // mutex used when manipulating with state delta
   std::mutex m_mutexDelta;
-  // mutex related to reversibles
-  std::mutex m_mutexReversibles;
+  // mutex related to revertibles
+  std::mutex m_mutexRevertibles;
 
   bytes m_stateDeltaSerialized;
 
@@ -109,7 +109,7 @@ class AccountStore
   void GetSerializedDelta(bytes& dst);
 
   bool DeserializeDelta(const bytes& src, unsigned int offset,
-                        bool reversible = false);
+                        bool revertible = false);
 
   bool DeserializeDeltaTemp(const bytes& src, unsigned int offset);
 
@@ -142,10 +142,10 @@ class AccountStore
                                        const Account& account,
                                        const Account& oriAccount,
                                        const bool fullCopy = false,
-                                       const bool reversible = false) {
+                                       const bool revertible = false) {
     (*m_addressToAccount)[address] = account;
 
-    if (reversible) {
+    if (revertible) {
       if (fullCopy) {
         m_addressToAccountRevCreated[address] = account;
       } else {
@@ -168,11 +168,11 @@ class AccountStore
 
   void InitTemp();
 
-  void CommitTempReversible();
+  void CommitTempRevertible();
 
   void RevertCommitTemp();
 
-  void InitReversibles();
+  void InitRevertibles();
 };
 
 #endif  // __ACCOUNTSTORE_H__

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -77,9 +77,10 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   bool ParseCreateContractJsonOutput(const Json::Value& _json,
                                      uint64_t& gasRemained);
 
-  bool ParseCallContract(uint64_t& gasRemained, const std::string& runnerPrint);
+  bool ParseCallContract(uint64_t& gasRemained, const std::string& runnerPrint,
+                         bool first = true);
   bool ParseCallContractJsonOutput(const Json::Value& _json,
-                                   uint64_t& gasRemained);
+                                   uint64_t& gasRemained, bool first);
 
   Json::Value GetBlockStateJson(const uint64_t& BlockNum) const;
 

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -401,6 +401,9 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
     }
 
     if (ret && !ParseCallContract(gasRemained, runnerPrint)) {
+      if (m_curDepth > 0) {
+        Contract::ContractStorage::GetContractStorage().RevertPrevState();
+      }
       ret = false;
     }
     if (!ret) {
@@ -767,12 +770,13 @@ bool AccountStoreSC<MAP>::ParseCreateContractJsonOutput(
 
 template <class MAP>
 bool AccountStoreSC<MAP>::ParseCallContract(uint64_t& gasRemained,
-                                            const std::string& runnerPrint) {
+                                            const std::string& runnerPrint,
+                                            bool first) {
   Json::Value jsonOutput;
   if (!ParseCallContractOutput(jsonOutput, runnerPrint)) {
     return false;
   }
-  return ParseCallContractJsonOutput(jsonOutput, gasRemained);
+  return ParseCallContractJsonOutput(jsonOutput, gasRemained, first);
 }
 
 template <class MAP>
@@ -820,7 +824,8 @@ bool AccountStoreSC<MAP>::ParseCallContractOutput(
 
 template <class MAP>
 bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
-                                                      uint64_t& gasRemained) {
+                                                      uint64_t& gasRemained,
+                                                      bool first) {
   // LOG_MARKER();
   std::chrono::system_clock::time_point tpStart;
   if (ENABLE_CHECK_PERFORMANCE_LOG) {
@@ -894,15 +899,6 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
     }
   }
 
-  if (!contractAccount->SetStorage(state_entries)) {
-    LOG_GENERAL(WARNING, "SetStorage failed");
-  }
-
-  if (ENABLE_CHECK_PERFORMANCE_LOG) {
-    LOG_GENERAL(DEBUG, "LDB Write (microseconds) = " << r_timer_end(tpStart));
-    LOG_GENERAL(DEBUG, "Gas used = " << (startGas - gasRemained));
-  }
-
   for (const auto& e : _json["events"]) {
     LogEntry entry;
     if (!entry.Install(e, m_curContractAddr)) {
@@ -911,52 +907,85 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
     m_curTranReceipt.AddEntry(entry);
   }
 
+  bool ret = false;
+
   // If output message is null
   if (_json["message"].isNull()) {
     LOG_GENERAL(INFO,
                 "null message in scilla output when invoking a "
                 "contract, transaction finished");
-    return true;
+    ret = true;
   }
 
-  // Non-null messages must have few mandatory fields.
-  if (!_json["message"].isMember("_tag") ||
-      !_json["message"].isMember("_amount") ||
-      !_json["message"].isMember("params") ||
-      !_json["message"].isMember("_recipient")) {
-    LOG_GENERAL(WARNING,
-                "The message in the json output of this contract is corrupted");
-    return false;
+  Address recipient;
+  Account* account = new Account();
+
+  if (!ret) {
+    // Non-null messages must have few mandatory fields.
+    if (!_json["message"].isMember("_tag") ||
+        !_json["message"].isMember("_amount") ||
+        !_json["message"].isMember("params") ||
+        !_json["message"].isMember("_recipient")) {
+      LOG_GENERAL(
+          WARNING,
+          "The message in the json output of this contract is corrupted");
+      return false;
+    }
+
+    recipient = Address(_json["message"]["_recipient"].asString());
+    if (recipient == Address()) {
+      LOG_GENERAL(WARNING, "The recipient can't be null address");
+      return false;
+    }
+
+    delete account;
+    account = this->GetAccount(recipient);
+
+    if (account == nullptr) {
+      LOG_GENERAL(WARNING, "The recipient account doesn't exist");
+      return false;
+    }
+
+    // Recipient is non-contract
+    if (!account->isContract()) {
+      LOG_GENERAL(INFO, "The recipient is non-contract");
+      return TransferBalanceAtomic(
+          m_curContractAddr, recipient,
+          atoi(_json["message"]["_amount"].asString().c_str()));
+    }
+
+    // Recipient is contract
+    // _tag field is empty
+    if (_json["message"]["_tag"].asString().empty()) {
+      LOG_GENERAL(INFO,
+                  "_tag in the scilla output is empty when invoking a "
+                  "contract, transaction finished");
+      ret = true;
+    }
   }
 
-  Address recipient = Address(_json["message"]["_recipient"].asString());
-  if (recipient == Address()) {
-    LOG_GENERAL(WARNING, "The recipient can't be null address");
-    return false;
+  if (first) {
+    if (ret) {
+      if (!contractAccount->SetStorage(state_entries)) {
+        LOG_GENERAL(WARNING, "SetStorage failed");
+      }
+      if (ENABLE_CHECK_PERFORMANCE_LOG) {
+        LOG_GENERAL(DEBUG,
+                    "LDB Write (microseconds) = " << r_timer_end(tpStart));
+        LOG_GENERAL(DEBUG, "Gas used = " << (startGas - gasRemained));
+      }
+      return true;
+    }
+    Contract::ContractStorage::GetContractStorage().BufferCurrentState();
   }
 
-  Account* account = this->GetAccount(recipient);
-
-  if (account == nullptr) {
-    LOG_GENERAL(WARNING, "The recipient account doesn't exist");
-    return false;
+  if (ENABLE_CHECK_PERFORMANCE_LOG) {
+    LOG_GENERAL(DEBUG, "LDB Write (microseconds) = " << r_timer_end(tpStart));
+    LOG_GENERAL(DEBUG, "Gas used = " << (startGas - gasRemained));
   }
 
-  // Recipient is non-contract
-  if (!account->isContract()) {
-    LOG_GENERAL(INFO, "The recipient is non-contract");
-    return TransferBalanceAtomic(
-        m_curContractAddr, recipient,
-        atoi(_json["message"]["_amount"].asString().c_str()));
-  }
-
-  // Recipient is contract
-  // _tag field is empty
-  if (_json["message"]["_tag"].asString().empty()) {
-    LOG_GENERAL(INFO,
-                "_tag in the scilla output is empty when invoking a "
-                "contract, transaction finished");
-    return true;
+  if (!contractAccount->SetStorage(state_entries)) {
+    LOG_GENERAL(WARNING, "SetStorage failed");
   }
 
   ++m_curDepth;
@@ -1045,7 +1074,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
 
   Address t_address = m_curContractAddr;
   m_curContractAddr = recipient;
-  if (!ParseCallContract(gasRemained, runnerPrint)) {
+  if (!ParseCallContract(gasRemained, runnerPrint, false)) {
     LOG_GENERAL(WARNING,
                 "ParseCallContract failed of calling contract: " << recipient);
     return false;

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -894,7 +894,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(const Json::Value& _json,
     }
   }
 
-  if (!contractAccount->SetStorage(state_entries, true)) {
+  if (!contractAccount->SetStorage(state_entries)) {
     LOG_GENERAL(WARNING, "SetStorage failed");
   }
 

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -215,7 +215,7 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
   }
 
   AccountStore::GetInstance().InitTemp();
-  AccountStore::GetInstance().InitReversibles();
+  AccountStore::GetInstance().InitRevertibles();
   m_stateDeltaFromShards.clear();
   m_allPoWConns.clear();
   ClearDSPoWSolns();

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -216,7 +216,7 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary() {
     m_mediator.m_node->ProcessTransactionWhenShardLeader();
     AccountStore::GetInstance().SerializeDelta();
   }
-  AccountStore::GetInstance().CommitTempReversible();
+  AccountStore::GetInstance().CommitTempRevertible();
 
   if (!m_mediator.m_node->ComposeMicroBlock()) {
     LOG_GENERAL(WARNING, "DS ComposeMicroBlock Failed");
@@ -996,7 +996,7 @@ bool DirectoryService::FinalBlockValidator(
         return false;
       }
       AccountStore::GetInstance().SerializeDelta();
-      AccountStore::GetInstance().CommitTempReversible();
+      AccountStore::GetInstance().CommitTempRevertible();
     }
   } else {
     m_mediator.m_node->m_microblock = nullptr;

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -525,7 +525,7 @@ void AccountDeltaToProtobuf(const Account* oldAccount,
 
 bool ProtobufToAccountDelta(const ProtoAccount& protoAccount, Account& account,
                             const Address& addr, const bool fullCopy, bool temp,
-                            bool reversible = false) {
+                            bool revertible = false) {
   if (!CheckRequiredFieldsProtoAccount(protoAccount)) {
     LOG_GENERAL(WARNING, "CheckRequiredFieldsProtoAccount failed");
     return false;
@@ -600,7 +600,7 @@ bool ProtobufToAccountDelta(const ProtoAccount& protoAccount, Account& account,
                              DataConversion::StringToCharArray(entry.data()));
       }
 
-      if (!account.SetStorage(addr, entries, temp, reversible)) {
+      if (!account.SetStorage(addr, entries, temp, revertible)) {
         return false;
       }
 
@@ -2528,7 +2528,7 @@ bool Messenger::StateDeltaToAddressMap(
 bool Messenger::GetAccountStoreDelta(const bytes& src,
                                      const unsigned int offset,
                                      AccountStore& accountStore,
-                                     const bool reversible, bool temp) {
+                                     const bool revertible, bool temp) {
   ProtoAccountStore result;
 
   result.ParseFromArray(src.data() + offset, src.size() - offset);
@@ -2567,7 +2567,7 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
     t_account = *oriAccount;
     account = *oriAccount;
     if (!ProtobufToAccountDelta(entry.account(), account, address, fullCopy,
-                                temp, reversible)) {
+                                temp, revertible)) {
       LOG_GENERAL(WARNING,
                   "ProtobufToAccountDelta failed for account at address "
                       << entry.address());
@@ -2575,7 +2575,7 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
     }
 
     accountStore.AddAccountDuringDeserialization(address, account, t_account,
-                                                 fullCopy, reversible);
+                                                 fullCopy, revertible);
   }
 
   return true;

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -98,7 +98,7 @@ class Messenger {
                                    AccountStore& accountStore);
   static bool GetAccountStoreDelta(const bytes& src, const unsigned int offset,
                                    AccountStore& accountStore,
-                                   const bool reversible, bool temp);
+                                   const bool revertible, bool temp);
   static bool GetAccountStoreDelta(const bytes& src, const unsigned int offset,
                                    AccountStoreTemp& accountStoreTemp,
                                    bool temp);

--- a/src/libPersistence/ContractStorage.cpp
+++ b/src/libPersistence/ContractStorage.cpp
@@ -108,7 +108,7 @@ bool ContractStorage::PutContractState(const dev::h160& address,
 
 bool ContractStorage::PutContractState(
     const dev::h160& address, const vector<pair<Index, bytes>>& entries,
-    dev::h256& stateHash, bool temp, bool reversible,
+    dev::h256& stateHash, bool temp, bool revertible,
     const vector<Index>& existing_indexes, bool provideExisting) {
   // LOG_MARKER();
 
@@ -137,7 +137,7 @@ bool ContractStorage::PutContractState(
     if (temp) {
       t_stateDataMap[entry.first.hex()] = entry.second;
     } else {
-      if (reversible) {
+      if (revertible) {
         r_stateDataMap[entry.first.hex()] = m_stateDataMap[entry.first.hex()];
       }
       m_stateDataMap[entry.first.hex()] = entry.second;
@@ -145,7 +145,7 @@ bool ContractStorage::PutContractState(
   }
 
   // Update the stateIndexDB
-  if (!SetContractStateIndexes(address, entry_indexes, temp, reversible)) {
+  if (!SetContractStateIndexes(address, entry_indexes, temp, revertible)) {
     LOG_GENERAL(WARNING, "SetContractStateIndex failed");
     return false;
   }
@@ -157,7 +157,7 @@ bool ContractStorage::PutContractState(
 
 bool ContractStorage::SetContractStateIndexes(const dev::h160& address,
                                               const std::vector<Index>& indexes,
-                                              bool temp, bool reversible) {
+                                              bool temp, bool revertible) {
   // LOG_MARKER();
 
   bytes rawBytes;
@@ -169,7 +169,7 @@ bool ContractStorage::SetContractStateIndexes(const dev::h160& address,
   if (temp) {
     t_stateIndexMap[address.hex()] = rawBytes;
   } else {
-    if (reversible) {
+    if (revertible) {
       r_stateIndexMap[address.hex()] = m_stateIndexMap[address.hex()];
     }
     m_stateIndexMap[address.hex()] = rawBytes;
@@ -196,7 +196,7 @@ void ContractStorage::RevertContractStates() {
   }
 }
 
-void ContractStorage::InitReversibles() {
+void ContractStorage::InitRevertibles() {
   LOG_MARKER();
   r_stateIndexMap.clear();
   r_stateDataMap.clear();

--- a/src/libPersistence/ContractStorage.cpp
+++ b/src/libPersistence/ContractStorage.cpp
@@ -155,6 +155,16 @@ bool ContractStorage::PutContractState(
   return true;
 }
 
+void ContractStorage::BufferCurrentState() {
+  p_stateIndexMap = t_stateIndexMap;
+  p_stateDataMap = t_stateDataMap;
+}
+
+void ContractStorage::RevertPrevState() {
+  t_stateIndexMap = std::move(p_stateIndexMap);
+  t_stateDataMap = std::move(p_stateDataMap);
+}
+
 bool ContractStorage::SetContractStateIndexes(const dev::h160& address,
                                               const std::vector<Index>& indexes,
                                               bool temp, bool revertible) {

--- a/src/libPersistence/ContractStorage.h
+++ b/src/libPersistence/ContractStorage.h
@@ -54,7 +54,7 @@ class ContractStorage : public Singleton<ContractStorage> {
   /// Set the indexes of all the states of an contract account
   bool SetContractStateIndexes(const dev::h160& address,
                                const std::vector<Index>& indexes, bool temp,
-                               bool reversible);
+                               bool revertible);
 
   /// Get the raw rlp string of the states of an account
   std::vector<bytes> GetContractStatesData(const dev::h160& address, bool temp);
@@ -105,7 +105,7 @@ class ContractStorage : public Singleton<ContractStorage> {
 
   bool PutContractState(const dev::h160& address,
                         const std::vector<std::pair<Index, bytes>>& entries,
-                        dev::h256& stateHash, bool temp, bool reversible,
+                        dev::h256& stateHash, bool temp, bool revertible,
                         const std::vector<Index>& existing_indexes = {},
                         bool provideExisting = false);
 
@@ -125,7 +125,7 @@ class ContractStorage : public Singleton<ContractStorage> {
 
   void RevertContractStates();
 
-  void InitReversibles();
+  void InitRevertibles();
 };
 
 }  // namespace Contract

--- a/src/libPersistence/ContractStorage.h
+++ b/src/libPersistence/ContractStorage.h
@@ -116,8 +116,10 @@ class ContractStorage : public Singleton<ContractStorage> {
                         const std::vector<Index>& existing_indexes = {},
                         bool provideExisting = false);
 
+  /// Buffer the current t_map into p_map
   void BufferCurrentState();
 
+  /// Revert the t_map from the p_map just buffered
   void RevertPrevState();
 
   bool CommitStateDB();

--- a/src/libPersistence/ContractStorage.h
+++ b/src/libPersistence/ContractStorage.h
@@ -42,14 +42,21 @@ class ContractStorage : public Singleton<ContractStorage> {
   LevelDB m_stateIndexDB;
   LevelDB m_stateDataDB;
 
+  // Used by AccountStore
   std::unordered_map<std::string, bytes> m_stateIndexMap;
   std::unordered_map<std::string, bytes> m_stateDataMap;
 
+  // Used by AccountStoreTemp for StateDelta
   std::unordered_map<std::string, bytes> t_stateIndexMap;
   std::unordered_map<std::string, bytes> t_stateDataMap;
 
+  // Used for RevertCommitTemp
   std::unordered_map<std::string, bytes> r_stateIndexMap;
   std::unordered_map<std::string, bytes> r_stateDataMap;
+
+  // Used for revert state due to failure in chain call
+  std::unordered_map<std::string, bytes> p_stateIndexMap;
+  std::unordered_map<std::string, bytes> p_stateDataMap;
 
   /// Set the indexes of all the states of an contract account
   bool SetContractStateIndexes(const dev::h160& address,
@@ -95,7 +102,7 @@ class ContractStorage : public Singleton<ContractStorage> {
   std::vector<Index> GetContractStateIndexes(const dev::h160& address,
                                              bool temp);
 
-  /// Get the raw rlp string of the state by a index
+  /// Get the raw protobuf string of the state by a index
   std::string GetContractStateData(const Index& index, bool temp);
 
   /// Put one's contract states in database

--- a/src/libPersistence/ContractStorage.h
+++ b/src/libPersistence/ContractStorage.h
@@ -116,6 +116,10 @@ class ContractStorage : public Singleton<ContractStorage> {
                         const std::vector<Index>& existing_indexes = {},
                         bool provideExisting = false);
 
+  void BufferCurrentState();
+
+  void RevertPrevState();
+
   bool CommitStateDB();
 
   void InitTempState();

--- a/tests/Data/Test_Account.cpp
+++ b/tests/Data/Test_Account.cpp
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(testStorage) {
   dev::h256 hash;
 
   acc1.SetStorage(Address(), {}, true);
-  acc1.SetStorage({}, true);
+  acc1.SetStorage({});
   acc1.SetStorageRoot(hash);
   acc1.GetRawStorage(hash, true);
 

--- a/tests/Data/Test_Contract.cpp
+++ b/tests/Data/Test_Contract.cpp
@@ -552,7 +552,7 @@ BOOST_AUTO_TEST_CASE(testStoragePerf) {
       state_entries.push_back(std::make_tuple(vname, true, type, value));
     }
 
-    account->SetStorage(state_entries, true);
+    account->SetStorage(state_entries);
 
     bytes dataTransfer;
     uint64_t amount =
@@ -687,7 +687,7 @@ BOOST_AUTO_TEST_CASE(testFungibleToken) {
       state_entries.push_back(std::make_tuple(vname, true, type, value));
     }
 
-    account->SetStorage(state_entries, true);
+    account->SetStorage(state_entries);
 
     // 3. Create a call to Transfer from one account to another
     bytes dataTransfer;
@@ -884,7 +884,7 @@ BOOST_AUTO_TEST_CASE(testNonFungibleToken) {
       state_entries.push_back(std::make_tuple(vname, true, type, value));
     }
 
-    account->SetStorage(state_entries, true);
+    account->SetStorage(state_entries);
 
     // 3. Execute transferFrom as an operator
     boost::random::mt19937 rng;
@@ -1069,8 +1069,8 @@ BOOST_AUTO_TEST_CASE(testDEX) {
       token_state_entries.push_back(std::make_tuple(vname, true, type, value));
     }
 
-    token1Account->SetStorage(token_state_entries, true);
-    token2Account->SetStorage(token_state_entries, true);
+    token1Account->SetStorage(token_state_entries);
+    token2Account->SetStorage(token_state_entries);
 
     // Deploy DEX
     // Deploy the DEX contract with the 0th test case, but use custom messages
@@ -1177,7 +1177,7 @@ BOOST_AUTO_TEST_CASE(testDEX) {
     dex_state_entries.push_back(std::make_tuple(
         "orderInfo", true, "Map (ByStr32) (Pair (ByStr20) (BNum))",
         JSONUtils::convertJsontoStr(orderInfo)));
-    dexAccount->SetStorage(dex_state_entries, true);
+    dexAccount->SetStorage(dex_state_entries);
 
     // Approve DEX on Token A and Token B respectively
     Json::Value dataApprove = fungibleTokenT5.message;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Added a buffer in ContractStorage for storing the t_map before the execution.
When there is a chain call, and accidentally failed in the middle, 
the contract can use the buffer to revert back to the state when the txn was not executed.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
