### PR TITLE
Fix epochfin for lookup when no shard formed

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -716,7 +716,11 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
       LOG_GENERAL(WARNING, "StoreFinalBlock failed!");
       return false;
     }
-    if (!LOOKUP_NODE_MODE) {
+    // if lookup and loaded microblocks, then skip
+    lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
+    if (!(LOOKUP_NODE_MODE &&
+          m_unavailableMicroBlocks.find(txBlock.GetHeader().GetBlockNum()) !=
+              m_unavailableMicroBlocks.end())) {
       if (!BlockStorage::GetBlockStorage().PutEpochFin(
               m_mediator.m_currentEpochNum)) {
         LOG_GENERAL(WARNING, "BlockStorage::PutEpochFin failed "


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Let the lookup put epochfin during non-vacuous epoch if no microblock is loaded from finalblock.
For fixing issue of PutEpochFin didn't get triggered when no shard is formed:
https://github.com/Zilliqa/Issues/issues/535
## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
