### PR TITLE
Add responses stats for each subsets

### DIFF
--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -274,6 +274,25 @@ void ConsensusLeader::SubsetEnded(uint16_t subsetID) {
     // Reset all other subsets to INITIAL so they reject any further messages
     // from their backups
     for (unsigned int i = 0; i < m_consensusSubsets.size(); i++) {
+      // Log the responses stats if its ds consensus and DS_GUARD mode
+      if (m_DS && GUARD_MODE) {
+        ConsensusSubset& subset = m_consensusSubsets.at(i);
+        unsigned int dsguardCount = 0, nondsguardCount = 0;
+        for (unsigned int j = 0; j < subset.responseMap.size(); j++) {
+          if (subset.responseMap[j]) {
+            if (j < Guard::GetInstance().GetNumOfDSGuard()) {
+              dsguardCount++;
+            } else {
+              nondsguardCount++;
+            }
+          }
+        }
+        LOG_GENERAL(INFO,
+                    "[SubsetID: " << i << "] Responses received: Guards = "
+                                  << dsguardCount
+                                  << ", Non-guards = " << nondsguardCount);
+      }
+
       if (i == subsetID) {
         continue;
       }

--- a/src/libConsensus/ConsensusLeader.h
+++ b/src/libConsensus/ConsensusLeader.h
@@ -166,6 +166,9 @@ class ConsensusLeader : public ConsensusCommon {
   /// Function to check for missing responses
   void Audit();
 
+  /// Function to log the responses stats
+  void LogResponsesStats(unsigned int subsetID);
+
  private:
   static std::map<Action, std::string> ActionStrings;
   std::string GetActionString(Action action) const;


### PR DESCRIPTION
## Description
This PR adds logging for responses stats for all subsets indicating no. of responses received from dsguards and those from nondsguards.
Logging applies only for consensus when its at ds level and if DS_GUARD_MODE is enabled.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] Thisis not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
