### PR TITLE
[PoW] fix invalid signature for REMOTE_MINE

### DIFF
--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -378,8 +378,7 @@ bool POW::SendWorkToProxy(const PairOfKey& pairOfKey, uint64_t blockNum,
           timeWindow);
   jsonValue[4] = "0x" + strPoWTime;
   auto powTimeBytes =
-      DataConversion::IntegerToBytes<uint32_t, sizeof(uint32_t)>(
-          POW_WINDOW_IN_SECONDS);
+      DataConversion::IntegerToBytes<uint32_t, sizeof(uint32_t)>(timeWindow);
   tmp.insert(tmp.end(), powTimeBytes.begin(), powTimeBytes.end());
 
   if (tmp.size() != (PUB_KEY_SIZE + BLOCK_HASH_SIZE + sizeof(uint64_t) +


### PR DESCRIPTION
## Description
when network upgrade to v4.2.0, the proxy rejects all pow requests from node because of "invalid signature".

The root cause is node send request with "timeWindow" but sign with "POW_WINDOW_IN_SECONDS".
https://github.com/Zilliqa/Zilliqa/blob/3e3339f0944218f1e6fe182ec730c7aeb5b192c5/src/libPOW/pow.cpp#L375-L384

A hotfix added in proxy code already, verify signature with fixed POW_WINDOW_IN_SECONDS.
https://github.com/DurianStallSingapore/Zilliqa-Mining-Proxy/commit/3d6534a950325e6488671ac684ac2cbe489b031a

## Review Suggestion

## Status

### Implementation
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
