### PR TITLE
Fix RejoinAsNormal after any failures 

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -173,8 +173,7 @@ bool Node::Install(const SyncType syncType, const bool toRetrieveHistory,
 
     if (SyncType::NEW_SYNC == syncType ||
         SyncType::NEW_LOOKUP_SYNC == syncType ||
-        (rejoiningAfterRecover && (SyncType::NORMAL_SYNC == syncType ||
-                                   SyncType::DS_SYNC == syncType))) {
+        (rejoiningAfterRecover && (SyncType::NORMAL_SYNC == syncType))) {
       return true;
     }
 
@@ -563,7 +562,8 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
   }
 
   if (SyncType::NEW_SYNC == syncType || SyncType::NEW_LOOKUP_SYNC == syncType ||
-      (rejoiningAfterRecover && (SyncType::NORMAL_SYNC == syncType))) {
+      (rejoiningAfterRecover &&
+       (SyncType::NORMAL_SYNC == syncType || SyncType::DS_SYNC == syncType))) {
     return true;
   }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -173,7 +173,8 @@ bool Node::Install(const SyncType syncType, const bool toRetrieveHistory,
 
     if (SyncType::NEW_SYNC == syncType ||
         SyncType::NEW_LOOKUP_SYNC == syncType ||
-        (rejoiningAfterRecover && (SyncType::NORMAL_SYNC == syncType))) {
+        (rejoiningAfterRecover && (SyncType::NORMAL_SYNC == syncType ||
+                                   SyncType::DS_SYNC == syncType))) {
       return true;
     }
 
@@ -1632,7 +1633,7 @@ void Node::AddBlock(const TxBlock& block) {
   m_mediator.m_txBlockChain.AddBlock(block);
 }
 
-void Node::RejoinAsNormal(bool rejoiningAfterRecover) {
+void Node::RejoinAsNormal() {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(
         WARNING,
@@ -1642,7 +1643,7 @@ void Node::RejoinAsNormal(bool rejoiningAfterRecover) {
 
   LOG_MARKER();
   if (m_mediator.m_lookup->GetSyncType() == SyncType::NO_SYNC) {
-    auto func = [this, rejoiningAfterRecover]() mutable -> void {
+    auto func = [this]() mutable -> void {
       while (true) {
         m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
         this->CleanVariables();
@@ -1655,7 +1656,7 @@ void Node::RejoinAsNormal(bool rejoiningAfterRecover) {
         }
         BlockStorage::GetBlockStorage().RefreshAll();
         AccountStore::GetInstance().RefreshDB();
-        if (this->Install(SyncType::NORMAL_SYNC, true, rejoiningAfterRecover)) {
+        if (this->Install(SyncType::NORMAL_SYNC, true, true)) {
           break;
         };
         this_thread::sleep_for(chrono::seconds(RETRY_REJOINING_TIMEOUT));

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -540,7 +540,7 @@ class Node : public Executable {
   bool LoadShardingStructure(bool callByRetrieve = false);
 
   // Rejoin the network as a shard node in case of failure happens in protocol
-  void RejoinAsNormal(bool rejoiningAfterRecover = false);
+  void RejoinAsNormal();
 
   /// Force state changes from MBCON/MBCON_PREP -> WAITING_FINALBLOCK
   void PrepareGoodStateForFinalBlock();

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -536,6 +536,7 @@ bool BlockStorage::GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks) {
 
   leveldb::Iterator* it =
       m_txBlockchainDB->GetDB()->NewIterator(leveldb::ReadOptions());
+  uint64_t count = 0;
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
     string bns = it->key().ToString();
     string blockString = it->value().ToString();
@@ -547,8 +548,9 @@ bool BlockStorage::GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks) {
     TxBlockSharedPtr block = TxBlockSharedPtr(
         new TxBlock(bytes(blockString.begin(), blockString.end()), 0));
     blocks.emplace_back(block);
-    LOG_GENERAL(INFO, "Retrievd TxBlock Num:" << bns);
+    count++;
   }
+  LOG_GENERAL(INFO, "Retrievd " << count << " TxBlocks");
 
   delete it;
 
@@ -853,10 +855,6 @@ bool BlockStorage::GetStateDelta(const uint64_t& finalBlockNum,
     LOG_GENERAL(INFO,
                 "Didn't find state delta of final block " << finalBlockNum);
   }
-
-  stateDelta = bytes(dataStr.begin(), dataStr.end());
-  LOG_PAYLOAD(INFO, "Retrieved state delta of final block " << finalBlockNum,
-              stateDelta, Logger::MAX_BYTES_TO_DISPLAY);
 
   return found;
 }

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -220,6 +220,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
           this_thread::sleep_for(chrono::seconds(RETRY_REJOINING_TIMEOUT));
         }
         BlockStorage::GetBlockStorage().RefreshAll();
+        AccountStore::GetInstance().RefreshDB();
       } else {
         m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
         bool isDsNode = false;
@@ -231,7 +232,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
           }
         }
         if (!isDsNode) {
-          m_n.RejoinAsNormal(true);
+          m_n.RejoinAsNormal();
         }
         break;
       }


### PR DESCRIPTION
## Description
Fix RejoinAsNormal to handle any failures

- Fix for Rejoining of node after recovery and that not in shard is extended to all other rejoining cases that can happen for `RejoinAsNormal`
- RejoinAsNormal -> Install -> StartRetrieveFromHistory -> will skip checking of node if in shard or not.
 

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
