### PR TITLE
Refactor and fix calculate shard leader

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3369,8 +3369,9 @@ void Lookup::SendTxnPacketToNodes(uint32_t numShards) {
         lock_guard<mutex> g(m_mediator.m_ds->m_mutexShards);
         uint16_t lastBlockHash = DataConversion::charArrTo16Bits(
             m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash().asBytes());
-        uint32_t leader_id = m_mediator.m_node->CalculateShardLeader(
-            lastBlockHash, m_mediator.m_ds->m_shards.at(i).size());
+        uint32_t leader_id = m_mediator.m_node->CalculateShardLeaderFromShard(
+            lastBlockHash, m_mediator.m_ds->m_shards.at(i).size(),
+            m_mediator.m_ds->m_shards.at(i));
         LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
                   "Shard leader id " << leader_id);
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -262,8 +262,8 @@ void Node::StartFirstTxEpoch() {
     m_consensusLeaderID =
         lastBlockHash % Guard::GetInstance().GetNumOfDSGuard();
   } else {
-    m_consensusLeaderID =
-        CalculateShardLeader(lastBlockHash, m_myShardMembers->size());
+    m_consensusLeaderID = CalculateShardLeaderFromDequeOfNode(
+        lastBlockHash, m_myShardMembers->size(), *m_myShardMembers);
   }
 
   // Check if I am the leader or backup of the shard

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -334,8 +334,8 @@ void Node::UpdateStateForNextConsensusRound() {
       m_consensusLeaderID =
           lastBlockHash % Guard::GetInstance().GetNumOfDSGuard();
     } else {
-      m_consensusLeaderID =
-          CalculateShardLeader(lastBlockHash, m_myShardMembers->size());
+      m_consensusLeaderID = CalculateShardLeaderFromDequeOfNode(
+          lastBlockHash, m_myShardMembers->size(), *m_myShardMembers);
     }
   }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -995,7 +995,8 @@ uint32_t Node::CalculateShardLeaderFromShard(uint16_t lastBlockHash,
 
     unsigned int iterationCount = 0;
     while (!Guard::GetInstance().IsNodeInShardGuardList(
-               std::get<0>(shardMembers.at(consensusLeaderIndex))) &&
+               std::get<SHARD_NODE_PUBKEY>(
+                   shardMembers.at(consensusLeaderIndex))) &&
            (iterationCount < SHARD_LEADER_SELECT_TOL)) {
       LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
                 "consensusLeaderIndex " << consensusLeaderIndex

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <functional>
 #include <thread>
+#include <tuple>
 
 #include <boost/filesystem.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -958,15 +959,43 @@ void Node::StartSynchronization() {
   DetachedFunction(1, func);
 }
 
-uint32_t Node::CalculateShardLeader(uint16_t lastBlockHash,
-                                    uint32_t sizeOfShard) {
+uint32_t Node::CalculateShardLeaderFromDequeOfNode(
+    uint16_t lastBlockHash, uint32_t sizeOfShard,
+    const DequeOfNode& shardMembers) {
   LOG_MARKER();
   if (GUARD_MODE) {
     uint32_t consensusLeaderIndex = lastBlockHash % sizeOfShard;
 
     unsigned int iterationCount = 0;
     while (!Guard::GetInstance().IsNodeInShardGuardList(
-               m_myShardMembers->at(consensusLeaderIndex).first) &&
+               shardMembers.at(consensusLeaderIndex).first) &&
+           (iterationCount < SHARD_LEADER_SELECT_TOL)) {
+      LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+                "consensusLeaderIndex " << consensusLeaderIndex
+                                        << " is not a shard guard.");
+      SHA2<HASH_TYPE::HASH_VARIANT_256> sha2;
+      sha2.Update(DataConversion::IntegerToBytes<uint16_t, sizeof(uint16_t)>(
+          lastBlockHash));
+      lastBlockHash = DataConversion::charArrTo16Bits(sha2.Finalize());
+      consensusLeaderIndex = lastBlockHash % sizeOfShard;
+      iterationCount++;
+    }
+    return consensusLeaderIndex;
+  } else {
+    return lastBlockHash % sizeOfShard;
+  }
+}
+
+uint32_t Node::CalculateShardLeaderFromShard(uint16_t lastBlockHash,
+                                             uint32_t sizeOfShard,
+                                             const Shard& shardMembers) {
+  LOG_MARKER();
+  if (GUARD_MODE) {
+    uint32_t consensusLeaderIndex = lastBlockHash % sizeOfShard;
+
+    unsigned int iterationCount = 0;
+    while (!Guard::GetInstance().IsNodeInShardGuardList(
+               std::get<0>(shardMembers.at(consensusLeaderIndex))) &&
            (iterationCount < SHARD_LEADER_SELECT_TOL)) {
       LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
                 "consensusLeaderIndex " << consensusLeaderIndex

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -563,7 +563,12 @@ class Node : public Executable {
   bool IsShardNode(const PubKey& pubKey);
   bool IsShardNode(const Peer& peerInfo);
 
-  uint32_t CalculateShardLeader(uint16_t lastBlockHash, uint32_t sizeOfShard);
+  uint32_t CalculateShardLeaderFromDequeOfNode(uint16_t lastBlockHash,
+                                               uint32_t sizeOfShard,
+                                               const DequeOfNode& shardMembers);
+  uint32_t CalculateShardLeaderFromShard(uint16_t lastBlockHash,
+                                         uint32_t sizeOfShard,
+                                         const Shard& shardMembers);
 
   static bool GetDSLeader(const BlockLink& lastBlockLink,
                           const DSBlock& latestDSBlock,


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Refactor `CalculateShardLeader` into `CalculateShardLeaderFromDequeOfNode` and `CalculateShardLeaderFromShard`
- `CalculateShardLeaderFromDequeOfNode` accepts `DequeOfNode` which is `vector<pair<PubKey, Peer>>`
- `CalculateShardLeaderFromShard` accepts `Shard` which is `vector<std::tuple<PubKey, Peer, uint16_t>>`
- Both function do not works on member variables directly.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] medium-scale cloud test
- [x] all vc cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
