### PR TITLE
Handle peer connection counter correctly

### DIFF
--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -675,16 +675,6 @@ void P2PComm::AcceptConnectionCallback([[gnu::unused]] evconnlistener* listener,
             ((struct sockaddr_in*)cli_addr)->sin_port);
 
   LOG_GENERAL(DEBUG, "Incoming message from " << from);
-  {
-    std::unique_lock<std::mutex> lock(m_mutexPeerConnectionCount);
-    if (m_peerConnectionCount[from.GetIpAddress()] > MAX_PEER_CONNECTION) {
-      LOG_GENERAL(WARNING, "Connection ignored from " << from);
-      evutil_closesocket(cli_sock);
-      return;
-    }
-    m_peerConnectionCount[from.GetIpAddress()]++;
-  }
-
   if (Blacklist::GetInstance().Exist(from.m_ipAddress)) {
     LOG_GENERAL(INFO, "The node "
                           << from
@@ -694,6 +684,16 @@ void P2PComm::AcceptConnectionCallback([[gnu::unused]] evconnlistener* listener,
     evutil_closesocket(cli_sock);
 
     return;
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(m_mutexPeerConnectionCount);
+    if (m_peerConnectionCount[from.GetIpAddress()] > MAX_PEER_CONNECTION) {
+      LOG_GENERAL(WARNING, "Connection ignored from " << from);
+      evutil_closesocket(cli_sock);
+      return;
+    }
+    m_peerConnectionCount[from.GetIpAddress()]++;
   }
 
   // Set up buffer event for this new connection

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -477,12 +477,12 @@ void P2PComm::CloseAndFreeBufferEvent(struct bufferevent* bufev) {
   socklen_t addr_size = sizeof(struct sockaddr_in);
   getpeername(fd, (struct sockaddr*)&cli_addr, &addr_size);
   uint128_t ipAddr = cli_addr.sin_addr.s_addr;
-
-  std::unique_lock<std::mutex> lock(m_mutexPeerConnectionCount);
-  if (m_peerConnectionCount[ipAddr] > 0) {
-    m_peerConnectionCount[ipAddr]--;
+  {
+    std::unique_lock<std::mutex> lock(m_mutexPeerConnectionCount);
+    if (m_peerConnectionCount[ipAddr] > 0) {
+      m_peerConnectionCount[ipAddr]--;
+    }
   }
-
   bufferevent_free(bufev);
 }
 


### PR DESCRIPTION
## Description

- This PR covers https://github.com/Zilliqa/Issues/issues/512
- Fixed scope of mutex `m_mutexPeerConnectionCount`


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
