### PR TITLE
Make ScillaTestUtil aware of multi-versions

### DIFF
--- a/tests/Data/ScillaTestUtil.cpp
+++ b/tests/Data/ScillaTestUtil.cpp
@@ -56,14 +56,23 @@ uint64_t ScillaTestUtil::GetFileSize(std::string filename) {
 }
 
 // Get ScillaTest for contract "name" and test numbered "i".
+// "version" is used only if ENABLE_SCILLA_MULTI_VERSION is set.
 bool ScillaTestUtil::GetScillaTest(ScillaTest &t, std::string contrName,
-                                   unsigned int i) {
+                                   unsigned int i, std::string version) {
   if (SCILLA_ROOT.empty()) {
     return false;
   }
 
   // TODO: Does this require a separate entry in constants.xml?
-  std::string testDir = SCILLA_ROOT + "/tests/contracts/" + contrName;
+  std::string testDir;
+  if (ENABLE_SCILLA_MULTI_VERSION) {
+    testDir = SCILLA_ROOT + "/" + version + "/tests/contracts/" + contrName;
+  } else {
+    testDir = SCILLA_ROOT + "/tests/contracts/" + contrName;
+  }
+
+  std::cout << "testDir: " << testDir << "\n";
+
   if (!boost::filesystem::is_directory(testDir)) {
     return false;
   }

--- a/tests/Data/ScillaTestUtil.h
+++ b/tests/Data/ScillaTestUtil.h
@@ -39,7 +39,9 @@ bool ParseJsonFile(Json::Value &j, std::string filename);
 uint64_t GetFileSize(std::string filename);
 
 // Get ScillaTest for contract "name" and test numbered "i".
-bool GetScillaTest(ScillaTest &t, std::string contrName, unsigned int i);
+// "version" is used only if ENABLE_SCILLA_MULTI_VERSION is set.
+bool GetScillaTest(ScillaTest &t, std::string contrName, unsigned int i,
+                   std::string version = "0");
 // Get _balance from output state of interpreter, from OUTPUT_JSON.
 // Return 0 on failure.
 boost::multiprecision::uint128_t GetBalanceFromOutput(void);


### PR DESCRIPTION
`ScillaTestUtil` used by `Test_Contract.cpp` does not work in multi-versioned mode currently. This PR fixes that. `ScillaTestUtil::GetScillaTest` now takes an additional optional (default to version 0) parameter to specify a version.

## Status

### Implementation
- [*] **ready for review**

### Integration Test (Core Team)
Local testing only.
