### PR TITLE
Adjust the criteria for epoch num check when receiving packet from neighbors

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1264,20 +1264,15 @@ bool Node::ProcessTxnPacketFromLookup([[gnu::unused]] const bytes& message,
     }
   }
 
-  bool isLookup = false;
-  if (m_mediator.m_lookup->IsLookupNode(from) &&
-      from.GetPrintableIPAddress() != "127.0.0.1") {
-    isLookup = true;
-  }
+  bool isLookup = m_mediator.m_lookup->IsLookupNode(from) &&
+                  from.GetPrintableIPAddress() != "127.0.0.1";
 
-  bool properState = false;
-  if ((m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
+  bool properState =
+      (m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
        m_mediator.m_ds->m_state == DirectoryService::MICROBLOCK_SUBMISSION) ||
       (m_mediator.m_ds->m_mode == DirectoryService::Mode::IDLE &&
        (m_state == MICROBLOCK_CONSENSUS_PREP ||
-        m_state == MICROBLOCK_CONSENSUS))) {
-    properState = true;
-  }
+        m_state == MICROBLOCK_CONSENSUS));
 
   if (isLookup || !properState) {
     if ((epochNumber + (isLookup ? 0 : 1)) < m_mediator.m_currentEpochNum) {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1264,19 +1264,30 @@ bool Node::ProcessTxnPacketFromLookup([[gnu::unused]] const bytes& message,
     }
   }
 
-  if ((m_mediator.m_lookup->IsLookupNode(from) &&
-       from.GetPrintableIPAddress() != "127.0.0.1") ||
-      (m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
-       m_mediator.m_ds->m_state != DirectoryService::MICROBLOCK_SUBMISSION) ||
+  bool isLookup = false;
+  if (m_mediator.m_lookup->IsLookupNode(from) &&
+      from.GetPrintableIPAddress() != "127.0.0.1") {
+    isLookup = true;
+  }
+
+  bool properState = false;
+  if ((m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
+       m_mediator.m_ds->m_state == DirectoryService::MICROBLOCK_SUBMISSION) ||
       (m_mediator.m_ds->m_mode == DirectoryService::Mode::IDLE &&
-       !(m_state == MICROBLOCK_CONSENSUS_PREP ||
-         m_state == MICROBLOCK_CONSENSUS))) {
-    if (epochNumber < m_mediator.m_currentEpochNum) {
+       (m_state == MICROBLOCK_CONSENSUS_PREP ||
+        m_state == MICROBLOCK_CONSENSUS))) {
+    properState = true;
+  }
+
+  if (isLookup || !properState) {
+    if ((epochNumber + (isLookup ? 0 : 1)) < m_mediator.m_currentEpochNum) {
       LOG_GENERAL(WARNING, "Txn packet from older epoch, discard");
       return false;
     }
     lock_guard<mutex> g(m_mutexTxnPacketBuffer);
-    LOG_GENERAL(INFO, "Received txn from lookup, stored to buffer");
+    LOG_GENERAL(INFO, string(isLookup ? "Received txn from lookup"
+                                      : "Received not in the prepared state") +
+                          ", store to buffer");
     LOG_STATE("[TXNPKTPROC]["
               << std::setw(15) << std::left
               << m_mediator.m_selfPeer.GetPrintableIPAddress() << "]["


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The previous check of the epoch num when receiving txn packet is only appy for the ones receiving from lookup. For receiving from neighbors, it should has a lower number by 1, as the commit of the packet from the node who received from lookup will only happen when a new epoch is mined

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
