### PR TITLE
Clean logs in ProcessPoWSubmissionFromPacket

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -128,8 +128,8 @@ bool DirectoryService::CheckState(Action action) {
 
   if (!found) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "Action " << GetActionString(action) << " not allowed in state "
-                        << GetStateString());
+              GetActionString(action)
+                  << " not allowed in state " << GetStateString());
     return false;
   }
 

--- a/src/libDirectoryService/PoWProcessing.cpp
+++ b/src/libDirectoryService/PoWProcessing.cpp
@@ -247,15 +247,15 @@ bool DirectoryService::ProcessPoWSubmissionFromPacket(
     return false;
   }
 
-  if (CheckPoWSubmissionExceedsLimitsForNode(submitterPubKey)) {
-    LOG_GENERAL(WARNING, "Max PoW sent: " << submitterPeer);
-    return false;
-  }
-
   // Log all values
   LOG_GENERAL(INFO, "Key   = " << submitterPubKey);
   LOG_GENERAL(INFO, "Peer  = " << submitterPeer);
   LOG_GENERAL(INFO, "Diff  = " << to_string(difficultyLevel));
+
+  if (CheckPoWSubmissionExceedsLimitsForNode(submitterPubKey)) {
+    LOG_GENERAL(WARNING, "Max PoW sent");
+    return false;
+  }
 
   // Define the PoW parameters
   array<unsigned char, 32> rand1 = m_mediator.m_dsBlockRand;
@@ -310,7 +310,7 @@ bool DirectoryService::ProcessPoWSubmissionFromPacket(
     // everyone if ((m_state != POW_SUBMISSION) && (m_state !=
     // DSBLOCK_CONSENSUS_PREP))
     if (CheckState(VERIFYPOW)) {
-      LOG_GENERAL(INFO, "Verified OK");
+      // LOG_GENERAL(INFO, "Verified OK");
       lock(m_mutexAllPOW, m_mutexAllPoWConns);
       lock_guard<mutex> g(m_mutexAllPOW, adopt_lock);
       lock_guard<mutex> g2(m_mutexAllPoWConns, adopt_lock);
@@ -324,17 +324,14 @@ bool DirectoryService::ProcessPoWSubmissionFromPacket(
       if (m_allPoWs.find(submitterPubKey) == m_allPoWs.end()) {
         m_allPoWs[submitterPubKey] = soln;
       } else if (m_allPoWs[submitterPubKey].result > soln.result) {
-        string harderSolnStr, oldSolnStr;
-        DataConversion::charArrToHexStr(soln.result, harderSolnStr);
-        DataConversion::charArrToHexStr(m_allPoWs[submitterPubKey].result,
-                                        oldSolnStr);
-        LOG_GENERAL(INFO, "Replaced PoW " << oldSolnStr.substr(0, 8)
-                                          << "... with harder PoW "
-                                          << harderSolnStr.substr(0, 8)
-                                          << "... for " << submitterPubKey);
+        // string harderSolnStr, oldSolnStr;
+        // DataConversion::charArrToHexStr(soln.result, harderSolnStr);
+        // DataConversion::charArrToHexStr(m_allPoWs[submitterPubKey].result,
+        // oldSolnStr);
+        LOG_GENERAL(INFO, "Replaced PoW");
         m_allPoWs[submitterPubKey] = soln;
       } else if (m_allPoWs[submitterPubKey].result == soln.result) {
-        LOG_GENERAL(INFO, "Ignored duplicate PoW");
+        LOG_GENERAL(INFO, "Duplicate PoW");
         return true;
       }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -979,8 +979,8 @@ bool Node::CheckState(Action action) {
 
   if (!found) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "Action " << GetActionString(action) << " not allowed in state "
-                        << GetStateString());
+              GetActionString(action)
+                  << " not allowed in state " << GetStateString());
     return false;
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Our DS logs are **extremely** long during PoW processing.
There is a bunch of redundant information as well.
This PR makes these changes to `DirectoryService::ProcessPoWSubmissionFromPacket`:

1. Removed redundant messages after each of the 3 calls to `CheckState()`. You can tell which one caused a failure anyway.
2. Shortened the message inside `CheckState()` (removed word "Action").
3. Removed POWSTAT message and timer start/stop since a DS has to do this for **ALL** PoW submissions including duplicates.
4. Removed "Verified OK" message, since at this point of the function the PoW is already fine. It's better to just print the other cases (e.g., duplicate or replaced PoW).
5. Shortened the "Replaced harder PoW" message. Don't need to print the key again here.
6. Shortened the "Max PoW sent" message. Moved the key/peer/diff printing up so we don't need to print the key again here.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
