### PR TITLE
Limit TxBlocks on lookup

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -81,7 +81,7 @@ void DirectoryService::StartSynchronization(bool clean) {
     while (m_mediator.m_lookup->GetSyncType() != SyncType::NO_SYNC) {
       m_mediator.m_lookup->ComposeAndSendGetDirectoryBlocksFromSeed(
           m_mediator.m_blocklinkchain.GetLatestIndex() + 1);
-      m_synchronizer.FetchLatestTxBlocks(
+      m_synchronizer.FetchLatestTxBlockSeed(
           m_mediator.m_lookup,
           m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum() +
               1);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1115,13 +1115,13 @@ bool Lookup::ProcessGetTxBlockFromSeed(const bytes& message,
     return false;
   }
 
-  vector<TxBlock> txBlocks;
-  RetrieveTxBlocks(txBlocks, lowBlockNum, highBlockNum);
-
   LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
             "ProcessGetTxBlockFromSeed requested by " << from << " for blocks "
                                                       << lowBlockNum << " to "
                                                       << highBlockNum);
+
+  vector<TxBlock> txBlocks;
+  RetrieveTxBlocks(txBlocks, lowBlockNum, highBlockNum);
 
   bytes txBlockMessage = {MessageType::LOOKUP,
                           LookupInstructionType::SETTXBLOCKFROMSEED};
@@ -1135,7 +1135,8 @@ bool Lookup::ProcessGetTxBlockFromSeed(const bytes& message,
 
   Peer requestingNode(from.m_ipAddress, portNo);
   P2PComm::GetInstance().SendMessage(requestingNode, txBlockMessage);
-
+  LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+            "Sent Txblks " << lowBlockNum << " - " << highBlockNum);
   return true;
 }
 
@@ -1148,21 +1149,19 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   lock_guard<mutex> g(m_mediator.m_node->m_mutexFinalBlock);
 
   if (lowBlockNum == 0) {
-    // give all the blocks till now in blockchain
     lowBlockNum = 1;
-  } else {
-    uint64_t lowestLimitNum = (m_mediator.m_dsBlockChain.GetBlockCount() >
-                               INCRDB_DSNUMS_WITH_STATEDELTAS)
-                                  ? (m_mediator.m_dsBlockChain.GetLastBlock()
-                                         .GetHeader()
-                                         .GetBlockNum() -
-                                     INCRDB_DSNUMS_WITH_STATEDELTAS) *
-                                        NUM_FINAL_BLOCK_PER_POW
-                                  : 0;
-    if (lowBlockNum <= lowestLimitNum) {
-      // Limit the number of txn blocks upto last N ds epochs
-      lowBlockNum = lowestLimitNum;
-    }
+  }
+
+  uint64_t lowestLimitNum =
+      (m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() - 1) *
+      NUM_FINAL_BLOCK_PER_POW;
+  if (lowBlockNum < lowestLimitNum) {
+    LOG_GENERAL(WARNING,
+                "Requested number of txBlocks are beyond the current DS epoch "
+                "(lowBlockNum :"
+                    << lowBlockNum << ", lowestLimitNum : " << lowestLimitNum
+                    << ")");
+    lowBlockNum = lowestLimitNum;
   }
 
   if (highBlockNum == 0) {
@@ -1846,7 +1845,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
   if (lowBlockNum > highBlockNum) {
     LOG_GENERAL(
         WARNING,
-        "The lowBlockNum is higher the highblocknum, maybe DS epoch ongoing");
+        "The lowBlockNum is higher than highblocknum, maybe DS epoch ongoing");
     cv_setTxBlockFromSeed.notify_all();
     return false;
   }
@@ -3362,7 +3361,7 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
     return false;
   }
 
-  if (!Lookup::VerifySenderNode(GetLookupNodesStatic(), lookupPubKey)) {
+  if (!Lookup::VerifySenderNode(GetSeedNodes(), lookupPubKey)) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "The message sender pubkey: "
                   << lookupPubKey << " is not in my lookup node list.");

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1153,8 +1153,7 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   }
 
   uint64_t lowestLimitNum =
-      (m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() - 1) *
-      NUM_FINAL_BLOCK_PER_POW;
+      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() + 1;
   if (lowBlockNum < lowestLimitNum) {
     LOG_GENERAL(WARNING,
                 "Requested number of txBlocks are beyond the current DS epoch "

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1153,7 +1153,7 @@ void Lookup::RetrieveTxBlocks(vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
   }
 
   uint64_t lowestLimitNum =
-      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() + 1;
+      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum();
   if (lowBlockNum < lowestLimitNum) {
     LOG_GENERAL(WARNING,
                 "Requested number of txBlocks are beyond the current DS epoch "

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1904,7 +1904,7 @@ bool Lookup::GetDSInfo() {
   LOG_MARKER();
   m_dsInfoWaitingNotifying = true;
 
-  GetDSInfoFromLookupNodes();
+  GetDSInfoFromSeedNodes();
 
   {
     unique_lock<mutex> lock(m_mutexDSInfoUpdation);
@@ -2292,7 +2292,7 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
   } else if (LOOKUP_NODE_MODE && m_syncType == SyncType::NEW_LOOKUP_SYNC) {
     m_dsInfoWaitingNotifying = true;
 
-    GetDSInfoFromLookupNodes();
+    GetDSInfoFromSeedNodes();
 
     {
       unique_lock<mutex> lock(m_mutexDSInfoUpdation);

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -2541,12 +2541,6 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
                                      const unsigned int offset,
                                      AccountStore& accountStore,
                                      const bool revertible, bool temp) {
-  if (offset >= src.size()) {
-    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
-                             << src.size() << ", offset " << offset);
-    return false;
-  }
-
   ProtoAccountStore result;
   result.ParseFromArray(src.data() + offset, src.size() - offset);
 
@@ -2602,12 +2596,6 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
                                      const unsigned int offset,
                                      AccountStoreTemp& accountStoreTemp,
                                      bool temp) {
-  if (offset >= src.size()) {
-    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
-                             << src.size() << ", offset " << offset);
-    return false;
-  }
-
   ProtoAccountStore result;
   result.ParseFromArray(src.data() + offset, src.size() - offset);
 

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -169,8 +169,6 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
 
   if (ARCHIVAL_LOOKUP && !LOOKUP_NODE_MODE) {
     LOG_GENERAL(FATAL, "Archvial lookup is true but not lookup ");
-  } else if (ARCHIVAL_LOOKUP && LOOKUP_NODE_MODE) {
-    m_lookupServer->StartCollectorThread();
   }
 
   P2PComm::GetInstance().SetSelfPeer(peer);
@@ -332,6 +330,9 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
       } else {
         if (m_lookupServer->StartListening()) {
           LOG_GENERAL(INFO, "API Server started successfully");
+          if (ARCHIVAL_LOOKUP) {
+            m_lookupServer->StartCollectorThread();
+          }
         } else {
           LOG_GENERAL(WARNING, "API Server couldn't start");
         }

--- a/tests/Data/AccountData/Test_AccountStore.cpp
+++ b/tests/Data/AccountData/Test_AccountStore.cpp
@@ -391,9 +391,9 @@ BOOST_AUTO_TEST_CASE(serialization) {
   BOOST_CHECK_EQUAL(false, as.Deserialize(dst, 0));
   BOOST_CHECK_EQUAL(true, as.SerializeDelta());
   as.GetSerializedDelta(dst);
-  BOOST_CHECK_EQUAL(false, as.DeserializeDelta(dst, 0, true));
-  BOOST_CHECK_EQUAL(false, as.DeserializeDelta(dst, 0, false));
-  BOOST_CHECK_EQUAL(false, as.DeserializeDeltaTemp(dst, 0));
+  BOOST_CHECK_EQUAL(true, as.DeserializeDelta(dst, 0, true));
+  BOOST_CHECK_EQUAL(true, as.DeserializeDelta(dst, 0, false));
+  BOOST_CHECK_EQUAL(true, as.DeserializeDeltaTemp(dst, 0));
 
   // Increase coverage
   as.AddAccountDuringDeserialization(Address(), Account(), Account(), false,


### PR DESCRIPTION
## Description
This PR covers:
- limits number of txBlocks to be sent back by lookup.
- Also, fix verification of DirectoryBlock against upper seed list instead of lookup list.
- Multiple replacement to use `*FromSeed` instead of `*FromLookup`
- Fixes StateDelta issue introduced as side-effect of   PR#1617

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
