### PR TITLE
Fix a rare cornercase in view change

### DIFF
--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -550,7 +550,7 @@ bool DirectoryService::CheckUseVCBlockInsteadOfDSBlock(
       if (prevVCBlockptr->GetHeader().GetViewChangeState() ==
               DSBLOCK_CONSENSUS ||
           prevVCBlockptr->GetHeader().GetViewChangeState() ==
-              DSBLOCK_CONSENSUS) {
+              DSBLOCK_CONSENSUS_PREP) {
         return true;
       } else {
         LOG_GENERAL(

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -545,8 +545,38 @@ bool DirectoryService::CheckUseVCBlockInsteadOfDSBlock(
       return false;
     }
 
-    if (prevVCBlockptr->GetHeader().GetViewChangeState() != m_viewChangestate) {
-      return false;
+    if (m_viewChangestate == DSBLOCK_CONSENSUS ||
+        m_viewChangestate == DSBLOCK_CONSENSUS_PREP) {
+      if (prevVCBlockptr->GetHeader().GetViewChangeState() ==
+              DSBLOCK_CONSENSUS ||
+          prevVCBlockptr->GetHeader().GetViewChangeState() ==
+              DSBLOCK_CONSENSUS) {
+        return true;
+      } else {
+        LOG_GENERAL(
+            WARNING,
+            "The previous vc block is not for current state.  prevVCBlockptr: "
+                << to_string(prevVCBlockptr->GetHeader().GetViewChangeState())
+                << " m_viewChangestate:" << m_viewChangestate);
+        return false;
+      }
+    }
+
+    if (m_viewChangestate == FINALBLOCK_CONSENSUS ||
+        m_viewChangestate == FINALBLOCK_CONSENSUS_PREP) {
+      if (prevVCBlockptr->GetHeader().GetViewChangeState() ==
+              FINALBLOCK_CONSENSUS ||
+          prevVCBlockptr->GetHeader().GetViewChangeState() ==
+              FINALBLOCK_CONSENSUS_PREP) {
+        return true;
+      } else {
+        LOG_GENERAL(
+            WARNING,
+            "The previous vc block is not for current state.  prevVCBlockptr: "
+                << to_string(prevVCBlockptr->GetHeader().GetViewChangeState())
+                << " m_viewChangestate:" << m_viewChangestate);
+        return false;
+      }
     }
   } else {
     return false;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Fixed a rare occurrence where DS leader stalled at ds consensus prep or final block consensus prep stage, will result in using wrong block hash (final block instead vc block)  as input to the hash function to select new candidate leader when multiple view change occurs. 

This issue only occurs iff
1. The stalled state is in prep. Note: This situation is unlikely as the transition from prep to consensus requires just creation of consensus object
2. More than 1 view change in the same epoch and same state

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] ~local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test - All vc tests
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
