### PR TITLE
Fix log messages for address

### DIFF
--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -2420,7 +2420,7 @@ bool Messenger::GetAccountStore(const bytes& src, const unsigned int offset,
          address.asArray().begin());
     if (!ProtobufToAccount(entry.account(), account, address)) {
       LOG_GENERAL(WARNING, "ProtobufToAccount failed for account at address "
-                               << entry.address());
+                               << address);
       return false;
     }
 
@@ -2458,7 +2458,7 @@ bool Messenger::GetAccountStore(const bytes& src, const unsigned int offset,
          address.asArray().begin());
     if (!ProtobufToAccount(entry.account(), account, address)) {
       LOG_GENERAL(WARNING, "ProtobufToAccount failed for account at address "
-                               << entry.address());
+                               << address);
       return false;
     }
 
@@ -2579,9 +2579,9 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
     account = *oriAccount;
     if (!ProtobufToAccountDelta(entry.account(), account, address, fullCopy,
                                 temp, revertible)) {
-      LOG_GENERAL(WARNING,
-                  "ProtobufToAccountDelta failed for account at address "
-                      << entry.address());
+      LOG_GENERAL(
+          WARNING,
+          "ProtobufToAccountDelta failed for account at address " << address);
       return false;
     }
 
@@ -2636,9 +2636,9 @@ bool Messenger::GetAccountStoreDelta(const bytes& src,
 
     if (!ProtobufToAccountDelta(entry.account(), account, address, fullCopy,
                                 temp)) {
-      LOG_GENERAL(WARNING,
-                  "ProtobufToAccountDelta failed for account at address "
-                      << entry.address());
+      LOG_GENERAL(
+          WARNING,
+          "ProtobufToAccountDelta failed for account at address " << address);
       return false;
     }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Some error log messages use `entry.address()` which is of type `bytes` and is not readable.
We should instead just use `Address address`, which is also already used for earlier log messages in some of the relevant functions.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
