### PR TITLE
Fix node rejoin but cannot get DS block issue

### DIFF
--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -183,8 +183,7 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
             // exciplitly declare in the same thread
             m_mediator.m_lookup->m_startedPoW = false;
           }
-          m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
-          StartSynchronization();
+          RejoinAsNormal();
         } else {
           LOG_GENERAL(WARNING, "DS block not recvd, what to do ?");
         }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
There is a potential racing issue when start sync after GetLatestDSBlock function. If the server reply slow, then BlockLink haven't increased, the StartSynchronization can get DS block from seed node. If server reply fast, the shard node BlockLink already increased, when request new DS block, it cannot get anything from seed node.
So for safe run, should use back the old method clean the pensistence and rejoin as normal.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/571

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
