### PR TITLE
Fix total gas used check fail problem

### DIFF
--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -67,10 +67,10 @@ bool Node::ComposeMicroBlock() {
   LOG_MARKER();
 
   // TxBlockHeader
-  uint32_t version = MICROBLOCK_VERSION;
-  uint32_t shardId = m_myshardId;
-  uint64_t gasLimit = MICROBLOCK_GAS_LIMIT;
-  uint64_t gasUsed = m_gasUsedTotal;
+  const uint32_t version = MICROBLOCK_VERSION;
+  const uint32_t shardId = m_myshardId;
+  const uint64_t gasLimit = MICROBLOCK_GAS_LIMIT;
+  const uint64_t gasUsed = m_gasUsedTotal;
   uint128_t rewards = 0;
   if (m_mediator.GetIsVacuousEpoch() &&
       m_mediator.m_ds->m_mode != DirectoryService::IDLE) {
@@ -315,9 +315,6 @@ void Node::ProcessTransactionWhenShardLeader() {
     m_TxnOrder.push_back(t.GetTranID());
   };
 
-  m_gasUsedTotal = 0;
-  m_txnFees = 0;
-
   vector<Transaction> gasLimitExceededTxnBuffer;
 
   while (m_gasUsedTotal < MICROBLOCK_GAS_LIMIT) {
@@ -525,9 +522,6 @@ bool Node::VerifyTxnsOrdering(const vector<TxnHash>& tranHashes) {
         make_pair(t.GetTranID(), TransactionWithReceipt(t, tr)));
   };
 
-  m_gasUsedTotal = 0;
-  m_txnFees = 0;
-
   vector<Transaction> gasLimitExceededTxnBuffer;
 
   while (m_gasUsedTotal < MICROBLOCK_GAS_LIMIT) {
@@ -681,6 +675,10 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader() {
   }
 
   m_txn_distribute_window_open = false;
+  // Even don't have txns, also clear the variables, to avoid total gas check
+  // fail problem
+  m_gasUsedTotal = 0;
+  m_txnFees = 0;
 
   if (!m_mediator.GetIsVacuousEpoch() &&
       ((m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetDifficulty() >=
@@ -954,6 +952,11 @@ unsigned char Node::CheckLegitimacyOfTxnHashes(bytes& errorMsg) {
                 "called from LookUp node");
     return true;
   }
+
+  // Even don't have txns, also clear the variables, to avoid total gas check
+  // fail problem
+  m_gasUsedTotal = 0;
+  m_txnFees = 0;
 
   if (!m_mediator.GetIsVacuousEpoch() &&
       ((m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetDifficulty() >=

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -125,8 +125,8 @@ class Node : public Executable, public Broadcastable {
   // operates under m_mutexProcessedTransaction
   std::vector<TxnHash> m_TxnOrder;
 
-  uint64_t m_gasUsedTotal;
-  boost::multiprecision::uint128_t m_txnFees;
+  uint64_t m_gasUsedTotal = 0;
+  boost::multiprecision::uint128_t m_txnFees = 0;
 
   // std::mutex m_mutexCommittedTransactions;
   // std::unordered_map<uint64_t, std::list<TransactionWithReceipt>>


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix total gas used check fail problem
<!-- What is the context of your pull request? -->
Initilize the total gas used and txn fees variable in constructor. And clean the variable even there is no transactions. To avoid last tx blocks data goes into next tx block
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/438

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
