### PR TITLE
Fix AccountStore Lock in MacOS

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -178,9 +178,9 @@ void AccountStore::MoveRootToDisk(const h256& root) {
 bool AccountStore::MoveUpdatesToDisk() {
   LOG_MARKER();
 
-  lock(m_mutexPrimary, m_mutexDB);
-  unique_lock<shared_timed_mutex> g(m_mutexPrimary, adopt_lock);
-  lock_guard<mutex> g2(m_mutexDB, adopt_lock);
+  unique_lock<shared_timed_mutex> g(m_mutexPrimary, defer_lock);
+  unique_lock<mutex> g2(m_mutexDB, defer_lock);
+  lock(g, g2);
 
   unordered_map<string, string> code_batch;
 
@@ -238,9 +238,9 @@ bool AccountStore::MoveUpdatesToDisk() {
 void AccountStore::DiscardUnsavedUpdates() {
   LOG_MARKER();
 
-  lock(m_mutexPrimary, m_mutexDB);
-  unique_lock<shared_timed_mutex> g(m_mutexPrimary, adopt_lock);
-  lock_guard<mutex> g2(m_mutexDB, adopt_lock);
+  unique_lock<shared_timed_mutex> g(m_mutexPrimary, defer_lock);
+  unique_lock<mutex> g2(m_mutexDB, defer_lock);
+  lock(g, g2);
 
   try {
     m_state.db()->rollback();
@@ -257,9 +257,9 @@ bool AccountStore::RetrieveFromDisk() {
 
   InitSoft();
 
-  lock(m_mutexPrimary, m_mutexDB);
-  unique_lock<shared_timed_mutex> g(m_mutexPrimary, adopt_lock);
-  lock_guard<mutex> g2(m_mutexDB, adopt_lock);
+  unique_lock<shared_timed_mutex> g(m_mutexPrimary, defer_lock);
+  unique_lock<mutex> g2(m_mutexDB, defer_lock);
+  lock(g, g2);
 
   bytes rootBytes;
   if (!BlockStorage::GetBlockStorage().GetMetadata(STATEROOT, rootBytes)) {

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -113,9 +113,9 @@ bool AccountStore::Deserialize(const bytes& src, unsigned int offset) {
 bool AccountStore::SerializeDelta() {
   LOG_MARKER();
 
-  lock(m_mutexDelta, m_mutexPrimary);
-  lock_guard<mutex> g(m_mutexDelta, adopt_lock);
-  shared_lock<shared_timed_mutex> g2(m_mutexPrimary, adopt_lock);
+  unique_lock<mutex> g(m_mutexDelta, defer_lock);
+  shared_lock<shared_timed_mutex> g2(m_mutexPrimary, defer_lock);
+  lock(g, g2);
 
   m_stateDeltaSerialized.clear();
 
@@ -142,9 +142,9 @@ bool AccountStore::DeserializeDelta(const bytes& src, unsigned int offset,
   LOG_MARKER();
 
   if (revertible) {
-    lock(m_mutexPrimary, m_mutexRevertibles);
-    unique_lock<shared_timed_mutex> g(m_mutexPrimary, adopt_lock);
-    lock_guard<mutex> g2(m_mutexRevertibles, adopt_lock);
+    unique_lock<shared_timed_mutex> g(m_mutexPrimary, defer_lock);
+    unique_lock<mutex> g2(m_mutexRevertibles, defer_lock);
+    lock(g, g2);
 
     if (!Messenger::GetAccountStoreDelta(src, offset, *this, revertible,
                                          false)) {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
in MacOS, the handling the previous way of declaring scoped lock is different from Linux, such resulted in stucking at mix usage of `lock_guard` and `shared_lock` or `unique_lock` in scoped lock.
The revised version passed the Test_AccountStore in both linux and macos system.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
