### PR TITLE
Use a non class variable when in DS consensus is not finalized

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -747,7 +747,7 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
     allPoWs = m_allPoWs;
   }
 
-    {
+  {
     std::lock_guard<std::mutex> g(m_mutexAllDSPOWs);
     allDSPoWs = m_allDSPoWs;
   }

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -740,10 +740,16 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
   lock_guard<mutex> g2(m_mutexAllPoWConns, adopt_lock);
 
   MapOfPubKeyPoW allPoWs;
+  MapOfPubKeyPoW allDSPoWs;
 
   {
     std::lock_guard<std::mutex> g(m_mutexAllPOW);
     allPoWs = m_allPoWs;
+  }
+
+    {
+    std::lock_guard<std::mutex> g(m_mutexAllDSPOWs);
+    allDSPoWs = m_allDSPoWs;
   }
 
   if (allPoWs.size() > MAX_SHARD_NODE_NUM) {
@@ -764,8 +770,8 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
         LOG_GENERAL(INFO,
                     "Node " << pubKeyPoW.first
                             << " failed to join because priority not enough.");
-        if (m_allDSPoWs.find(pubKeyPoW.first) != m_allDSPoWs.end()) {
-          m_allDSPoWs.erase(pubKeyPoW.first);
+        if (allDSPoWs.find(pubKeyPoW.first) != allDSPoWs.end()) {
+          allDSPoWs.erase(pubKeyPoW.first);
         }
       }
     }
@@ -773,7 +779,7 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSPrimary() {
     allPoWs.swap(tmpAllPoWs);
   }
 
-  auto sortedDSPoWSolns = SortPoWSoln(m_allDSPoWs);
+  auto sortedDSPoWSolns = SortPoWSoln(allDSPoWs);
   auto sortedPoWSolns = SortPoWSoln(allPoWs, true);
 
   map<PubKey, Peer> powDSWinners;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Copy `m_allDSPoWs` to a local variable to avoid polluting and inconsistency to the class variable when ds consensus is not yet completed. 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
