### PR TITLE
Clean more log messages in the shard node

### DIFF
--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -355,7 +355,6 @@ bool ConsensusLeader::ProcessMessageCommitCore(
 
 bool ConsensusLeader::ProcessMessageCommit(const bytes& commit,
                                            unsigned int offset) {
-  LOG_MARKER();
   return ProcessMessageCommitCore(commit, offset, PROCESS_COMMIT, CHALLENGE,
                                   CHALLENGE_DONE);
 }
@@ -668,7 +667,6 @@ bool ConsensusLeader::ProcessMessageResponseCore(
 
 bool ConsensusLeader::ProcessMessageResponse(const bytes& response,
                                              unsigned int offset) {
-  LOG_MARKER();
   return ProcessMessageResponseCore(response, offset, PROCESS_RESPONSE,
                                     COLLECTIVESIG, COLLECTIVESIG_DONE);
 }
@@ -724,14 +722,12 @@ bool ConsensusLeader::GenerateCollectiveSigMessage(bytes& collectivesig,
 
 bool ConsensusLeader::ProcessMessageFinalCommit(const bytes& finalcommit,
                                                 unsigned int offset) {
-  LOG_MARKER();
   return ProcessMessageCommitCore(finalcommit, offset, PROCESS_FINALCOMMIT,
                                   FINALCHALLENGE, FINALCHALLENGE_DONE);
 }
 
 bool ConsensusLeader::ProcessMessageFinalResponse(const bytes& finalresponse,
                                                   unsigned int offset) {
-  LOG_MARKER();
   return ProcessMessageResponseCore(
       finalresponse, offset, PROCESS_FINALRESPONSE, FINALCOLLECTIVESIG, DONE);
 }

--- a/src/libCrypto/MultiSig.cpp
+++ b/src/libCrypto/MultiSig.cpp
@@ -790,8 +790,6 @@ shared_ptr<Signature> MultiSig::AggregateSign(
 bool MultiSig::VerifyResponse(const Response& response,
                               const Challenge& challenge, const PubKey& pubkey,
                               const CommitPoint& commitPoint) {
-  LOG_MARKER();
-
   try {
     // Initial checks
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -675,8 +675,6 @@ class Messenger {
   template <class T>
   static bool GetConsensusID(const bytes& src, const unsigned int offset,
                              uint32_t& consensusID, PubKey& senderPubKey) {
-    LOG_MARKER();
-
     T consensus_message;
 
     consensus_message.ParseFromArray(src.data() + offset, src.size() - offset);

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -635,12 +635,6 @@ bool Node::ProcessVCDSBlocksMessage(const bytes& message,
     FallbackTimerPulse();
   }
 
-  LOG_GENERAL(INFO, "DS committee");
-  unsigned int ds_index = 0;
-  for (const auto& member : *m_mediator.m_DSCommittee) {
-    LOG_GENERAL(INFO, "[" << PAD(ds_index++, 3, ' ') << "] " << member.second);
-  }
-
   BlockStorage::GetBlockStorage().PutDSCommittee(
       m_mediator.m_DSCommittee, m_mediator.m_ds->GetConsensusLeaderID());
 

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -84,8 +84,6 @@ bool Node::ComposeMicroBlockMessageForSender(bytes& microblock_message) const {
 
 bool Node::ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
                                       const Peer& from) {
-  LOG_MARKER();
-
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "Node::ProcessMicroBlockConsensus not expected to be "


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
For 600-node shard, running for just 50 epochs (1 hour), we already get this number of messages:

```
[INFO][  149][19-01-30T09:18:52.233][sage/Messenger.h:678][GetConsensusID      ] BEG - appears 2210 times (est size 174kB)
[INFO][  152][19-01-30T09:19:27.268][ostProcessing.cpp:87][ProcessMicroBlockCon] BEG - appears 4420 times (est size 348kB)
[INFO][  883][19-01-30T09:39:19.027][pto/MultiSig.cpp:793][VerifyResponse      ] BEG - appears 800 times (est size 63kB)
And so on...
```

These are not necessary because for the error conditions in the functions, a log will also be displayed.

We also don't need to print the DS committee inside `Node::ProcessVCDSBlocksMessage` because the call to `PutDSCommittee` immediately after it will also print the DS committee.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
