### PR TITLE
Fix rejoined DS backup using the wrong vacuous epoch flag

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1801,8 +1801,11 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
   bool isVacuousEpoch =
       (0 == (m_mediator.m_currentEpochNum + NUM_VACUOUS_EPOCHS) %
                 NUM_FINAL_BLOCK_PER_POW);
+
   m_mediator.m_currentEpochNum =
-      m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1;
+      m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
+  // To trigger m_isVacuousEpoch calculation
+  m_mediator.IncreaseEpochNum();
 
   m_mediator.m_consensusID =
       m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix DS micro block consensus check total reward at DS epoch
<!-- What is the context of your pull request? -->
Using IncreaseEpochNum function to increase block number, so the m_isVacuousEpoch is updated.
<!-- What are the related issues and pull requests? -->
```

[INFO][17999][19-02-08T06:33:58.739][ctoryService.cpp:382][SetState            ] [Epoch 5600] DS State = FINALBLOCK_CONSENSUS
[INFO][17999][19-02-08T06:33:58.739][eProcessing.cpp:1103][RunConsensusOnFinalB] END
[INFO][ 1087][19-02-08T06:33:59.583][work/P2PComm.cpp:304][DoSend              ] <144.202.109.176:33133> is blacklisted - blocking all messages
[WARN][ 1595][19-02-08T06:33:59.800][work/P2PComm.cpp:211][SendMessageSocketCor] Socket connect failed. Code = 110 Desc: Connection timed out. IP address: <45.76.38.88:33133>
[WARN][ 1595][19-02-08T06:33:59.800][work/P2PComm.cpp:216][SendMessageSocketCor] [blacklist] Encountered 110 (Connection timed out). Adding 45.76.38.88 to blacklist
[WARN][ 1595][19-02-08T06:33:59.800][work/P2PComm.cpp:281][SendMessageCore     ] Socket connect failed 1/1. IP address: <45.76.38.88:33133>
[INFO][ 1346][19-02-08T06:34:00.593][work/P2PComm.cpp:304][DoSend              ] <140.82.44.10:33133> is blacklisted - blocking all messages
[WARN][ 1487][19-02-08T06:34:01.852][work/P2PComm.cpp:211][SendMessageSocketCor] Socket connect failed. Code = 110 Desc: Connection timed out. IP address: <35.230.101.113:30303>
[WARN][ 1487][19-02-08T06:34:01.852][work/P2PComm.cpp:216][SendMessageSocketCor] [blacklist] Encountered 110 (Connection timed out). Adding 35.230.101.113 to blacklist
[WARN][ 1487][19-02-08T06:34:01.852][work/P2PComm.cpp:281][SendMessageCore     ] Socket connect failed 1/1. IP address: <35.230.101.113:30303>
[INFO][   35][19-02-08T06:34:05.815][RumorManager.cpp:517][RumorReceived       ] New msg for hash [4181A4] from <34.221.27.242:33133> (Len=2524): 0104000A29080010E02B1A208FE30956867041CC3EB3F6DE75CDC33F7500...
[INFO][   35][19-02-08T06:34:05.815][work/P2PComm.cpp:477][ProcessGossipMsg    ] Rumor size: 2621
[INFO][  493][19-02-08T06:34:05.815][stProcessing.cpp:283][ProcessFinalBlockCon] BEG
[INFO][  493][19-02-08T06:34:05.816][stProcessing.cpp:414][ProcessFinalBlockCon] BEG
[INFO][  493][19-02-08T06:34:05.816][sensusBackup.cpp:413][ProcessMessage      ] BEG
[INFO][  493][19-02-08T06:34:05.816][nsensusBackup.cpp:64][ProcessMessageAnnoun] BEG
[INFO][  493][19-02-08T06:34:05.816][reProcessing.cpp:941][FinalBlockValidator ] BEG
[INFO][  493][19-02-08T06:34:05.816][e/Messenger.cpp:3944][GetDSFinalBlockAnnou] BEG
[INFO][  493][19-02-08T06:34:05.816][e/Messenger.cpp:2069][GetConsensusAnnounce] BEG
[INFO][  493][19-02-08T06:34:05.817][e/Messenger.cpp:2069][GetConsensusAnnounce] END
[INFO][  493][19-02-08T06:34:05.817][e/Messenger.cpp:3944][GetDSFinalBlockAnnou] END
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:405][CheckMicroBlocks    ] BEG
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:420][CheckMicroBlocks    ] MicroBlock hash = e279626218d96790dffac60fd9aba2a9372644f4947d259340191701148b8d28
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:420][CheckMicroBlocks    ] MicroBlock hash = ceb82a0b8dbf74c86df49edcb4ea98d07a1243b4645d57331f194cd4e25635a0
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:405][CheckMicroBlocks    ] END
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:897][CheckMicroBlockValid] BEG
[INFO][  493][19-02-08T06:34:05.817][eProcessing.cpp:1180][CheckMicroBlockValid] BEG
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:885][CheckMicroBlockVersi] Version check passed
[INFO][  493][19-02-08T06:34:05.817][reProcessing.cpp:907][CheckMicroBlockshard] shardId check passed
[INFO][  493][19-02-08T06:34:05.819][reProcessing.cpp:944][CheckMicroBlockTimes] BEG
[INFO][  493][19-02-08T06:34:05.819][reProcessing.cpp:944][CheckMicroBlockTimes] END
[INFO][  493][19-02-08T06:34:05.819][eProcessing.cpp:1036][CheckMicroBlockHashe] Hash count check passed
[INFO][  493][19-02-08T06:34:05.819][eProcessing.cpp:1009][CheckLegitimacyOfTxn] [Epoch 5600] Vacuous epoch: Skipping processing transactions
**[WARN][  493][19-02-08T06:34:05.819][eProcessing.cpp:1075][CheckMicroBlockHashe] Total rewards check failed**
[WARN][  493][19-02-08T06:34:05.819][eProcessing.cpp:1075][CheckMicroBlockHashe]  Received = 0
[WARN][  493][19-02-08T06:34:05.819][eProcessing.cpp:1075][CheckMicroBlockHashe]  Expected = 263698630136986000
[INFO][  493][19-02-08T06:34:05.819][eProcessing.cpp:1180][CheckMicroBlockValid] END
[WARN][  493][19-02-08T06:34:05.819][reProcessing.cpp:915][CheckMicroBlockValid] Microblock validation failed
[INFO][  493][19-02-08T06:34:05.819][reProcessing.cpp:897][CheckMicroBlockValid] END
[WARN][  493][19-02-08T06:34:05.819][reProcessing.cpp:963][FinalBlockValidator ] DS CheckMicroBlockValidity Failed
```

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
