### PR TITLE
Avoid massive memory consumption during state retrieval

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -270,22 +270,6 @@ bool AccountStore::RetrieveFromDisk() {
   try {
     h256 root(rootBytes);
     m_state.setRoot(root);
-    for (const auto& i : m_state) {
-      Address address(i.first);
-
-      Account account;
-      if (!account.DeserializeBase(bytes(i.second.begin(), i.second.end()),
-                                   0)) {
-        LOG_GENERAL(WARNING, "Account::DeserializeBase failed");
-        continue;
-      }
-
-      if (account.isContract()) {
-        account.SetAddress(address);
-      }
-
-      m_addressToAccount->insert({address, account});
-    }
   } catch (const boost::exception& e) {
     LOG_GENERAL(WARNING, "Error with AccountStore::RetrieveFromDisk. "
                              << boost::diagnostic_information(e));

--- a/src/libData/AccountData/AccountStoreTrie.h
+++ b/src/libData/AccountData/AccountStoreTrie.h
@@ -46,7 +46,6 @@ class AccountStoreTrie : public AccountStoreSC<MAP> {
 
   dev::h256 GetStateRootHash() const;
   bool UpdateStateTrieAll();
-  void RepopulateStateTrie();
 
   void PrintAccountState() override;
 };

--- a/src/libData/AccountData/AccountStoreTrie.tpp
+++ b/src/libData/AccountData/AccountStoreTrie.tpp
@@ -45,7 +45,7 @@ bool AccountStoreTrie<DB, MAP>::Serialize(bytes& dst,
 
 template <class DB, class MAP>
 Account* AccountStoreTrie<DB, MAP>::GetAccount(const Address& address) {
-  // LOG_MARKER();
+  LOG_MARKER();
   using namespace boost::multiprecision;
 
   Account* account = AccountStoreBase<MAP>::GetAccount(address);
@@ -55,6 +55,7 @@ Account* AccountStoreTrie<DB, MAP>::GetAccount(const Address& address) {
 
   std::string rawAccountBase = m_state.at(address);
   if (rawAccountBase.empty()) {
+    LOG_GENERAL(WARNING, "Didn't find account in m_state")
     return nullptr;
   }
 

--- a/src/libData/AccountData/AccountStoreTrie.tpp
+++ b/src/libData/AccountData/AccountStoreTrie.tpp
@@ -45,7 +45,7 @@ bool AccountStoreTrie<DB, MAP>::Serialize(bytes& dst,
 
 template <class DB, class MAP>
 Account* AccountStoreTrie<DB, MAP>::GetAccount(const Address& address) {
-  LOG_MARKER();
+  // LOG_MARKER();
   using namespace boost::multiprecision;
 
   Account* account = AccountStoreBase<MAP>::GetAccount(address);
@@ -55,7 +55,7 @@ Account* AccountStoreTrie<DB, MAP>::GetAccount(const Address& address) {
 
   std::string rawAccountBase = m_state.at(address);
   if (rawAccountBase.empty()) {
-    LOG_GENERAL(WARNING, "Didn't find account in m_state")
+    LOG_GENERAL(WARNING, "Didn't find account in m_state");
     return nullptr;
   }
 
@@ -114,14 +114,6 @@ bool AccountStoreTrie<DB, MAP>::UpdateStateTrieAll() {
   }
 
   return true;
-}
-
-template <class DB, class MAP>
-void AccountStoreTrie<DB, MAP>::RepopulateStateTrie() {
-  LOG_MARKER();
-  m_state.init();
-  m_prevRoot = m_state.root();
-  UpdateStateTrieAll();
 }
 
 template <class DB, class MAP>

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -476,7 +476,7 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
       // missing microblocks from leader, set to a valid state to accept cosig1
       // and cosig2
 
-      // Block till txn is fetched
+      // Block till microblock is fetched
       unique_lock<mutex> lock(m_mutexCVMissingMicroBlock);
       if (cv_MissingMicroBlock.wait_for(
               lock, chrono::seconds(FETCHING_MISSING_DATA_TIMEOUT)) ==

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -276,7 +276,6 @@ bool Retriever::ValidateStates() {
   if (m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetStateRootHash() ==
       AccountStore::GetInstance().GetStateRootHash()) {
     LOG_GENERAL(INFO, "ValidateStates passed.");
-    AccountStore::GetInstance().RepopulateStateTrie();
     return true;
   } else {
     LOG_GENERAL(WARNING, "ValidateStates failed.");


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
we don't have to refill the m_addressToAccount during the retrieval, and this may cause huge memory consumption. It should be fine to get the account from the m_state when it is needed after it been initialized.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
~- [ ] local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test (tested with recovery)
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
