### PR TITLE
Add lookup list that does not change with online/offline status

### DIFF
--- a/src/libDirectoryService/Coinbase.cpp
+++ b/src/libDirectoryService/Coinbase.cpp
@@ -98,71 +98,6 @@ bool DirectoryService::SaveCoinbaseCore(const vector<bool>& b1,
   return true;
 }
 
-void DirectoryService::LookupCoinbase(
-    [[gnu::unused]] const DequeOfShard& shards,
-    [[gnu::unused]] const MapOfPubKeyPoW& allPow,
-    [[gnu::unused]] const map<PubKey, Peer>& powDSWinner,
-    [[gnu::unused]] const MapOfPubKeyPoW& dsPow) {
-  LOG_MARKER();
-  VectorOfNode vecLookup = m_mediator.m_lookup->GetLookupNodes();
-  const auto& epochNum = m_mediator.m_currentEpochNum;
-
-  lock_guard<mutex> g(m_mutexCoinbaseRewardees);
-
-  for (const auto& lookupNode : vecLookup) {
-    LOG_GENERAL(INFO, " " << lookupNode.first);
-    m_coinbaseRewardees[epochNum][CoinbaseReward::LOOKUP_REWARD].push_back(
-        lookupNode.first);
-  }
-
-  /*for (const auto& shard : shards) {
-    for (const auto& shardNode : shard) {
-      auto toFind = get<SHARD_NODE_PUBKEY>(shardNode);
-      auto it = allPow.find(toFind);
-      if (it == allPow.end()) {
-        LOG_GENERAL(INFO, "Could not find the node, maybe it is the oldest DS "
-  << toFind); continue;
-      }
-      const auto& lookupId = it->second.lookupId;
-      // Verify
-
-      if (lookupId >= vecLookup.size()) {
-        LOG_GENERAL(WARNING, "Lookup id greater than lookup Size " << lookupId);
-        continue;
-      }
-      else
-      {
-        if(DEBUG_LEVEL >= 5)
-        {
-          LOG_GENERAL(INFO,"[LCNBSE]"<<"Awarded lookup "<<lookupId);
-        }
-      }
-
-      const auto& lookupPubkey = vecLookup.at(lookupId).first;
-      m_coinbaseRewardees[epochNum][CoinbaseReward::LOOKUP_REWARD].push_back(
-          Account::GetAddressFromPublicKey(lookupPubkey));
-    }
-  }
-
-  for (const auto& dsWinner : powDSWinner) {
-    auto toFind = dsWinner.first;
-    auto it = dsPow.find(toFind);
-
-    if (it == dsPow.end()) {
-      LOG_GENERAL(FATAL, "Could not find " << toFind);
-    }
-    const auto& lookupId = it->second.lookupId;
-    if (lookupId >= vecLookup.size()) {
-      LOG_GENERAL(WARNING, "Lookup id greater than lookup Size " << lookupId);
-      continue;
-    }
-
-    const auto& lookupPubkey = vecLookup.at(lookupId).first;
-    m_coinbaseRewardees[epochNum][CoinbaseReward::LOOKUP_REWARD].push_back(
-        Account::GetAddressFromPublicKey(lookupPubkey));
-  }*/
-}
-
 bool DirectoryService::SaveCoinbase(const vector<bool>& b1,
                                     const vector<bool>& b2,
                                     const int32_t& shard_id,
@@ -206,7 +141,7 @@ void DirectoryService::InitCoinbase() {
 
   LOG_MARKER();
 
-  const auto& vecLookup = m_mediator.m_lookup->GetLookupNodes();
+  const auto& vecLookup = m_mediator.m_lookup->GetLookupNodesStatic();
   const auto& epochNum = m_mediator.m_currentEpochNum;
 
   lock_guard<mutex> g(m_mutexCoinbaseRewardees);

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -287,10 +287,6 @@ class DirectoryService : public Executable {
   boost::multiprecision::uint128_t GetIncreasedGasPrice();
   bool VerifyGasPrice(const boost::multiprecision::uint128_t& gasPrice);
 
-  void LookupCoinbase(const DequeOfShard& shards, const MapOfPubKeyPoW& allPow,
-                      const std::map<PubKey, Peer>& powDSWinner,
-                      const MapOfPubKeyPoW& dsPow);
-
   bool VerifyPoWWinner(const MapOfPubKeyPoW& dsWinnerPoWsFromLeader);
   bool VerifyDifficulty();
   bool VerifyPoWOrdering(const DequeOfShard& shards,

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -144,6 +144,7 @@ void Lookup::InitSync() {
 void Lookup::SetLookupNodes(const VectorOfNode& lookupNodes) {
   // Only used for random testing
   m_lookupNodes = lookupNodes;
+  m_lookupNodesStatic = lookupNodes;
 }
 
 void Lookup::SetLookupNodes() {
@@ -214,6 +215,8 @@ void Lookup::SetLookupNodes() {
                                  m_mediator.m_selfPeer);
     }
   }
+
+  m_lookupNodesStatic = m_lookupNodes;
 }
 
 void Lookup::SetAboveLayer() {
@@ -406,8 +409,14 @@ VectorOfNode Lookup::GetLookupNodes() const {
   return m_lookupNodes;
 }
 
+VectorOfNode Lookup::GetLookupNodesStatic() const {
+  LOG_MARKER();
+  lock_guard<mutex> lock(m_mutexLookupNodes);
+  return m_lookupNodesStatic;
+}
+
 bool Lookup::IsLookupNode(const PubKey& pubKey) const {
-  VectorOfNode lookups = GetLookupNodes();
+  VectorOfNode lookups = GetLookupNodesStatic();
   return std::find_if(lookups.begin(), lookups.end(),
                       [&pubKey](const PairOfNode& node) {
                         return node.first == pubKey;
@@ -415,7 +424,7 @@ bool Lookup::IsLookupNode(const PubKey& pubKey) const {
 }
 
 bool Lookup::IsLookupNode(const Peer& peerInfo) const {
-  VectorOfNode lookups = GetLookupNodes();
+  VectorOfNode lookups = GetLookupNodesStatic();
   return std::find_if(lookups.begin(), lookups.end(),
                       [&peerInfo](const PairOfNode& node) {
                         return node.second.GetIpAddress() ==
@@ -1278,7 +1287,7 @@ bool Lookup::ProcessSetShardFromSeed([[gnu::unused]] const bytes& message,
     return false;
   }
 
-  if (!VerifySenderNode(GetLookupNodes(), lookupPubKey)) {
+  if (!VerifySenderNode(GetLookupNodesStatic(), lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "The message sender pubkey: "
                   << lookupPubKey << " is not in my lookup node list.");
@@ -2405,7 +2414,7 @@ bool Lookup::ProcessSetOfflineLookups(const bytes& message, unsigned int offset,
     return false;
   }
 
-  if (!VerifySenderNode(GetLookupNodes(), lookupPubKey)) {
+  if (!VerifySenderNode(GetLookupNodesStatic(), lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "The message sender pubkey: "
                   << lookupPubKey << " is not in my lookup node list.");
@@ -3047,7 +3056,7 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
     return false;
   }
 
-  if (!Lookup::VerifySenderNode(GetLookupNodes(), lookupPubKey)) {
+  if (!Lookup::VerifySenderNode(GetLookupNodesStatic(), lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "The message sender pubkey: "
                   << lookupPubKey << " is not in my lookup node list.");

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -62,6 +62,11 @@ class Lookup : public Executable {
   bool m_dsInfoWaitingNotifying = false;
   bool m_fetchedDSInfo = false;
 
+  // m_lookupNodes can change during operation if some lookups go offline.
+  // m_lookupNodesStatic is the fixed copy of m_lookupNodes after loading from
+  // constants.xml.
+  VectorOfNode m_lookupNodesStatic;
+
   // To ensure that the confirm of DS node rejoin won't be later than
   // It receiving a new DS block
   bool m_currDSExpired = false;
@@ -159,6 +164,9 @@ class Lookup : public Executable {
 
   // Getter for m_lookupNodes
   VectorOfNode GetLookupNodes() const;
+
+  // Getter for m_lookupNodesStatic
+  VectorOfNode GetLookupNodesStatic() const;
 
   // Getter for m_seedNodes
   VectorOfNode GetSeedNodes() const;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1161,7 +1161,7 @@ bool Node::ProcessTxnPacketFromLookup([[gnu::unused]] const bytes& message,
     return false;
   }
 
-  if (!Lookup::VerifySenderNode(m_mediator.m_lookup->GetLookupNodes(),
+  if (!Lookup::VerifySenderNode(m_mediator.m_lookup->GetLookupNodesStatic(),
                                 lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Sender pubkey " << lookupPubKey << " not in lookup list");


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
1. Removed unused function `DirectoryService::LookupCoinbase`
2. Added `m_lookupNodesStatic` which is same as `m_lookupNodes` but does not get updated whenever some lookups go offline
3. Modified `InitCoinbase` to use `m_lookupNodesStatic`. This prevents differing views between DS nodes when trying to reward lookups, as in some cases some DS nodes may consider lookups as offline and therefore not reward them (since `m_lookupNodes` would no longer contain those lookups).
4. Modified `IsLookupNode` and the calls to `VerifySenderNode` to use `m_lookupNodesStatic`. When a lookup recovers and goes back online, and then tries to send a message to a node, that node may reject the message since it still considers the lookup as offline.
5. Other cases where `m_lookupNodes` is used have been left unchanged (e.g., sending data to lookups).

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

This changes the way lookups are rewarded.
* Current way: Only online lookups from the original constants list
* New way: All lookups from the original constants list

This changes the way nodes receive messages from offline lookups.
* Current way: Will reject any message from lookup the node thinks is offline
* New way: Will accept message from any lookup in the original constants list

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
