### PR TITLE
Catch an exception by reference to prevent gcc-8 errors

### DIFF
--- a/src/libUtils/IPConverter.cpp
+++ b/src/libUtils/IPConverter.cpp
@@ -49,7 +49,7 @@ bool GetIPPortFromSocket(string socket, string& ip, int& port) {
   try {
     port = boost::lexical_cast<int>(addr_parts.back());
     return true;
-  } catch (boost::bad_lexical_cast) {
+  } catch (boost::bad_lexical_cast&) {
     return false;
   }
   // Defense


### PR DESCRIPTION
## Description

Fixes https://github.com/Zilliqa/Zilliqa/issues/1402.

## Review Suggestion

Check that Zilliqa compiles under both gcc-7 and gcc-8.

## Implementation

Catch the exception by reference instead of value.
