### PR TITLE
Fix the code for setting a lookup back online

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2280,13 +2280,6 @@ bool Lookup::ProcessSetLookupOnline(const bytes& message, unsigned int offset,
     return false;
   }
 
-  if (!VerifySenderNode(GetLookupNodes(), lookupPubKey)) {
-    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "The message sender pubkey: "
-                  << lookupPubKey << " is not in my lookup node list.");
-    return false;
-  }
-
   uint128_t ipAddr = from.m_ipAddress;
   Peer requestingNode(ipAddr, portNo);
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2745,7 +2745,7 @@ bool Lookup::GetMyLookupOffline() {
   return true;
 }
 
-bool Lookup::GetMyLookupOnline() {
+bool Lookup::GetMyLookupOnline(bool fromRecovery) {
   if (!LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "Lookup::GetMyLookupOnline not expected to be called from "
@@ -2755,7 +2755,8 @@ bool Lookup::GetMyLookupOnline() {
 
   LOG_MARKER();
   bool found = false;
-  {
+
+  if (!fromRecovery) {
     std::lock_guard<std::mutex> lock(m_mutexLookupNodes);
     auto selfPeer(m_mediator.m_selfPeer);
     auto selfPubkey(m_mediator.m_selfKey.second);
@@ -2772,6 +2773,10 @@ bool Lookup::GetMyLookupOnline() {
       LOG_GENERAL(WARNING, "My Peer Info is not in m_lookupNodesOffline");
       return false;
     }
+  } else {
+    // If recovering a lookup, we don't expect it to be in the offline list, so
+    // just set found to true here
+    found = true;
   }
 
   if (found) {

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -222,7 +222,7 @@ class Lookup : public Executable {
   bool GetMyLookupOffline();
 
   // Set my lookup ip online in other lookup nodes
-  bool GetMyLookupOnline();
+  bool GetMyLookupOnline(bool fromRecovery = false);
 
   // Rejoin the network as a lookup node in case of failure happens in protocol
   void RejoinAsLookup();

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -256,7 +256,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, unsigned int syncType,
         // When doing recovery, make sure to let other lookups know I'm back
         // online
         if (LOOKUP_NODE_MODE) {
-          if (!m_mediator.m_lookup->GetMyLookupOnline()) {
+          if (!m_mediator.m_lookup->GetMyLookupOnline(true)) {
             LOG_GENERAL(WARNING, "Failed to notify lookups I am back online");
           }
         }

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -253,6 +253,13 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, unsigned int syncType,
         break;
       case SyncType::RECOVERY_ALL_SYNC:
         LOG_GENERAL(INFO, "Recovery all nodes, no Sync Needed");
+        // When doing recovery, make sure to let other lookups know I'm back
+        // online
+        if (LOOKUP_NODE_MODE) {
+          if (!m_mediator.m_lookup->GetMyLookupOnline()) {
+            LOG_GENERAL(WARNING, "Failed to notify lookups I am back online");
+          }
+        }
         break;
       case SyncType::GUARD_DS_SYNC:
         LOG_GENERAL(INFO, "Sync as a ds guard node");


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR ensures a lookup node is able to send `SETLOOKUPONLINE` to the other lookups when doing recovery instead of rejoining.

This PR also removes an incorrect check inside `Lookup::ProcessSetLookupOnline` which rejects the message from the lookup if it is not in the online list (which it obviously isn't in at that time).

Test procedure:
1. Launch small-scale cloud testnet with 2 lookups
2. Go into lookup 0 and `pkill zilliqa` to trigger rejoining and sending `SETLOOKUPOFFLINE` to lookup 1
3. Do recovery of lookup 0
4. Verify that lookup 0 recovers successfully and that lookup 1 receives `SETLOOKUPONLINE`

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
