### PR TITLE
Re-serialize consensus msg when buffering

### DIFF
--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -191,40 +191,49 @@ PairOfNode ConsensusCommon::GetCommitteeMember(const unsigned int index) {
 
 ConsensusCommon::State ConsensusCommon::GetState() const { return m_state; }
 
-bool ConsensusCommon::GetConsensusID(const bytes& message,
-                                     const unsigned int offset,
-                                     uint32_t& consensusID,
-                                     PubKey& senderPubKey) const {
+bool ConsensusCommon::PreProcessMessage(const bytes& message,
+                                        const unsigned int offset,
+                                        uint32_t& consensusID,
+                                        PubKey& senderPubKey,
+                                        bytes& reserializedMessage) const {
   if (message.size() > offset) {
     switch (message.at(offset)) {
       case ConsensusMessageType::ANNOUNCE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusAnnouncement>(
-            message, offset + 1, consensusID, senderPubKey);
+        return Messenger::PreProcessMessage<
+            ZilliqaMessage::ConsensusAnnouncement>(message, offset + 1,
+                                                   consensusID, senderPubKey,
+                                                   reserializedMessage);
       case ConsensusMessageType::CONSENSUSFAILURE:
-        return Messenger::GetConsensusID<
+        return Messenger::PreProcessMessage<
             ZilliqaMessage::ConsensusConsensusFailure>(
-            message, offset + 1, consensusID, senderPubKey);
+            message, offset + 1, consensusID, senderPubKey,
+            reserializedMessage);
       case ConsensusMessageType::COMMIT:
       case ConsensusMessageType::FINALCOMMIT:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusCommit>(
-            message, offset + 1, consensusID, senderPubKey);
+        return Messenger::PreProcessMessage<ZilliqaMessage::ConsensusCommit>(
+            message, offset + 1, consensusID, senderPubKey,
+            reserializedMessage);
       case ConsensusMessageType::COMMITFAILURE:
-        return Messenger::GetConsensusID<
+        return Messenger::PreProcessMessage<
             ZilliqaMessage::ConsensusCommitFailure>(message, offset + 1,
-                                                    consensusID, senderPubKey);
+                                                    consensusID, senderPubKey,
+                                                    reserializedMessage);
       case ConsensusMessageType::CHALLENGE:
       case ConsensusMessageType::FINALCHALLENGE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusChallenge>(
-            message, offset + 1, consensusID, senderPubKey);
+        return Messenger::PreProcessMessage<ZilliqaMessage::ConsensusChallenge>(
+            message, offset + 1, consensusID, senderPubKey,
+            reserializedMessage);
       case ConsensusMessageType::RESPONSE:
       case ConsensusMessageType::FINALRESPONSE:
-        return Messenger::GetConsensusID<ZilliqaMessage::ConsensusResponse>(
-            message, offset + 1, consensusID, senderPubKey);
+        return Messenger::PreProcessMessage<ZilliqaMessage::ConsensusResponse>(
+            message, offset + 1, consensusID, senderPubKey,
+            reserializedMessage);
       case ConsensusMessageType::COLLECTIVESIG:
       case ConsensusMessageType::FINALCOLLECTIVESIG:
-        return Messenger::GetConsensusID<
+        return Messenger::PreProcessMessage<
             ZilliqaMessage::ConsensusCollectiveSig>(message, offset + 1,
-                                                    consensusID, senderPubKey);
+                                                    consensusID, senderPubKey,
+                                                    reserializedMessage);
       default:
         LOG_GENERAL(WARNING,
                     "Unknown msg type " << (unsigned int)message.at(offset));

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -214,9 +214,10 @@ class ConsensusCommon {
   /// Returns the state of the active consensus session
   State GetState() const;
 
-  /// Returns the consensus ID indicated in the message
-  bool GetConsensusID(const bytes& message, const unsigned int offset,
-                      uint32_t& consensusID, PubKey& senderPubKey) const;
+  /// Returns some general data about the consensus message
+  bool PreProcessMessage(const bytes& message, const unsigned int offset,
+                         uint32_t& consensusID, PubKey& senderPubKey,
+                         bytes& reserializedMessage) const;
 
   /// Returns the consensus error code
   ConsensusErrorCode GetConsensusErrorCode() const;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -312,8 +312,7 @@ class DirectoryService : public Executable {
   void UpdateMyDSModeAndConsensusId();
   void UpdateDSCommiteeComposition();
 
-  void ProcessDSBlockConsensusWhenDone(const bytes& message,
-                                       unsigned int offset);
+  void ProcessDSBlockConsensusWhenDone();
 
   // internal calls from ProcessFinalBlockConsensus
   bool ComposeFinalBlockMessageForSender(bytes& finalblock_message);

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -295,11 +295,13 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
   }
 
   uint32_t consensus_id = 0;
+  bytes reserialized_message;
   PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, consensus_id,
-                                         senderPubKey)) {
-    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
+  if (!m_consensusObject->PreProcessMessage(
+          message, offset, consensus_id, senderPubKey, reserialized_message)) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+              "PreProcessMessage failed");
     return false;
   }
 
@@ -327,8 +329,8 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
       return false;
     }
 
-    AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
-                                   senderPubKey);
+    AddToFinalBlockConsensusBuffer(consensus_id, reserialized_message, offset,
+                                   from, senderPubKey);
 
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "Process final block arrived early, saved to buffer");
@@ -355,10 +357,10 @@ bool DirectoryService::ProcessFinalBlockConsensus(const bytes& message,
                 "Buffer final block with larger consensus ID ("
                     << consensus_id << "), current ("
                     << m_mediator.m_consensusID << ")");
-      AddToFinalBlockConsensusBuffer(consensus_id, message, offset, from,
-                                     senderPubKey);
+      AddToFinalBlockConsensusBuffer(consensus_id, reserialized_message, offset,
+                                     from, senderPubKey);
     } else {
-      return ProcessFinalBlockConsensusCore(message, offset, from);
+      return ProcessFinalBlockConsensusCore(reserialized_message, offset, from);
     }
   }
 

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -678,8 +678,9 @@ class Messenger {
   // ============================================================================
 
   template <class T>
-  static bool GetConsensusID(const bytes& src, const unsigned int offset,
-                             uint32_t& consensusID, PubKey& senderPubKey) {
+  static bool PreProcessMessage(const bytes& src, const unsigned int offset,
+                                uint32_t& consensusID, PubKey& senderPubKey,
+                                bytes& reserializedSrc) {
     T consensus_message;
 
     consensus_message.ParseFromArray(src.data() + offset, src.size() - offset);
@@ -710,6 +711,13 @@ class Messenger {
     }
 
     consensusID = consensus_message.consensusinfo().consensusid();
+
+    // Copy src into reserializedSrc, trimming away any excess bytes beyond the
+    // definition of protobuf message T
+    reserializedSrc.resize(offset + consensus_message.ByteSize());
+    copy(src.begin(), src.begin() + offset, reserializedSrc.begin());
+    consensus_message.SerializeToArray(reserializedSrc.data() + offset,
+                                       consensus_message.ByteSize());
 
     return true;
   }

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -91,11 +91,13 @@ bool Node::ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
   }
 
   uint32_t consensus_id = 0;
+  bytes reserialized_message;
   PubKey senderPubKey;
 
-  if (!m_consensusObject->GetConsensusID(message, offset, consensus_id,
-                                         senderPubKey)) {
-    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum, "GetConsensusID failed.");
+  if (!m_consensusObject->PreProcessMessage(
+          message, offset, consensus_id, senderPubKey, reserialized_message)) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+              "PreProcessMessage failed");
     return false;
   }
 
@@ -105,8 +107,8 @@ bool Node::ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
   }
 
   if (m_state != MICROBLOCK_CONSENSUS) {
-    AddToMicroBlockConsensusBuffer(consensus_id, message, offset, from,
-                                   senderPubKey);
+    AddToMicroBlockConsensusBuffer(consensus_id, reserialized_message, offset,
+                                   from, senderPubKey);
 
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "Process micro block arrived early, saved to buffer");
@@ -122,10 +124,10 @@ bool Node::ProcessMicroBlockConsensus(const bytes& message, unsigned int offset,
                     << consensus_id << "), current ("
                     << m_mediator.m_consensusID << ")");
 
-      AddToMicroBlockConsensusBuffer(consensus_id, message, offset, from,
-                                     senderPubKey);
+      AddToMicroBlockConsensusBuffer(consensus_id, reserialized_message, offset,
+                                     from, senderPubKey);
     } else {
-      return ProcessMicroBlockConsensusCore(message, offset, from);
+      return ProcessMicroBlockConsensusCore(reserialized_message, offset, from);
     }
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
1. Removed unused parameters for `ProcessDSBlockConsensusWhenDone`
2. Renamed `GetConsensusID` to `PreProcessMessage` in both `ConsensusCommon` and `Messenger`
3. Added extra parameter `bytes& reserializedMessage`, which will return the re-serialized consensus message.
4. Use this `reserializedMessage` in place of the original `message` when buffering the consensus message in microblock and finalblock consensus.

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
