### PR TITLE
Fix argument processing for the NAT address option.

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -107,14 +107,14 @@ int main(int argc, const char* argv[]) {
       }
 
       if (address != "NAT") {
+        if (!IPConverter::ToNumericalIPFromStr(address, ip)) {
+          return ERROR_IN_COMMAND_LINE;
+        }
+
         string address_;
         if (IPConverter::GetIPPortFromSocket(address, address_, port)) {
           address = address_;
         }
-      }
-
-      if (!IPConverter::ToNumericalIPFromStr(address, ip)) {
-        return ERROR_IN_COMMAND_LINE;
       }
 
       if ((port < 0) || (port > 65535)) {


### PR DESCRIPTION
## Description

A simple fix to allow the `--address NAT` to work as expected. The current behaviour complains that 'NAT' is not a valid IP address because of a spurious IP format check. This simply moves the check to inside the `if address != "NAT"` block where it makes sense to check for the IP address format.
