### PR TITLE
Fix wrong usage of updating DSINCOMPLETED for lookup node

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -736,10 +736,22 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
         LOG_GENERAL(WARNING, "MoveUpdatesToDisk failed, what to do?");
         // return false;
       } else {
-        BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED,
-                                                    {'0'});
         BlockStorage::GetBlockStorage().PutLatestEpochStatesUpdated(
             m_mediator.m_currentEpochNum);
+        if (!LOOKUP_NODE_MODE) {
+          BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED,
+                                                      {'0'});
+        } else {
+          // change if all microblock received from shards
+          lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
+          if (m_unavailableMicroBlocks.find(
+                  m_mediator.m_txBlockChain.GetLastBlock()
+                      .GetHeader()
+                      .GetBlockNum()) == m_unavailableMicroBlocks.end()) {
+            BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED,
+                                                        {'0'});
+          }
+        }
         LOG_STATE("[FLBLK][" << setw(15) << left
                              << m_mediator.m_selfPeer.GetPrintableIPAddress()
                              << "]["
@@ -1027,8 +1039,17 @@ bool Node::ProcessMBnForwardTransactionCore(const MBnForwardedTxnEntry& entry) {
               m_mediator.m_txBlockChain.GetLastBlock()
                   .GetHeader()
                   .GetBlockNum()) {
-        BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED,
-                                                    {'0'});
+        // change if states was moved to disk
+        uint64_t epochNum;
+        if (!BlockStorage::GetBlockStorage().GetLatestEpochStatesUpdated(
+                epochNum)) {
+          LOG_GENERAL(WARNING, "GetLatestEpochStatesUpdated failed");
+          return false;
+        }
+        if (epochNum == m_mediator.m_currentEpochNum) {
+          BlockStorage::GetBlockStorage().PutMetadata(MetaType::DSINCOMPLETED,
+                                                      {'0'});
+        }
         BlockStorage::GetBlockStorage().ResetDB(BlockStorage::TX_BODY_TMP);
       }
     }

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -1035,7 +1035,7 @@ void BlockStorage::GetDiagnosticDataNodes(
 
     uint64_t dsBlockNum = 0;
     try {
-      dsBlockNum = stoul(dsBlockNumStr);
+      dsBlockNum = stoull(dsBlockNumStr);
     } catch (...) {
       LOG_GENERAL(WARNING,
                   "Non-numeric key " << dsBlockNumStr << " at index " << index);
@@ -1098,7 +1098,7 @@ void BlockStorage::GetDiagnosticDataCoinbase(
 
     uint64_t dsBlockNum = 0;
     try {
-      dsBlockNum = stoul(dsBlockNumStr);
+      dsBlockNum = stoull(dsBlockNumStr);
     } catch (...) {
       LOG_GENERAL(WARNING,
                   "Non-numeric key " << dsBlockNumStr << " at index " << index);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Let lookup only update MetaType::DSINCOMPLETED only when both of states storing and microblock receiving were done.  

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
~- [ ] local machine test~
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
