### PR TITLE
Remove verification of time stamp when node is processing vcblock

### DIFF
--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -43,7 +43,6 @@
 #include "libUtils/SanityChecks.h"
 #include "libUtils/TimeLockedFunction.h"
 #include "libUtils/TimeUtils.h"
-#include "libUtils/TimestampVerifier.h"
 
 using namespace std;
 using namespace boost::multiprecision;
@@ -191,13 +190,6 @@ bool Node::ProcessVCBlockCore(const VCBlock& vcblock) {
   if (BlockStorage::GetBlockStorage().GetVCBlock(temp_blockHash, VCBlockptr)) {
     LOG_GENERAL(WARNING,
                 "Duplicated vc block detected. 0x" << temp_blockHash.hex());
-    return false;
-  }
-
-  // Check timestamp
-  if (!VerifyTimestamp(vcblock.GetTimestamp(),
-                       CONSENSUS_OBJECT_TIMEOUT + VIEWCHANGE_TIME +
-                           VIEWCHANGE_PRECHECK_TIME + VIEWCHANGE_EXTRA_TIME)) {
     return false;
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR removes the timestamp check for VC block when shard node and lookups are processing it. 

VC block will concat with DS block if view change occurs at DS block consensus. However, due to the nature of view change, it may last longer than the timestamp check if multiple view change occurs. Current checks for VC block is sufficient without a timestamp check. 

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] vc cloud test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
