### PR TITLE
[release-4.1] Set vacuous epoch during recovery

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1850,10 +1850,6 @@ bool Node::ToBlockMessage([[gnu::unused]] unsigned char ins_byte) {
           return true;
         }
       }
-    } else if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP &&
-               ins_byte == NodeInstructionType::FINALBLOCK)  // Is seed node
-    {
-      return false;
     } else  // Is lookup node
     {
       return true;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -138,6 +138,14 @@ bool Node::Install(const SyncType syncType, const bool toRetrieveHistory) {
     m_mediator.m_currentEpochNum =
         m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1;
 
+    if ((m_mediator.m_currentEpochNum + NUM_VACUOUS_EPOCHS) %
+            NUM_FINAL_BLOCK_PER_POW ==
+        0) {
+      m_mediator.m_isVacuousEpoch = true;
+    } else {
+      m_mediator.m_isVacuousEpoch = false;
+    }
+
     if (wakeupForUpgrade || RECOVERY_TRIM_INCOMPLETED_BLOCK) {
       m_mediator.m_consensusID = m_mediator.m_currentEpochNum == 1 ? 1 : 0;
     }
@@ -1842,7 +1850,11 @@ bool Node::ToBlockMessage([[gnu::unused]] unsigned char ins_byte) {
           return true;
         }
       }
-    } else  // IS_LOOKUP_NODE
+    } else if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP &&
+               ins_byte == NodeInstructionType::FINALBLOCK)  // Is seed node
+    {
+      return false;
+    } else  // Is lookup node
     {
       return true;
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1850,7 +1850,7 @@ bool Node::ToBlockMessage([[gnu::unused]] unsigned char ins_byte) {
           return true;
         }
       }
-    } else  // Is lookup node
+    } else  // IS_LOOKUP_NODE
     {
       return true;
     }


### PR DESCRIPTION
## Description
During recovery, check and set `m_isVacuousEpoch`

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
