### PR TITLE
Fix protobuf initialization for NodeGetGuardNodeNetworkInfoUpdate

### DIFF
--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -7525,7 +7525,7 @@ bool Messenger::SetLookupGetNewDSGuardNetworkInfoFromLookup(
   result.mutable_data()->set_dsepochnumber(dsEpochNumber);
   SerializableToProtobufByteArray(lookupKey.second, *result.mutable_pubkey());
 
-  if (result.IsInitialized()) {
+  if (result.data().IsInitialized()) {
     bytes tmp(result.data().ByteSize());
     result.data().SerializeToArray(tmp.data(), tmp.size());
 


### PR DESCRIPTION
## Description
This PR fix  -

Messenger::SetLookupGetNewDSGuardNetworkInfoFromLookup failed due protobuf intialization bug.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
