### PR TITLE
Add state check before entering WhenDone funcs for all consensus

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -712,6 +712,12 @@ bool DirectoryService::ProcessDSBlockConsensus(
 
   lock_guard<mutex> g(m_mutexConsensus);
 
+  if (!CheckState(PROCESS_DSBLOCKCONSENSUS)) {
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Not in PROCESS_DSBLOCKCONSENSUS state");
+    return false;
+  }
+
   if (!m_consensusObject->ProcessMessage(message, offset, from)) {
     return false;
   }

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -1230,7 +1230,9 @@ void DirectoryService::RunConsensusOnDSBlock(bool isRejoin) {
     RejoinAsDS();
   }
 
-  SetState(DSBLOCK_CONSENSUS_PREP);
+  if (m_state != DSBLOCK_CONSENSUS_PREP) {
+    SetState(DSBLOCK_CONSENSUS_PREP);
+  }
 
   {
     lock_guard<mutex> h(m_mutexCoinbaseRewardees);

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -592,6 +592,10 @@ void DirectoryService::StartNewDSEpochConsensus(bool fromFallback,
 
   LOG_MARKER();
 
+  if (m_state != POW_SUBMISSION) {
+    SetState(POW_SUBMISSION);
+  }
+
   m_mediator.m_consensusID = 0;
   m_mediator.m_node->SetConsensusLeaderID(0);
 
@@ -601,7 +605,6 @@ void DirectoryService::StartNewDSEpochConsensus(bool fromFallback,
 
   m_mediator.m_node->CleanMicroblockConsensusBuffer();
 
-  SetState(POW_SUBMISSION);
   cv_POWSubmission.notify_all();
 
   POW::GetInstance().EthashConfigureClient(

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1152,7 +1152,9 @@ void DirectoryService::RunConsensusOnFinalBlock() {
       RejoinAsDS();
     }
 
-    SetState(FINALBLOCK_CONSENSUS_PREP);
+    if (m_state != FINALBLOCK_CONSENSUS_PREP) {
+      SetState(FINALBLOCK_CONSENSUS_PREP);
+    }
 
     m_mediator.m_node->PrepareGoodStateForFinalBlock();
 

--- a/src/libNode/FallbackPostProcessing.cpp
+++ b/src/libNode/FallbackPostProcessing.cpp
@@ -198,6 +198,8 @@ void Node::ProcessFallbackConsensusWhenDone() {
                                                   {'0'});
     }
 
+    SetState(POW_SUBMISSION);
+
     // Detach a thread, Pending for POW Submission and RunDSBlockConsensus
     auto func = [this]() -> void {
       m_mediator.m_ds->StartNewDSEpochConsensus(true);
@@ -305,6 +307,12 @@ bool Node::ProcessFallbackConsensus(const bytes& message, unsigned int offset,
   }
 
   lock_guard<mutex> g(m_mutexConsensus);
+
+  if (!CheckState(PROCESS_FALLBACKCONSENSUS)) {
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Not in PROCESS_FALLBACKCONSENSUS state");
+    return false;
+  }
 
   if (!m_consensusObject->ProcessMessage(message, offset, from)) {
     return false;

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -228,6 +228,12 @@ bool Node::ProcessMicroBlockConsensusCore(const bytes& message,
 
   lock_guard<mutex> g(m_mutexConsensus);
 
+  if (!CheckState(PROCESS_MICROBLOCKCONSENSUS)) {
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Not in MICROBLOCK_CONSENSUS state");
+    return false;
+  }
+
   if (!m_consensusObject->ProcessMessage(message, offset, from)) {
     return false;
   }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Fix race condition that may allow consensus message in the same round entering `WhenDone` function twice 

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
~- [ ] local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
