### PR TITLE
Use GetEpochFin in auto_back_up.py

### DIFF
--- a/scripts/auto_back_up.py
+++ b/scripts/auto_back_up.py
@@ -81,7 +81,7 @@ def GetCurrentTxBlockNum():
     val = loaded_json["result"]
     if (val != None and val != ''):
         blockNum = int(val) - 1 # -1 because we need TxBlockNum (not epochnum)
-    return blockNum
+    return blockNum + 1
 
 def backUp(curr_blockNum):
     with tarfile.open(TESTNET_NAME + ".tar.gz", "w:gz") as tar:

--- a/scripts/auto_back_up.py
+++ b/scripts/auto_back_up.py
@@ -28,6 +28,7 @@ TESTNET_NAME= "TEST_NET_NAME"
 BUCKET_NAME='BUCKET_NAME'
 AWS_PERSISTENCE_LOCATION= "s3://"+BUCKET_NAME+"/persistence/"+TESTNET_NAME
 
+
 def recvall(sock):
     BUFF_SIZE = 4096 # 4 KiB
     data = ""
@@ -73,13 +74,14 @@ def send_packet_tcp(data, host, port):
     return received
 
 def GetCurrentTxBlockNum():
-    loaded_json = get_response([], 'GetCurrentMiniEpoch', '127.0.0.1', 4301)
+    loaded_json = get_response([], 'GetEpochFin', '127.0.0.1', 4301)
+    blockNum = -1
+    if loaded_json == None:
+        return blockNum
     val = loaded_json["result"]
     if (val != None and val != ''):
         blockNum = int(val) - 1 # -1 because we need TxBlockNum (not epochnum)
-    else:
-        blockNum = -1
-    return blockNum + 1
+    return blockNum
 
 def backUp(curr_blockNum):
     with tarfile.open(TESTNET_NAME + ".tar.gz", "w:gz") as tar:


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In order to avoid the possible crash when calling `auto_back_up.py` without Zilliqa process running, change `GetCurrentMiniEpoch` to `GetEpochFin`.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
