### PR TITLE
Fix pedantic errors stopping GCC 8 from compiling.

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -794,7 +794,7 @@ bool DirectoryService::UpdateDSGuardIdentity() {
     // TODO: changge to N ds nodes who co-sign on the ds block
     std::vector<Peer> networkInfoUpdateReceivers;
     unsigned int numOfNetworkInfoReceivers =
-        std::min(NUM_GOSSIP_RECEIVERS, (const unsigned int)peerInfo.size());
+        std::min(NUM_GOSSIP_RECEIVERS, (unsigned int)peerInfo.size());
 
     for (unsigned int i = 0; i < numOfNetworkInfoReceivers; i++) {
       networkInfoUpdateReceivers.emplace_back(peerInfo.at(i));

--- a/src/libUtils/IPConverter.cpp
+++ b/src/libUtils/IPConverter.cpp
@@ -49,7 +49,7 @@ bool GetIPPortFromSocket(string socket, string& ip, int& port) {
   try {
     port = boost::lexical_cast<int>(addr_parts.back());
     return true;
-  } catch (boost::bad_lexical_cast) {
+  } catch (boost::bad_lexical_cast&) {
     return false;
   }
   // Defense


### PR DESCRIPTION
## Description
Fix for issue https://github.com/Zilliqa/Zilliqa/issues/1402.

## Review Suggestion
Verify that the new code additions allow compilation properly on both GCC 7 and 8.

## Status

### Implementation
Rather simple syntax fixes to prevent GCC 8 from throwing errors (catch exception by reference and removing unnecessary const from a cast type).
