### PR TITLE
Fix notification of CV and deprecate of FetchDSBlocks

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3415,8 +3415,7 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
 
   if (dsblocknumafter > dsblocknumbefore) {
-    if (m_syncType == SyncType::NO_SYNC &&
-        m_mediator.m_node->m_stillMiningPrimary) {
+    if (AlreadyJoinedNetwork()) {
       m_fetchedLatestDSBlock = true;
       cv_latestDSBlock.notify_all();
       return true;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3289,6 +3289,10 @@ bool Lookup::ProcessGetDirectoryBlocksFromSeed(const bytes& message,
     return false;
   }
 
+  lock_guard<mutex> g(m_mediator.m_node->m_mutexDSBlock);
+
+  LOG_GENERAL(INFO, "Index Num: " << index_num);
+
   bytes msg = {MessageType::LOOKUP,
                LookupInstructionType::SETDIRBLOCKSFROMSEED};
 
@@ -3302,6 +3306,11 @@ bool Lookup::ProcessGetDirectoryBlocksFromSeed(const bytes& message,
     if (get<BlockLinkIndex::BLOCKTYPE>(b) == BlockType::DS) {
       dirBlocks.emplace_back(
           m_mediator.m_dsBlockChain.GetBlock(get<BlockLinkIndex::DSINDEX>(b)));
+      LOG_GENERAL(INFO, "ds block num: "
+                            << m_mediator.m_dsBlockChain
+                                   .GetBlock(get<BlockLinkIndex::DSINDEX>(b))
+                                   .GetHeader()
+                                   .GetBlockNum());
     } else if (get<BlockLinkIndex::BLOCKTYPE>(b) == BlockType::VC) {
       VCBlockSharedPtr vcblockptr;
       if (!BlockStorage::GetBlockStorage().GetVCBlock(
@@ -3387,6 +3396,8 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
     LOG_GENERAL(INFO, "Already have dir blocks");
     return true;
   }
+
+  LOG_GENERAL(INFO, "Index Num: " << index_num);
 
   DequeOfNode newDScomm;
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3418,7 +3418,6 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
     if (AlreadyJoinedNetwork()) {
       m_fetchedLatestDSBlock = true;
       cv_latestDSBlock.notify_all();
-      return true;
     }
 
     if (m_syncType == SyncType::DS_SYNC ||

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -51,9 +51,8 @@ bool Node::GetLatestDSBlock() {
   unsigned int counter = 1;
   while (!m_mediator.m_lookup->m_fetchedLatestDSBlock &&
          counter <= FETCH_LOOKUP_MSG_MAX_RETRY) {
-    m_synchronizer.FetchLatestDSBlocksSeed(
-        m_mediator.m_lookup,
-        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1);
+    m_mediator.m_lookup->ComposeAndSendGetDirectoryBlocksFromSeed(
+        m_mediator.m_blocklinkchain.GetLatestIndex() + 1);
 
     {
       unique_lock<mutex> lock(


### PR DESCRIPTION
## Description
If the node is in SYNC state, it might get the ds block through setDirectoryBlocks, which should also trigger the CV 
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
