### PR TITLE
Buffer and Process received final blocks after seed is syncedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,11 @@ if(DM_TEST_DM_MOREMB_HALF)
     add_definitions(-DDM_TEST_DM_MOREMB_HALF)
 endif()
 
+if(SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)
+    message(STATUS "SJ 1 test enabled")
+    add_definitions(-DSJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)
+endif()
+
 include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIR})

--- a/build.sh
+++ b/build.sh
@@ -126,6 +126,10 @@ do
         CMAKE_EXTRA_OPTIONS="-DDM_TEST_DM_MOREMB_HALF=1 ${CMAKE_EXTRA_OPTIONS}"
         echo "Build with DSMBMerging test - DS leader and half of the DS doesn't have some microblock"
     ;;
+    sj1)
+        CMAKE_EXTRA_OPTIONS="-DSJ_TEST_SJ_TXNBLKS_PROCESS_SLOW=1 ${CMAKE_EXTRA_OPTIONS}"
+        echo "Build with SJ test - New Seed take long time to process txnblocks during syncup"
+    ;;        
     *)
         echo "Usage $0 [cuda|opencl] [tsan|asan] [style] [heartbeattest] [fallbacktest] [vc<1-8>] [dm<1-9>]"
         exit 1

--- a/scripts/make_image_for_test.sh
+++ b/scripts/make_image_for_test.sh
@@ -41,9 +41,10 @@ Test_scenarios=("-DVC_TEST_DS_SUSPEND_3=1 "
                 "-DDM_TEST_DM_MORETXN_HALF=1 "
                 "-DDM_TEST_DM_MOREMB_HALF=1 "
                 "-DADDRESS_SANITIZER=ON "
-                "-DTHREAD_SANITIZER=ON " )
+                "-DTHREAD_SANITIZER=ON "
+                "-DSJ_TEST_SJ_TXNBLKS_PROCESS_SLOW=1 " )
 
-Test_scenarios_name=( "vc2" "vc4" "vc1vc6" "vc3vc6" "vc7" "vc8" "dm1" "dm2" "dm3" "dm4" "dm5" "dm6" "dm7" "dm8" "dm9" "asan" "tsan" )
+Test_scenarios_name=( "vc2" "vc4" "vc1vc6" "vc3vc6" "vc7" "vc8" "dm1" "dm2" "dm3" "dm4" "dm5" "dm6" "dm7" "dm8" "dm9" "asan" "tsan" "sj1" )
 
 cmd=$0
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1755,7 +1755,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
           LOG_GENERAL(INFO,
                       "Processing txnblks recvd from lookup is slow "
                       "(SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)");
-          this_thread::sleep_for(chrono::seconds(5));
+          this_thread::sleep_for(chrono::seconds(10));
         }
 #endif  // SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW
         CommitTxBlocks(txBlocks);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1754,7 +1754,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
         if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP) {
           LOG_GENERAL(INFO,
                       "Processing txnblks recvd from lookup is slow "
-                      "(SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)");)
+                      "(SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)");
           this_thread::sleep_for(chrono::seconds(5));
         }
 #endif  // SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1750,6 +1750,14 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
         m_mediator.m_blocklinkchain.GetLatestBlockLink());
     switch (res) {
       case ValidatorBase::TxBlockValidationMsg::VALID:
+#ifdef SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW
+        if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP) {
+          LOG_GENERAL(INFO,
+                      "Processing txnblks recvd from lookup is slow "
+                      "(SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW)");)
+          this_thread::sleep_for(chrono::seconds(5));
+        }
+#endif  // SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW
         CommitTxBlocks(txBlocks);
         break;
       case ValidatorBase::TxBlockValidationMsg::INVALID:

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -558,15 +558,14 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
       // Buffer the Final Block
       lock_guard<mutex> g(m_mutexSeedTxnBlksBuffer);
       m_seedTxnBlksBuffer.push_back(message);
-      LOG_GENERAL(INFO, "Seed not yet synced, so buffered this final block");
+      LOG_GENERAL(INFO, "Seed not synced, buffered this FBLK");
       return false;
     } else {
       // If seed node is synced and have buffered txn blocks
       lock_guard<mutex> g(m_mutexSeedTxnBlksBuffer);
       if (!m_seedTxnBlksBuffer.empty()) {
-        LOG_GENERAL(INFO,
-                    "Seed is synced, so processing buffered final blocks");
-        for (auto& txnblk : m_seedTxnBlksBuffer) {
+        LOG_GENERAL(INFO, "Seed synced, processing buffered FBLKS");
+        for (const auto& txnblk : m_seedTxnBlksBuffer) {
           ProcessFinalBlockCore(txnblk, offset, Peer(), true);
         }
         // clear the buffer since all buffered ones are checked and processed

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1842,7 +1842,11 @@ bool Node::ToBlockMessage([[gnu::unused]] unsigned char ins_byte) {
           return true;
         }
       }
-    } else  // IS_LOOKUP_NODE
+    } else if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP &&
+               ins_byte == NodeInstructionType::FINALBLOCK)  // Is seed node
+    {
+      return false;
+    } else  // Is lookup node
     {
       return true;
     }

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -100,6 +100,9 @@ class Node : public Executable {
   std::mutex m_mutexCVWaitDSBlock;
   std::condition_variable cv_waitDSBlock;
 
+  // Final Block Buffer for seed node
+  std::vector<bytes> m_seedTxnBlksBuffer;
+
   // Persistence Retriever
   std::shared_ptr<Retriever> m_retriever;
 
@@ -229,6 +232,8 @@ class Node : public Executable {
                                       const Peer& from);
   bool ProcessFinalBlock(const bytes& message, unsigned int offset,
                          const Peer& from);
+  bool ProcessFinalBlockCore(const bytes& message, unsigned int offset,
+                             const Peer& from, bool buffered = false);
   bool ProcessMBnForwardTransaction(const bytes& message,
                                     unsigned int cur_offset, const Peer& from);
   bool ProcessMBnForwardTransactionCore(const MBnForwardedTxnEntry& entry);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -102,6 +102,7 @@ class Node : public Executable {
 
   // Final Block Buffer for seed node
   std::vector<bytes> m_seedTxnBlksBuffer;
+  std::mutex m_mutexSeedTxnBlksBuffer;
 
   // Persistence Retriever
   std::shared_ptr<Retriever> m_retriever;


### PR DESCRIPTION
## Description
This PR address issue - https://github.com/Zilliqa/Issues/issues/449

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test :  Scenario where in buffered txnblocks are rejected since stale.
- [x] small-scale cloud test :  Scenario where in buffered txnblocks are accepted ( Test image with -DSJ_TEST_SJ_TXNBLKS_PROCESS_SLOW , commit: dae6bf4 image: dae6bf4-sj1 ).
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
