### PR TITLE
Don't increase difficulty at 1 year epoch number

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -991,10 +991,9 @@ uint8_t DirectoryService::CalculateNewDifficulty(
                 << std::to_string(currentDifficulty) << ", expectedNodes "
                 << EXPECTED_SHARD_NODE_NUM << ", powSubmissions "
                 << powSubmissions);
-  return CalculateNewDifficultyCore(
-      currentDifficulty, POW_DIFFICULTY, powSubmissions,
-      EXPECTED_SHARD_NODE_NUM, POW_CHANGE_TO_ADJ_DIFF,
-      m_mediator.m_currentEpochNum, CalculateNumberOfBlocksPerYear());
+  return CalculateNewDifficultyCore(currentDifficulty, POW_DIFFICULTY,
+                                    powSubmissions, EXPECTED_SHARD_NODE_NUM,
+                                    POW_CHANGE_TO_ADJ_DIFF);
 }
 
 uint8_t DirectoryService::CalculateNewDSDifficulty(
@@ -1006,18 +1005,17 @@ uint8_t DirectoryService::CalculateNewDSDifficulty(
                             << ", NUM_DS_ELECTION " << NUM_DS_ELECTION
                             << ", dsPowSubmissions " << dsPowSubmissions);
 
-  return CalculateNewDifficultyCore(
-      dsDifficulty, DS_POW_DIFFICULTY, dsPowSubmissions, NUM_DS_ELECTION,
-      POW_CHANGE_TO_ADJ_DS_DIFF, m_mediator.m_currentEpochNum,
-      CalculateNumberOfBlocksPerYear());
+  return CalculateNewDifficultyCore(dsDifficulty, DS_POW_DIFFICULTY,
+                                    dsPowSubmissions, NUM_DS_ELECTION,
+                                    POW_CHANGE_TO_ADJ_DS_DIFF);
 }
 
-uint8_t DirectoryService::CalculateNewDifficultyCore(
-    uint8_t currentDifficulty, uint8_t minDifficulty, int64_t powSubmissions,
-    int64_t expectedNodes, uint32_t powChangeoAdj, int64_t currentEpochNum,
-    int64_t numBlockPerYear) {
+uint8_t DirectoryService::CalculateNewDifficultyCore(uint8_t currentDifficulty,
+                                                     uint8_t minDifficulty,
+                                                     int64_t powSubmissions,
+                                                     int64_t expectedNodes,
+                                                     uint32_t powChangeoAdj) {
   constexpr int8_t MAX_ADJUST_STEP = 2;
-  constexpr uint8_t MAX_INCREASE_DIFFICULTY_YEARS = 10;
 
   int64_t adjustment = 0;
   if (expectedNodes > 0 && expectedNodes != powSubmissions) {
@@ -1042,17 +1040,8 @@ uint8_t DirectoryService::CalculateNewDifficultyCore(
     adjustment = -MAX_ADJUST_STEP;
   }
 
-  uint8_t newDifficulty = std::max((uint8_t)(adjustment + currentDifficulty),
-                                   (uint8_t)(minDifficulty));
-
-  // Within 10 years, every year increase the difficulty by one.
-  if (currentEpochNum / numBlockPerYear <= MAX_INCREASE_DIFFICULTY_YEARS &&
-      currentEpochNum % numBlockPerYear == 0) {
-    LOG_GENERAL(INFO, "At one year epoch " << currentEpochNum
-                                           << ", increase difficulty by 1.");
-    ++newDifficulty;
-  }
-  return newDifficulty;
+  return std::max((uint8_t)(adjustment + currentDifficulty),
+                  (uint8_t)(minDifficulty));
 }
 
 uint64_t DirectoryService::CalculateNumberOfBlocksPerYear() const {

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -590,10 +590,11 @@ class DirectoryService : public Executable {
   void StartNewDSEpochConsensus(bool fromFallback = false,
                                 bool isRejoin = false);
 
-  static uint8_t CalculateNewDifficultyCore(
-      uint8_t currentDifficulty, uint8_t minDifficulty, int64_t powSubmissions,
-      int64_t expectedNodes, uint32_t powChangeoAdj, int64_t currentEpochNum,
-      int64_t numBlockPerYear);
+  static uint8_t CalculateNewDifficultyCore(uint8_t currentDifficulty,
+                                            uint8_t minDifficulty,
+                                            int64_t powSubmissions,
+                                            int64_t expectedNodes,
+                                            uint32_t powChangeoAdj);
 
   /// Calculate node priority to determine which node has the priority to join
   /// the network.

--- a/tests/POW/test_POW.cpp
+++ b/tests/POW/test_POW.cpp
@@ -565,38 +565,28 @@ BOOST_AUTO_TEST_CASE(difficulty_adjustment_small_network) {
   int64_t powSubmissions = 25;
   int64_t expectedNodes = 20;
   uint32_t adjustThreshold = 5;
-  int64_t currentEpochNum = 200;
-  int64_t numBlocksPerYear = 10000;
 
   int newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 4);
 
-  currentEpochNum = 10000;
-  newDifficulty = DirectoryService::CalculateNewDifficultyCore(
-      currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
-  BOOST_REQUIRE(newDifficulty == 5);
-
   currentDifficulty = 6;
-  currentEpochNum = 10001;
   powSubmissions =
       15;  // Node number is droping and number of pow submissions is less than
            // expected node, so expect difficulty will drop.
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 5);
 
   currentDifficulty = 14;
-  currentEpochNum = 100000;
   expectedNodes = 200;
   powSubmissions = 201;
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
-  BOOST_REQUIRE(newDifficulty == 15);
+      adjustThreshold);
+  BOOST_REQUIRE(newDifficulty == 14);
 }
 
 BOOST_AUTO_TEST_CASE(difficulty_adjustment_large_network) {
@@ -605,53 +595,47 @@ BOOST_AUTO_TEST_CASE(difficulty_adjustment_large_network) {
   int64_t powSubmissions = 5100;
   int64_t expectedNodes = 5000;
   uint32_t adjustThreshold = 99;
-  int64_t currentEpochNum = 200;
-  int64_t numBlocksPerYear = 1971000;
 
   int newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 4);
 
   currentDifficulty = 4;
-  currentEpochNum = 1971001;
   expectedNodes = 10001;  // The current nodes exceed expected node
   powSubmissions =
       10002;  // Pow submission still increase, need to increase difficulty
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 4);
 
   currentDifficulty = 10;
-  currentEpochNum = 1971005;
   expectedNodes = 8000;
   powSubmissions =
       7900;  // Node number is droping and number of pow submissions is less
              // than expected node, so expect difficulty will drop.
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 9);
 
   currentDifficulty = 5;
-  currentEpochNum = 1971009;
   expectedNodes = 8000;
   powSubmissions = 8000;
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty ==
                 5);  // nothing changes, expect keep the same difficulty
 
   currentDifficulty = 14;
   expectedNodes = 10002;
   powSubmissions = 10005;
-  currentEpochNum = 19710000;
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
-  BOOST_REQUIRE(newDifficulty == 15);
+      adjustThreshold);
+  BOOST_REQUIRE(newDifficulty == 14);
 }
 
 BOOST_AUTO_TEST_CASE(difficulty_adjustment_for_ds_small) {
@@ -660,12 +644,10 @@ BOOST_AUTO_TEST_CASE(difficulty_adjustment_for_ds_small) {
   int64_t powSubmissions = 11;
   int64_t expectedNodes = 10;
   uint32_t adjustThreshold = 5;
-  int64_t currentEpochNum = 80;
-  int64_t numBlocksPerYear = 1971000;
 
   int newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 9);
 }
 
@@ -675,40 +657,35 @@ BOOST_AUTO_TEST_CASE(difficulty_adjustment_for_ds_large) {
   int64_t powSubmissions = 110;
   int64_t expectedNodes = 100;
   uint32_t adjustThreshold = 9;
-  int64_t currentEpochNum = 200;
-  int64_t numBlocksPerYear = 1971000;
 
   int newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 6);
 
   currentDifficulty = 6;
-  currentEpochNum = 1971000;
   powSubmissions = 120;
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
-  BOOST_REQUIRE(newDifficulty == 9);
+      adjustThreshold);
+  BOOST_REQUIRE(newDifficulty == 8);
 
   currentDifficulty = 8;
-  currentEpochNum = 1971001;
   expectedNodes = 103;  // Current node number exceed expected number.
   powSubmissions =
       99;  // The PoW submissions drop not much, so keep difficulty.
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
+      adjustThreshold);
   BOOST_REQUIRE(newDifficulty == 8);
 
   currentDifficulty = 14;
   expectedNodes = 102;
   powSubmissions = 102;
-  currentEpochNum = 19710000;
   newDifficulty = DirectoryService::CalculateNewDifficultyCore(
       currentDifficulty, minDifficulty, powSubmissions, expectedNodes,
-      adjustThreshold, currentEpochNum, numBlocksPerYear);
-  BOOST_REQUIRE(newDifficulty == 15);
+      adjustThreshold);
+  BOOST_REQUIRE(newDifficulty == 14);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Don't increase difficulty at 1 year epoch number
<!-- What is the context of your pull request? -->
If at 1 year epoch we increase difficulty by 1, we may have the chance to increase the difficulty by 3, then we may face 0 pow submission issue. And the current method difficulty will increase naturally, no need other special algorithms.
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
