### PR TITLE
DS store and send DSMicroBlock at every epoch

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -385,7 +385,7 @@ class DirectoryService : public Executable {
                            bytes& messageToCosign);
   bool CheckUseVCBlockInsteadOfDSBlock(const BlockLink& bl,
                                        VCBlockSharedPtr& prevVCBlockptr);
-  void StoreFinalBlockToDisk();
+  bool StoreFinalBlockToDisk();
 
   bool OnNodeFinalConsensusError(const bytes& errorMsg, const Peer& from);
   bool OnNodeMissingMicroBlocks(const bytes& errorMsg,

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -49,7 +49,9 @@ bool DirectoryService::StoreFinalBlockToDisk() {
     return true;
   }
 
-  if (m_mediator.m_node->m_microblock != nullptr) {
+  if (m_mediator.m_node->m_microblock != nullptr &&
+      m_mediator.m_node->m_microblock->GetHeader().GetTxRootHash() !=
+          TxnHash()) {
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "Storing DS MicroBlock" << endl
                                       << *(m_mediator.m_node->m_microblock));
@@ -245,7 +247,9 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
       << "] AFTER SENDING FLBLK");
 
-  if (m_mediator.m_node->m_microblock != nullptr) {
+  if (m_mediator.m_node->m_microblock != nullptr &&
+      m_mediator.m_node->m_microblock->GetHeader().GetTxRootHash() !=
+          TxnHash()) {
     m_mediator.m_node->CallActOnFinalblock();
   }
 

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -49,6 +49,19 @@ bool DirectoryService::StoreFinalBlockToDisk() {
     return true;
   }
 
+  if (m_mediator.m_node->m_microblock != nullptr) {
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Storing DS MicroBlock" << endl
+                                      << *(m_mediator.m_node->m_microblock));
+    bytes body;
+    m_mediator.m_node->m_microblock->Serialize(body, 0);
+    if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+            m_mediator.m_node->m_microblock->GetBlockHash(), body)) {
+      LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
+      return false;
+    }
+  }
+
   // Add finalblock to txblockchain
   m_mediator.m_node->AddBlock(*m_finalBlock);
   m_mediator.IncreaseEpochNum();
@@ -79,18 +92,6 @@ bool DirectoryService::StoreFinalBlockToDisk() {
     return false;
   }
 
-  if (m_mediator.m_node->m_microblock != nullptr) {
-    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-              "Storing DS MicroBlock" << endl
-                                      << *(m_mediator.m_node->m_microblock));
-    bytes body;
-    m_mediator.m_node->m_microblock->Serialize(body, 0);
-    if (!BlockStorage::GetBlockStorage().PutMicroBlock(
-            m_mediator.m_node->m_microblock->GetBlockHash(), body)) {
-      LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
-      return false;
-    }
-  }
   return true;
 }
 

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -39,14 +39,14 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-void DirectoryService::StoreFinalBlockToDisk() {
+bool DirectoryService::StoreFinalBlockToDisk() {
   LOG_MARKER();
 
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::StoreFinalBlockToDisk not expected to "
                 "be called from LookUp node.");
-    return;
+    return true;
   }
 
   // Add finalblock to txblockchain
@@ -64,14 +64,34 @@ void DirectoryService::StoreFinalBlockToDisk() {
 
   bytes serializedTxBlock;
   m_finalBlock->Serialize(serializedTxBlock, 0);
-  BlockStorage::GetBlockStorage().PutTxBlock(
-      m_finalBlock->GetHeader().GetBlockNum(), serializedTxBlock);
+  if (!BlockStorage::GetBlockStorage().PutTxBlock(
+          m_finalBlock->GetHeader().GetBlockNum(), serializedTxBlock)) {
+    LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
+    return false;
+  }
 
   bytes stateDelta;
   AccountStore::GetInstance().GetSerializedDelta(stateDelta);
-  BlockStorage::GetBlockStorage().PutStateDelta(
-      m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
-      stateDelta);
+  if (!BlockStorage::GetBlockStorage().PutStateDelta(
+          m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum(),
+          stateDelta)) {
+    LOG_GENERAL(WARNING, "Failed to put statedelta in persistence");
+    return false;
+  }
+
+  if (m_mediator.m_node->m_microblock != nullptr) {
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Storing DS MicroBlock" << endl
+                                      << *(m_mediator.m_node->m_microblock));
+    bytes body;
+    m_mediator.m_node->m_microblock->Serialize(body, 0);
+    if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+            m_mediator.m_node->m_microblock->GetBlockHash(), body)) {
+      LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
+      return false;
+    }
+  }
+  return true;
 }
 
 bool DirectoryService::ComposeFinalBlockMessageForSender(
@@ -151,8 +171,12 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
 
   DetachedFunction(1, resumeBlackList);
 
+  if (!StoreFinalBlockToDisk()) {
+    LOG_GENERAL(WARNING, "StoreFinalBlockToDisk failed!");
+    return;
+  }
+
   if (isVacuousEpoch) {
-    StoreFinalBlockToDisk();
     auto writeStateToDisk = [this]() -> void {
       if (!AccountStore::GetInstance().MoveUpdatesToDisk(
               ENABLE_REPOPULATE && (m_mediator.m_dsBlockChain.GetLastBlock()
@@ -179,7 +203,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
     };
     DetachedFunction(1, writeStateToDisk);
   } else {
-    StoreFinalBlockToDisk();
     // Coinbase
     SaveCoinbase(m_finalBlock->GetB1(), m_finalBlock->GetB2(),
                  CoinbaseReward::FINALBLOCK_REWARD,
@@ -221,11 +244,8 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       << m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1
       << "] AFTER SENDING FLBLK");
 
-  if (m_mediator.m_node->m_microblock != nullptr && !isVacuousEpoch) {
-    if (m_mediator.m_node->m_microblock->GetHeader().GetTxRootHash() !=
-        TxnHash()) {
-      m_mediator.m_node->CallActOnFinalblock();
-    }
+  if (m_mediator.m_node->m_microblock != nullptr) {
+    m_mediator.m_node->CallActOnFinalblock();
   }
 
   AccountStore::GetInstance().InitTemp();

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -708,11 +708,12 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
 
   DetachedFunction(1, resumeBlackList);
 
+  if (!LoadUnavailableMicroBlockHashes(
+          txBlock, txBlock.GetHeader().GetBlockNum(), toSendTxnToLookup)) {
+    return false;
+  }
+
   if (!isVacuousEpoch) {
-    if (!LoadUnavailableMicroBlockHashes(
-            txBlock, txBlock.GetHeader().GetBlockNum(), toSendTxnToLookup)) {
-      return false;
-    }
     StoreFinalBlock(txBlock);
   } else {
     LOG_GENERAL(INFO, "isVacuousEpoch now");

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -123,8 +123,13 @@ bool Node::LoadUnavailableMicroBlockHashes(const TxBlock& finalBlock,
                             << info.m_microBlockHash << " [TxnRootHash] "
                             << info.m_txnRootHash << " shardID "
                             << info.m_shardId);
-      m_unavailableMicroBlocks[blocknum].push_back(
-          {info.m_microBlockHash, info.m_txnRootHash});
+      if (info.m_shardId == m_mediator.m_ds->m_shards.size() &&
+          info.m_txnRootHash == TxnHash()) {
+        // do nothing
+      } else {
+        m_unavailableMicroBlocks[blocknum].push_back(
+            {info.m_microBlockHash, info.m_txnRootHash});
+      }
     } else {
       if (info.m_shardId == m_myshardId) {
         if (m_microblock == nullptr) {

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1028,9 +1028,6 @@ bool Node::ProcessMBnForwardTransactionCore(const MBnForwardedTxnEntry& entry) {
 
     CommitForwardedTransactions(entry);
 
-    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-              "isEveryMicroBlockAvailable: " << isEveryMicroBlockAvailable);
-
     if (isEveryMicroBlockAvailable) {
       DeleteEntryFromFwdingAssgnAndMissingBodyCountMap(
           entry.m_microBlock.GetHeader().GetEpochNum());

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -123,10 +123,8 @@ bool Node::LoadUnavailableMicroBlockHashes(const TxBlock& finalBlock,
                             << info.m_microBlockHash << " [TxnRootHash] "
                             << info.m_txnRootHash << " shardID "
                             << info.m_shardId);
-      if (info.m_shardId == m_mediator.m_ds->m_shards.size() &&
-          info.m_txnRootHash == TxnHash()) {
-        // do nothing
-      } else {
+      if (!(info.m_shardId == m_mediator.m_ds->m_shards.size() &&
+            info.m_txnRootHash == TxnHash())) {
         m_unavailableMicroBlocks[blocknum].push_back(
             {info.m_microBlockHash, info.m_txnRootHash});
       }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Before this PR:
1. DS never store DSMB
2. DS only send DSMB to lookup when 1. non-vacuous 2. TxRootHash not null
3. Lookup load every microblocks involved in the TxBlock

After this PR:
1. DS store DSMB when TxnRootHash not null
2. DS send DSMB whenever TxRootHash not null
3. Lookup won't load DSMB if TxRootHash is null

@KaustubhShamshery can check if there is anything need to be changed on the historical mb verification, basically can skip ds mb if the TxnRootHash is empty
## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
