### PR TITLE
Force multicast to shard guards after upgrading

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -529,6 +529,8 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone() {
 
   m_mediator.UpdateDSBlockRand();
 
+  m_forceMulticast = false;
+
   // Now we can update the sharding structure and transaction sharing
   // assignments
   if (m_mode == BACKUP_DS) {
@@ -577,7 +579,7 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone() {
         *m_pendingDSBlock, *(m_mediator.m_DSCommittee), m_shards, {},
         m_mediator.m_lookup->GetLookupNodes(),
         m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(),
-        m_consensusMyID, composeDSBlockMessageForSender,
+        m_consensusMyID, composeDSBlockMessageForSender, false,
         sendDSBlockToLookupNodesAndNewDSMembers, sendDSBlockToShardNodes);
   }
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -452,6 +452,8 @@ bool DirectoryService::CleanVariables() {
   m_consensusLeaderID = 0;
   m_mediator.m_consensusID = 0;
 
+  m_forceMulticast = false;
+
   return true;
 }
 
@@ -714,6 +716,19 @@ void DirectoryService::StartNewDSEpochConsensus(bool fromFallback,
   {
     lock_guard<mutex> g(m_mutexPowSolution);
     m_powSolutions.clear();
+  }
+}
+
+void DirectoryService::ReloadGuardedShards(DequeOfShard& shards) {
+  for (const auto& shard : m_shards) {
+    Shard t_shard;
+    for (const auto& node : shard) {
+      if (Guard::GetInstance().IsNodeInShardGuardList(
+              std::get<SHARD_NODE_PUBKEY>(node))) {
+        t_shard.emplace_back(node);
+      }
+    }
+    shards.emplace_back(t_shard);
   }
 }
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -53,6 +53,7 @@ DirectoryService::DirectoryService(Mediator& mediator) : m_mediator(mediator) {
   m_consensusLeaderID = 0;
   m_mediator.m_consensusID = 1;
   m_viewChangeCounter = 0;
+  m_forceMulticast = false;
 }
 
 DirectoryService::~DirectoryService() {}

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -525,7 +525,7 @@ class DirectoryService : public Executable {
   bool m_doRejoinAtFinalConsensus = false;
 
   /// Force multicast when sending block to shard
-  bool m_forceMulticast = false;
+  std::atomic<bool> m_forceMulticast;
 
   /// Constructor. Requires mediator reference to access Node and other global
   /// members.

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -425,6 +425,8 @@ class DirectoryService : public Executable {
   uint8_t CalculateNewDSDifficulty(const uint8_t& dsDifficulty);
   uint64_t CalculateNumberOfBlocksPerYear() const;
 
+  void ReloadGuardedShards(DequeOfShard& shards);
+
  public:
   enum Mode : unsigned char { IDLE = 0x00, PRIMARY_DS, BACKUP_DS };
 
@@ -521,6 +523,9 @@ class DirectoryService : public Executable {
 
   bool m_doRejoinAtDSConsensus = false;
   bool m_doRejoinAtFinalConsensus = false;
+
+  /// Force multicast when sending block to shard
+  bool m_forceMulticast = false;
 
   /// Constructor. Requires mediator reference to access Node and other global
   /// members.

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -30,6 +30,7 @@
 #include "libMediator/Mediator.h"
 #include "libMessage/Messenger.h"
 #include "libNetwork/Blacklist.h"
+#include "libNetwork/Guard.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/DetachedFunction.h"
 #include "libUtils/Logger.h"
@@ -180,11 +181,17 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
     t_microBlocks.emplace(microBlock.GetHeader().GetShardId(), microBlock);
   }
 
+  DequeOfShard t_shards;
+  if (m_forceMulticast && GUARD_MODE) {
+    ReloadGuardedShards(t_shards);
+  }
+
   DataSender::GetInstance().SendDataToOthers(
-      *m_finalBlock, *m_mediator.m_DSCommittee, m_shards, t_microBlocks,
+      *m_finalBlock, *m_mediator.m_DSCommittee,
+      (m_forceMulticast && GUARD_MODE) ? t_shards : m_shards, t_microBlocks,
       m_mediator.m_lookup->GetLookupNodes(),
       m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(), m_consensusMyID,
-      composeFinalBlockMessageForSender);
+      composeFinalBlockMessageForSender, m_forceMulticast);
 
   LOG_STATE(
       "[FLBLK]["

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -188,10 +188,10 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
 
   DataSender::GetInstance().SendDataToOthers(
       *m_finalBlock, *m_mediator.m_DSCommittee,
-      (m_forceMulticast && GUARD_MODE) ? t_shards : m_shards, t_microBlocks,
+      t_shards.empty() ? m_shards : t_shards, t_microBlocks,
       m_mediator.m_lookup->GetLookupNodes(),
       m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(), m_consensusMyID,
-      composeFinalBlockMessageForSender, m_forceMulticast);
+      composeFinalBlockMessageForSender, m_forceMulticast.load());
 
   LOG_STATE(
       "[FLBLK]["

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -329,10 +329,10 @@ void DirectoryService::ProcessViewChangeConsensusWhenDone() {
 
     DataSender::GetInstance().SendDataToOthers(
         *m_pendingVCBlock, tmpDSCommittee,
-        (m_forceMulticast && GUARD_MODE) ? t_shards : m_shards, t_microBlocks,
+        t_shards.empty() ? m_shards : t_shards, t_microBlocks,
         m_mediator.m_lookup->GetLookupNodes(),
         m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(),
-        m_consensusMyID, composeVCBlockForSender, m_forceMulticast,
+        m_consensusMyID, composeVCBlockForSender, m_forceMulticast.load(),
         t_sendDataToLookupFunc);
   }
 }

--- a/src/libDirectoryService/ViewChangePostProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePostProcessing.cpp
@@ -322,11 +322,18 @@ void DirectoryService::ProcessViewChangeConsensusWhenDone() {
       t_microBlocks.emplace(microBlock.GetHeader().GetShardId(), microBlock);
     }
 
+    DequeOfShard t_shards;
+    if (m_forceMulticast && GUARD_MODE) {
+      ReloadGuardedShards(t_shards);
+    }
+
     DataSender::GetInstance().SendDataToOthers(
-        *m_pendingVCBlock, tmpDSCommittee, m_shards, t_microBlocks,
+        *m_pendingVCBlock, tmpDSCommittee,
+        (m_forceMulticast && GUARD_MODE) ? t_shards : m_shards, t_microBlocks,
         m_mediator.m_lookup->GetLookupNodes(),
         m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(),
-        m_consensusMyID, composeVCBlockForSender, t_sendDataToLookupFunc);
+        m_consensusMyID, composeVCBlockForSender, m_forceMulticast,
+        t_sendDataToLookupFunc);
   }
 }
 

--- a/src/libNetwork/DataSender.h
+++ b/src/libNetwork/DataSender.h
@@ -60,7 +60,7 @@ class DataSender : Singleton<DataSender> {
       const DequeOfShard& shards,
       const std::unordered_map<uint32_t, BlockBase>& blockswcosigRecver,
       const uint16_t& consensusMyId, const unsigned int& my_shards_lo,
-      const unsigned int& my_shards_hi,
+      const unsigned int& my_shards_hi, bool forceMulticast,
       std::deque<std::vector<Peer>>& sharded_receivers);
 
   bool SendDataToOthers(
@@ -69,6 +69,7 @@ class DataSender : Singleton<DataSender> {
       const std::unordered_map<uint32_t, BlockBase>& blockswcosigRecver,
       const VectorOfNode& lookups, const BlockHash& hashForRandom,
       const uint16_t& consensusMyId, const ComposeMessageForSenderFunc&,
+      bool forceMulticast = false,
       const SendDataToLookupFunc& sendDataToLookupFunc =
           SendDataToLookupFuncDefault,
       const SendDataToShardFunc& sendDataToShardFunc = nullptr);

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -441,7 +441,7 @@ void Node::CallActOnFinalblock() {
       *m_microblock, *m_myShardMembers, {}, {},
       m_mediator.m_lookup->GetLookupNodes(),
       m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(), m_consensusMyID,
-      composeMBnForwardTxnMessageForSender, SendDataToLookupFuncDefault,
+      composeMBnForwardTxnMessageForSender, false, SendDataToLookupFuncDefault,
       sendMbnFowardTxnToShardNodes);
 }
 

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -283,7 +283,7 @@ bool Node::ProcessMicroBlockConsensusCore(const bytes& message,
           *m_microblock, *m_myShardMembers, ds_shards, t_blocks,
           m_mediator.m_lookup->GetLookupNodes(),
           m_mediator.m_txBlockChain.GetLastBlock().GetBlockHash(),
-          m_consensusMyID, composeMicroBlockMessageForSender, nullptr);
+          m_consensusMyID, composeMicroBlockMessageForSender, false, nullptr);
     }
 
     LOG_STATE(

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -884,6 +884,8 @@ void Node::WakeupAtTxEpoch() {
   }
 
   if (BROADCAST_GOSSIP_MODE) {
+    m_mediator.m_ds->m_forceMulticast = true;
+
     VectorOfNode peers;
     std::vector<PubKey> pubKeys;
     GetEntireNetworkPeerInfo(peers, pubKeys);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -369,6 +369,8 @@ class Node : public Executable {
   // This process is newly invoked by shell from late node join script
   bool m_runFromLate = false;
 
+  bool m_forceMulticast = false;
+
   // std::condition_variable m_cvAllMicroBlocksRecvd;
   // std::mutex m_mutexAllMicroBlocksRecvd;
   // bool m_allMicroBlocksRecvd = true;

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -369,8 +369,6 @@ class Node : public Executable {
   // This process is newly invoked by shell from late node join script
   bool m_runFromLate = false;
 
-  bool m_forceMulticast = false;
-
   // std::condition_variable m_cvAllMicroBlocksRecvd;
   // std::mutex m_mutexAllMicroBlocksRecvd;
   // bool m_allMicroBlocksRecvd = true;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Once we call recovery, turn the flag `m_forceMulticast` to true so that before the next DS epoch consensus, the finalblock will be sent to shards via multicast. And if in guard mode, the receiver will be reloaded by the shard guards so that in the new PoW phase those nodes can keep in sync.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
