### PR TITLE
Fix stateroot failure

### DIFF
--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -90,8 +90,7 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
                           << lower_bound_txnblk << " - " << upper_bound_txnblk);
 
     // clear all the state deltas from disk.
-    // BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
-    // AccountStore::GetInstance().RefreshDB();
+    BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
 
     std::string target = "persistence/stateDelta";
     unsigned int firstStateDeltaIndex = lower_bound_txnblk;
@@ -113,10 +112,6 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
 
           // generate state now for NUM_FINAL_BLOCK_PER_POW statedeltas
           for (unsigned int j = firstStateDeltaIndex; j <= i; j++) {
-            if (!bfs::exists("StateDeltaFromS3/stateDelta_" +
-                             std::to_string(j))) {
-              continue;
-            }
             bytes stateDelta;
             LOG_GENERAL(
                 INFO,

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -90,8 +90,8 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
                           << lower_bound_txnblk << " - " << upper_bound_txnblk);
 
     // clear all the state deltas from disk.
-    BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
-    AccountStore::GetInstance().RefreshDB();
+    // BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
+    // AccountStore::GetInstance().RefreshDB();
 
     std::string target = "persistence/stateDelta";
     unsigned int firstStateDeltaIndex = lower_bound_txnblk;

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -91,6 +91,7 @@ bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
 
     // clear all the state deltas from disk.
     BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA);
+    AccountStore::GetInstance().RefreshDB();
 
     std::string target = "persistence/stateDelta";
     unsigned int firstStateDeltaIndex = lower_bound_txnblk;


### PR DESCRIPTION
## Description
Fix the state-root check failure that occurs until 10th DS epoch since the epoch `uploadIncrDB.py` script is executed.

Eg: The consolidated state-delta that is available in the first stateDelta_103.tar.gz (being uploaded by `uploadIncrDB.py` ) was skipped. i.e. stateDelta for 100 , 101 and 102 were being skipped. Fixed the same.
**Note:** The issue remediates as soon as 10th DS epoch is crossed. Because after which we don't have consolidated stateDeltas. 
consolidated stateDelta only exist after the start/restart of uploadScript until next 10th DS epoch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
