### PR TITLE
Increase protobuf limit for some Get messages

### DIFF
--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -23,6 +23,8 @@
 #include "libMessage/ZilliqaMessage.pb.h"
 #include "libUtils/Logger.h"
 
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <algorithm>
 #include <map>
 #include <random>
@@ -5281,9 +5283,14 @@ bool Messenger::GetLookupSetTxBlockFromSeed(
 
   LookupSetTxBlockFromSeed result;
 
-  result.ParseFromArray(src.data() + offset, src.size() - offset);
+  google::protobuf::io::ArrayInputStream arrayIn(src.data() + offset,
+                                                 src.size() - offset);
+  google::protobuf::io::CodedInputStream codedIn(&arrayIn);
+  codedIn.SetTotalBytesLimit(MAX_READ_WATERMARK_IN_BYTES,
+                             MAX_READ_WATERMARK_IN_BYTES);
 
-  if (!result.IsInitialized()) {
+  if (!result.ParseFromCodedStream(&codedIn) ||
+      !codedIn.ConsumedEntireMessage() || !result.IsInitialized()) {
     LOG_GENERAL(WARNING, "LookupSetTxBlockFromSeed initialization failed");
     return false;
   }
@@ -5509,9 +5516,14 @@ bool Messenger::GetLookupSetStateFromSeed(const bytes& src,
 
   LookupSetStateFromSeed result;
 
-  result.ParseFromArray(src.data() + offset, src.size() - offset);
+  google::protobuf::io::ArrayInputStream arrayIn(src.data() + offset,
+                                                 src.size() - offset);
+  google::protobuf::io::CodedInputStream codedIn(&arrayIn);
+  codedIn.SetTotalBytesLimit(MAX_READ_WATERMARK_IN_BYTES,
+                             MAX_READ_WATERMARK_IN_BYTES);
 
-  if (!result.IsInitialized()) {
+  if (!result.ParseFromCodedStream(&codedIn) ||
+      !codedIn.ConsumedEntireMessage() || !result.IsInitialized()) {
     LOG_GENERAL(WARNING, "LookupSetStateFromSeed initialization failed");
     return false;
   }
@@ -6503,9 +6515,14 @@ bool Messenger::GetLookupSetDirectoryBlocksFromSeed(
     uint64_t& indexNum, PubKey& pubKey) {
   LookupSetDirectoryBlocksFromSeed result;
 
-  result.ParseFromArray(src.data() + offset, src.size() - offset);
+  google::protobuf::io::ArrayInputStream arrayIn(src.data() + offset,
+                                                 src.size() - offset);
+  google::protobuf::io::CodedInputStream codedIn(&arrayIn);
+  codedIn.SetTotalBytesLimit(MAX_READ_WATERMARK_IN_BYTES,
+                             MAX_READ_WATERMARK_IN_BYTES);
 
-  if (!result.IsInitialized()) {
+  if (!result.ParseFromCodedStream(&codedIn) ||
+      !codedIn.ConsumedEntireMessage() || !result.IsInitialized()) {
     LOG_GENERAL(WARNING,
                 "LookupSetDirectoryBlocksFromSeed initialization failed");
     return false;

--- a/tests/Message/CMakeLists.txt
+++ b/tests/Message/CMakeLists.txt
@@ -1,6 +1,11 @@
 link_directories(${CMAKE_BINARY_DIR}/lib)
 configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 
+add_executable(Test_Messenger_Limits Test_Messenger_Limits.cpp)
+target_include_directories (Test_Messenger_Limits PUBLIC ${CMAKE_BINARY_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
+target_link_libraries(Test_Messenger_Limits PUBLIC AccountData Message Boost::unit_test_framework Utils TestUtils)
+add_test(NAME Test_Messenger_Limits COMMAND Test_Messenger_Limits)
+
 add_executable(Test_Messenger_Primitives Test_Messenger_Primitives.cpp)
 target_include_directories (Test_Messenger_Primitives PUBLIC ${CMAKE_BINARY_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
 target_link_libraries(Test_Messenger_Primitives PUBLIC AccountData Message Boost::unit_test_framework Utils TestUtils)

--- a/tests/Message/Test_Messenger_Limits.cpp
+++ b/tests/Message/Test_Messenger_Limits.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2019 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <limits>
+#include <random>
+#include "libMessage/Messenger.h"
+#include "libTestUtils/TestUtils.h"
+#include "libUtils/Logger.h"
+
+#define BOOST_TEST_MODULE message
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace boost::multiprecision;
+
+BOOST_AUTO_TEST_SUITE(messenger_limits_test)
+
+BOOST_AUTO_TEST_CASE(init) {
+  INIT_STDOUT_LOGGER();
+  TestUtils::Initialize();
+}
+
+BOOST_AUTO_TEST_CASE(test_GetLookupSetTxBlockFromSeed) {
+  bytes dst;
+  const unsigned int offset = 0;
+  const uint64_t lowBlockNum = TestUtils::DistUint64();
+  const uint64_t highBlockNum = TestUtils::DistUint64();
+  const PairOfKey lookupKey = TestUtils::GenerateRandomKeyPair();
+
+  // Create a dummy TxBlock
+  const TxBlock txBlock(TestUtils::GenerateRandomTxBlockHeader(),
+                        vector<MicroBlockInfo>{},
+                        TestUtils::GenerateRandomCoSignatures());
+
+  // Get the approximate size each TxBlock adds to a SETTXBLOCKFROMSEED message
+  vector<TxBlock> txBlocks;
+  txBlocks.emplace_back(txBlock);
+  BOOST_CHECK(Messenger::SetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNum, highBlockNum, lookupKey, txBlocks));
+  const unsigned int sizeWithOneBlock = dst.size();
+  dst.clear();
+  txBlocks.emplace_back(txBlock);
+  BOOST_CHECK(Messenger::SetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNum, highBlockNum, lookupKey, txBlocks));
+  const unsigned int sizeWithTwoBlocks = dst.size();
+  dst.clear();
+  const unsigned int sizePerBlock = sizeWithTwoBlocks - sizeWithOneBlock;
+
+  // Compute how much to reach the limit MAX_READ_WATERMARK_IN_BYTES
+  unsigned int numBlocksToReachLimit =
+      (MAX_READ_WATERMARK_IN_BYTES - sizeWithTwoBlocks) / sizePerBlock;
+  if (sizeWithTwoBlocks + (numBlocksToReachLimit * sizePerBlock) >=
+      MAX_READ_WATERMARK_IN_BYTES) {
+    numBlocksToReachLimit--;
+  }
+
+  // Add the blocks to the list
+  for (unsigned int i = 0; i < numBlocksToReachLimit; i++) {
+    txBlocks.emplace_back(txBlock);
+  }
+
+  // Test for just below the limit
+  BOOST_CHECK(Messenger::SetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNum, highBlockNum, lookupKey, txBlocks));
+  uint64_t lowBlockNumDeserialized = 0;
+  uint64_t highBlockNumDeserialized = 0;
+  PubKey lookupPubKeyDeserialized;
+  vector<TxBlock> txBlocksDeserialized;
+  BOOST_CHECK(Messenger::GetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNumDeserialized, highBlockNumDeserialized,
+      lookupPubKeyDeserialized, txBlocksDeserialized));
+  BOOST_CHECK(lowBlockNum == lowBlockNumDeserialized);
+  BOOST_CHECK(highBlockNum == highBlockNumDeserialized);
+  BOOST_CHECK(lookupKey.second == lookupPubKeyDeserialized);
+  BOOST_CHECK(txBlocks == txBlocksDeserialized);
+
+  // Test for above the limit. Let's add a few just to be sure.
+  for (unsigned int i = 0; i < 10; i++) {
+    txBlocks.emplace_back(txBlock);
+  }
+  dst.clear();
+  BOOST_CHECK(Messenger::SetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNum, highBlockNum, lookupKey, txBlocks));
+  BOOST_CHECK(!Messenger::GetLookupSetTxBlockFromSeed(
+      dst, offset, lowBlockNumDeserialized, highBlockNumDeserialized,
+      lookupPubKeyDeserialized, txBlocksDeserialized));
+}
+
+BOOST_AUTO_TEST_CASE(test_GetLookupSetDirectoryBlocksFromSeed) {
+  bytes dst;
+  const unsigned int offset = 0;
+  const uint32_t shardingStructureVersion = TestUtils::DistUint32();
+  const uint64_t indexNum = TestUtils::DistUint64();
+  const PairOfKey lookupKey = TestUtils::GenerateRandomKeyPair();
+
+  // Create a dummy DSBlock
+  DSBlock dsBlock(TestUtils::GenerateRandomDSBlockHeader(),
+                  TestUtils::GenerateRandomCoSignatures());
+
+  // Get the approximate size each DSBlock adds to a SETDIRBLOCKSFROMSEED
+  // message
+  vector<boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>
+      directoryBlocks;
+  directoryBlocks.emplace_back(dsBlock);
+  BOOST_CHECK(Messenger::SetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, shardingStructureVersion, directoryBlocks, indexNum,
+      lookupKey));
+  const unsigned int sizeWithOneBlock = dst.size();
+  dst.clear();
+  directoryBlocks.emplace_back(dsBlock);
+  BOOST_CHECK(Messenger::SetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, shardingStructureVersion, directoryBlocks, indexNum,
+      lookupKey));
+  const unsigned int sizeWithTwoBlocks = dst.size();
+  dst.clear();
+  const unsigned int sizePerBlock = sizeWithTwoBlocks - sizeWithOneBlock;
+
+  // Compute how much to reach the limit MAX_READ_WATERMARK_IN_BYTES
+  unsigned int numBlocksToReachLimit =
+      (MAX_READ_WATERMARK_IN_BYTES - sizeWithTwoBlocks) / sizePerBlock;
+  if (sizeWithTwoBlocks + (numBlocksToReachLimit * sizePerBlock) >=
+      MAX_READ_WATERMARK_IN_BYTES) {
+    numBlocksToReachLimit--;
+  }
+
+  // Add the blocks to the list
+  for (unsigned int i = 0; i < numBlocksToReachLimit; i++) {
+    directoryBlocks.emplace_back(dsBlock);
+  }
+
+  // Test for just below the limit
+  BOOST_CHECK(Messenger::SetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, shardingStructureVersion, directoryBlocks, indexNum,
+      lookupKey));
+  uint32_t dummyShardingStructureVersionDeserialized = 0;  // Unchecked
+  uint64_t indexNumDeserialized = 0;
+  PubKey lookupPubKeyDeserialized;
+  vector<boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>
+      directoryBlocksDeserialized;
+  BOOST_CHECK(Messenger::GetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, dummyShardingStructureVersionDeserialized,
+      directoryBlocksDeserialized, indexNumDeserialized,
+      lookupPubKeyDeserialized));
+  BOOST_CHECK(directoryBlocks.size() == directoryBlocksDeserialized.size());
+  for (unsigned int i = 0; i < directoryBlocks.size(); i++) {
+    BOOST_CHECK(get<DSBlock>(directoryBlocks.at(i)) ==
+                get<DSBlock>(directoryBlocksDeserialized.at(i)));
+  }
+  BOOST_CHECK(indexNum == indexNumDeserialized);
+  BOOST_CHECK(lookupKey.second == lookupPubKeyDeserialized);
+
+  // Test for above the limit. Let's add a few just to be sure.
+  for (unsigned int i = 0; i < 10; i++) {
+    directoryBlocks.emplace_back(dsBlock);
+  }
+  dst.clear();
+  BOOST_CHECK(Messenger::SetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, shardingStructureVersion, directoryBlocks, indexNum,
+      lookupKey));
+  BOOST_CHECK(!Messenger::GetLookupSetDirectoryBlocksFromSeed(
+      dst, offset, dummyShardingStructureVersionDeserialized,
+      directoryBlocksDeserialized, indexNumDeserialized,
+      lookupPubKeyDeserialized));
+}
+
+BOOST_AUTO_TEST_CASE(test_GetLookupSetStateFromSeed) {
+  bytes dst;
+  const unsigned int offset = 0;
+  const PairOfKey lookupKey = TestUtils::GenerateRandomKeyPair();
+  unsigned int addressCounter = 1;
+
+  AccountStore::GetInstance().Init();
+  // Get the approximate size each account adds to a SETSTATEFROMSEED message
+  AccountStore::GetInstance().AddAccount(Address(addressCounter++),
+                                         Account(0, 0));
+  AccountStore::GetInstance().UpdateStateTrieAll();
+  BOOST_CHECK(Messenger::SetLookupSetStateFromSeed(
+      dst, offset, lookupKey, AccountStore::GetInstance()));
+
+  const unsigned int sizeWithOneAccount = dst.size();
+  dst.clear();
+  AccountStore::GetInstance().AddAccount(Address(addressCounter++),
+                                         Account(0, 0));
+  AccountStore::GetInstance().UpdateStateTrieAll();
+  BOOST_CHECK(Messenger::SetLookupSetStateFromSeed(
+      dst, offset, lookupKey, AccountStore::GetInstance()));
+
+  const unsigned int sizeWithTwoAccounts = dst.size();
+  dst.clear();
+  const unsigned int sizePerAccount = sizeWithTwoAccounts - sizeWithOneAccount;
+
+  // Compute how much to reach the limit MAX_READ_WATERMARK_IN_BYTES
+  unsigned int numAccountsToReachLimit =
+      (MAX_READ_WATERMARK_IN_BYTES - sizeWithTwoAccounts) / sizePerAccount;
+  if (sizeWithTwoAccounts + (numAccountsToReachLimit * sizePerAccount) >=
+      MAX_READ_WATERMARK_IN_BYTES) {
+    numAccountsToReachLimit--;
+  }
+
+  // Add the accounts to the list
+  for (unsigned int i = 0; i < numAccountsToReachLimit; i++) {
+    AccountStore::GetInstance().AddAccount(Address(addressCounter++),
+                                           Account(0, 0));
+  }
+  AccountStore::GetInstance().UpdateStateTrieAll();
+
+  // Test for just below the limit
+  BOOST_CHECK(Messenger::SetLookupSetStateFromSeed(
+      dst, offset, lookupKey, AccountStore::GetInstance()));
+  PubKey lookupPubKeyDeserialized;
+  bytes dummyAccountStoreBytes;  // unchecked
+  BOOST_CHECK(Messenger::GetLookupSetStateFromSeed(
+      dst, offset, lookupPubKeyDeserialized, dummyAccountStoreBytes));
+  BOOST_CHECK(lookupKey.second == lookupPubKeyDeserialized);
+
+  // Test for above the limit. Let's add a few just to be sure.
+  for (unsigned int i = 0; i < 10; i++) {
+    AccountStore::GetInstance().AddAccount(Address(addressCounter++),
+                                           Account(0, 0));
+  }
+  AccountStore::GetInstance().UpdateStateTrieAll();
+  dst.clear();
+  BOOST_CHECK(Messenger::SetLookupSetStateFromSeed(
+      dst, offset, lookupKey, AccountStore::GetInstance()));
+  PubKey lookupPubKeyDeserialized2;
+  BOOST_CHECK(!Messenger::GetLookupSetStateFromSeed(
+      dst, offset, lookupPubKeyDeserialized2, dummyAccountStoreBytes));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
There is a default protobuf limit of 64MB.
This PR reconfigures the limit to `MAX_READ_WATERMARK_IN_BYTES` for these 3 messages:
1. `SETTXBLOCKFROMSEED`
2. `SETDIRBLOCKSFROMSEED`
3. `SETSTATEFROMSEED`

File `Test_Messenger_Limits.cpp` added to test each message below and above the limit.
Also tested in local testnet by adding new nodes to make sure each message still works.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
