### PR TITLE
Automatically remove ipMapping.xml after using it

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -832,7 +832,7 @@ void Node::RemoveIpMapping() {
       LOG_GENERAL(INFO,
                   IP_MAPPING_FILE_NAME << " has been removed successfully.");
     } else {
-      LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " cannot been removed!");
+      LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " cannot be removed!");
     }
   } else {
     LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " not existed!");

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -718,6 +718,8 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         }
       }
     }
+
+    RemoveIpMapping();
   }
 
   bool bInShardStructure = false;
@@ -819,6 +821,21 @@ void Node::GetIpMapping(unordered_map<string, Peer>& ipMapping) {
       ipMapping[v.second.get<std::string>("pubkey")] =
           Peer((uint128_t)ip_addr.s_addr, v.second.get<uint32_t>("port"));
     }
+  }
+}
+
+void Node::RemoveIpMapping() {
+  LOG_MARKER();
+
+  if (boost::filesystem::exists(IP_MAPPING_FILE_NAME)) {
+    if (boost::filesystem::remove(IP_MAPPING_FILE_NAME)) {
+      LOG_GENERAL(INFO,
+                  IP_MAPPING_FILE_NAME << " has been removed successfully.");
+    } else {
+      LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " cannot been removed!");
+    }
+  } else {
+    LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " not existed!");
   }
 }
 

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -347,6 +347,8 @@ class Node : public Executable {
 
   void GetIpMapping(std::unordered_map<std::string, Peer>& ipMapping);
 
+  void RemoveIpMapping();
+
   void WakeupAtDSEpoch();
 
   void WakeupAtTxEpoch();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The `ipMapping.xml` will ONLY be used in recovery the entire network. So for more user-friendly, the zilliqa process should automatically remove this file after using it.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
