### PR TITLE
Fix corner case of safemath

### DIFF
--- a/src/libUtils/SafeMath.tpp
+++ b/src/libUtils/SafeMath.tpp
@@ -191,7 +191,7 @@ bool SafeMath<T>::add_unsignint(const T& a, const T& b, T& result) {
 
 template <class T>
 bool SafeMath<T>::sub_signint(const T& a, const T& b, T& result) {
-  if (a > 0 && b < a - std::numeric_limits<T>::max()) {
+  if (a >= 0 && b < a - std::numeric_limits<T>::max()) {
     LOG_GENERAL(WARNING, "Subtraction Overflow!");
     return false;
   }

--- a/tests/Utils/Test_SafeMath.cpp
+++ b/tests/Utils/Test_SafeMath.cpp
@@ -542,6 +542,23 @@ BOOST_AUTO_TEST_CASE(test_int8_t) {
   BOOST_CHECK_MESSAGE(false == SafeMath<int8_t>::mul(num1, num2, mulRes6),
                       "Test mul underflow failed!");
 
+  int8_t subRes;
+  BOOST_CHECK_MESSAGE(
+      false ==
+          SafeMath<int8_t>::sub(0, std::numeric_limits<int8_t>::min(), subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      false ==
+          SafeMath<int8_t>::sub(1, std::numeric_limits<int8_t>::min(), subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      true ==
+          SafeMath<int8_t>::sub(-1, std::numeric_limits<int8_t>::min(), subRes),
+      "Test signed sub failed!");
+  BOOST_REQUIRE(std::numeric_limits<int8_t>::max() == subRes);
+
   LOG_GENERAL(INFO, "Test int8_t done!");
 }
 
@@ -600,6 +617,23 @@ BOOST_AUTO_TEST_CASE(test_int16_t) {
   num2 = 2;
   BOOST_CHECK_MESSAGE(false == SafeMath<int16_t>::mul(num1, num2, mulRes6),
                       "Test mul underflow failed!");
+
+  int16_t subRes;
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int16_t>::sub(0, std::numeric_limits<int16_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int16_t>::sub(1, std::numeric_limits<int16_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<int16_t>::sub(-1, std::numeric_limits<int16_t>::min(),
+                                     subRes),
+      "Test signed sub failed!");
+  BOOST_REQUIRE(std::numeric_limits<int16_t>::max() == subRes);
 
   LOG_GENERAL(INFO, "Test int16_t done!");
 }
@@ -660,6 +694,23 @@ BOOST_AUTO_TEST_CASE(test_int32_t) {
   BOOST_CHECK_MESSAGE(false == SafeMath<int32_t>::mul(num1, num2, mulRes6),
                       "Test mul underflow failed!");
 
+  int32_t subRes;
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int32_t>::sub(0, std::numeric_limits<int32_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int32_t>::sub(1, std::numeric_limits<int32_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<int32_t>::sub(-1, std::numeric_limits<int32_t>::min(),
+                                     subRes),
+      "Test signed sub failed!");
+  BOOST_REQUIRE(std::numeric_limits<int32_t>::max() == subRes);
+
   LOG_GENERAL(INFO, "Test int32_t done!");
 }
 
@@ -718,6 +769,23 @@ BOOST_AUTO_TEST_CASE(test_int64_t) {
   num2 = 2;
   BOOST_CHECK_MESSAGE(false == SafeMath<int64_t>::mul(num1, num2, mulRes6),
                       "Test mul underflow failed!");
+
+  int64_t subRes;
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int64_t>::sub(0, std::numeric_limits<int64_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<int64_t>::sub(1, std::numeric_limits<int64_t>::min(),
+                                      subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<int64_t>::sub(-1, std::numeric_limits<int64_t>::min(),
+                                     subRes),
+      "Test signed sub failed!");
+  BOOST_REQUIRE(std::numeric_limits<int64_t>::max() == subRes);
 
   LOG_GENERAL(INFO, "Test int64_t done!");
 }
@@ -792,6 +860,23 @@ BOOST_AUTO_TEST_CASE(test_boost_int128_t) {
                                    num1, num2, mulRes6),
                       "Test mul underflow failed!");
 
+  boost::multiprecision::int128_t subRes;
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<boost::multiprecision::int128_t>::sub(
+                  0,
+                  std::numeric_limits<boost::multiprecision::int128_t>::min(),
+                  subRes),
+      "Test signed sub overflow failed!");
+  BOOST_REQUIRE(std::numeric_limits<boost::multiprecision::int128_t>::max() ==
+                subRes);
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<boost::multiprecision::int128_t>::sub(
+                   1,
+                   std::numeric_limits<boost::multiprecision::int128_t>::min(),
+                   subRes),
+      "Test signed sub overflow failed!");
+
   LOG_GENERAL(INFO, "Test boost_int128_t done!");
 }
 
@@ -864,6 +949,23 @@ BOOST_AUTO_TEST_CASE(test_boost_int256_t) {
   BOOST_CHECK_MESSAGE(false == SafeMath<boost::multiprecision::int256_t>::mul(
                                    num1, num2, mulRes6),
                       "Test mul underflow failed!");
+
+  boost::multiprecision::int256_t subRes;
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<boost::multiprecision::int256_t>::sub(
+                  0,
+                  std::numeric_limits<boost::multiprecision::int256_t>::min(),
+                  subRes),
+      "Test signed sub overflow failed!");
+  BOOST_REQUIRE(std::numeric_limits<boost::multiprecision::int256_t>::max() ==
+                subRes);
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<boost::multiprecision::int256_t>::sub(
+                   1,
+                   std::numeric_limits<boost::multiprecision::int256_t>::min(),
+                   subRes),
+      "Test signed sub overflow failed!");
 
   LOG_GENERAL(INFO, "Test boost_int256_t done!");
 }
@@ -938,6 +1040,23 @@ BOOST_AUTO_TEST_CASE(test_boost_int512_t) {
                                    num1, num2, mulRes6),
                       "Test mul underflow failed!");
 
+  boost::multiprecision::int512_t subRes;
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<boost::multiprecision::int512_t>::sub(
+                  0,
+                  std::numeric_limits<boost::multiprecision::int512_t>::min(),
+                  subRes),
+      "Test signed sub overflow failed!");
+  BOOST_REQUIRE(std::numeric_limits<boost::multiprecision::int512_t>::max() ==
+                subRes);
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<boost::multiprecision::int512_t>::sub(
+                   1,
+                   std::numeric_limits<boost::multiprecision::int512_t>::min(),
+                   subRes),
+      "Test signed sub overflow failed!");
+
   LOG_GENERAL(INFO, "Test boost_int512_t done!");
 }
 
@@ -1011,6 +1130,24 @@ BOOST_AUTO_TEST_CASE(test_boost_int1024_t) {
   BOOST_CHECK_MESSAGE(false == SafeMath<boost::multiprecision::int1024_t>::mul(
                                    num1, num2, mulRes6),
                       "Test mul underflow failed!");
+
+  boost::multiprecision::int1024_t subRes;
+  BOOST_CHECK_MESSAGE(
+      true == SafeMath<boost::multiprecision::int1024_t>::sub(
+                  0,
+                  std::numeric_limits<boost::multiprecision::int1024_t>::min(),
+                  subRes),
+      "Test signed sub overflow failed!");
+
+  BOOST_REQUIRE(std::numeric_limits<boost::multiprecision::int1024_t>::max() ==
+                subRes);
+
+  BOOST_CHECK_MESSAGE(
+      false == SafeMath<boost::multiprecision::int1024_t>::sub(
+                   1,
+                   std::numeric_limits<boost::multiprecision::int1024_t>::min(),
+                   subRes),
+      "Test signed sub overflow failed!");
 
   LOG_GENERAL(INFO, "Test boost_int1024_t done!");
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix corner case of safemath
<!-- What is the context of your pull request? -->
An signed integer substract, for example, type int8_t, when a = 0, b = -128, the substract is overflowed, but it is not handled. Now it has been fixed.
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
