### PR TITLE
Fix Blocklink index 

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2561,6 +2561,8 @@ bool Lookup::InitMining(uint32_t lookupIndex) {
   // before repopulating state in CommitTxBlocks. if (CheckStateRoot()) {
   // Attempt PoW
   m_startedPoW = true;
+  // set the node as synced
+  m_syncType = NO_SYNC;
   dsBlockRand = m_mediator.m_dsBlockRand;
   txBlockRand = m_mediator.m_txBlockRand;
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -626,9 +626,13 @@ bool Lookup::GetDSBlockFromLookupNodes(uint64_t lowBlockNum,
 }
 
 bool Lookup::GetDSBlockFromSeedNodes(uint64_t lowBlockNum,
-                                     uint64_t highblocknum) {
+                                     uint64_t highBlockNum) {
+  LOG_MARKER();
+  LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+            "ComposeGetDSBlockMessage for blocks " << lowBlockNum << " to "
+                                                   << highBlockNum);
   SendMessageToRandomSeedNode(
-      ComposeGetDSBlockMessage(lowBlockNum, highblocknum));
+      ComposeGetDSBlockMessage(lowBlockNum, highBlockNum));
   return true;
 }
 
@@ -2562,7 +2566,7 @@ bool Lookup::InitMining(uint32_t lookupIndex) {
   // Attempt PoW
   m_startedPoW = true;
   // set the node as synced
-  m_syncType = NO_SYNC;
+  SetSyncType(NO_SYNC);
   dsBlockRand = m_mediator.m_dsBlockRand;
   txBlockRand = m_mediator.m_txBlockRand;
 
@@ -3578,7 +3582,7 @@ void Lookup::ComposeAndSendGetDirectoryBlocksFromSeed(const uint64_t& index_num,
     LOG_GENERAL(WARNING, "Messenger::SetLookupGetDirectoryBlocksFromSeed");
     return;
   }
-
+  LOG_GENERAL(INFO, "blocklink index = " << index_num);
   if (!toSendSeed) {
     SendMessageToRandomLookupNode(message);
   } else {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3459,6 +3459,9 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
     return false;
   }
 
+  // make sure no VCDSBlock is processed at same time
+  lock_guard<mutex> g1(m_mediator.m_node->m_mutexDSBlock);
+
   // Not all calls to GetLookupSetDirectoryBlocksFromSeed set
   // shardingStructureVersion
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -54,13 +54,19 @@ using namespace boost::multiprecision;
 void Node::StoreDSBlockToDisk(const DSBlock& dsblock) {
   LOG_MARKER();
 
-  m_mediator.m_dsBlockChain.AddBlock(dsblock);
   LOG_GENERAL(INFO, "Block num = " << dsblock.GetHeader().GetBlockNum());
   LOG_GENERAL(
       INFO, "DS diff   = " << to_string(dsblock.GetHeader().GetDSDifficulty()));
   LOG_GENERAL(INFO,
               "Diff      = " << to_string(dsblock.GetHeader().GetDifficulty()));
   LOG_GENERAL(INFO, "Timestamp = " << dsblock.GetTimestamp());
+
+  if (-1 == m_mediator.m_dsBlockChain.AddBlock(dsblock)) {
+    LOG_GENERAL(
+        WARNING,
+        "This block is already added. Skipped re-adding to blocklink again");
+    return;
+  }
 
   // Update the rand1 value for next PoW
   m_mediator.UpdateDSBlockRand();

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1054,8 +1054,8 @@ void Node::StartSynchronization() {
                                                  : NEW_NODE_SYNC_INTERVAL));
       // check again may be pow was started by now
       if (m_mediator.m_lookup->m_startedPoW) {
-        // No need to keep on syncronizing now. If failed to do PoW, it will
-        // start syncronization again in next DS block
+        // No need to keep on synchronizing now. If failed to do PoW, it will
+        // start synchronization again in next DS block
         break;
       }
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1054,14 +1054,6 @@ void Node::StartSynchronization() {
       this_thread::sleep_for(chrono::seconds(m_mediator.m_lookup->m_startedPoW
                                                  ? POW_WINDOW_IN_SECONDS
                                                  : NEW_NODE_SYNC_INTERVAL));
-      // check again may be pow was started by now
-      if (m_mediator.m_lookup->m_startedPoW) {
-        // No need to keep on synchronizing now. If failed to do PoW, it will
-        // start synchronization again in next DS block
-        LOG_GENERAL(INFO,
-                    "PoW already started. Stopping syncronization thread");
-        break;
-      }
     }
   };
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1052,6 +1052,12 @@ void Node::StartSynchronization() {
       this_thread::sleep_for(chrono::seconds(m_mediator.m_lookup->m_startedPoW
                                                  ? POW_WINDOW_IN_SECONDS
                                                  : NEW_NODE_SYNC_INTERVAL));
+      // check again may be pow was started by now
+      if (m_mediator.m_lookup->m_startedPoW) {
+        // No need to keep on syncronizing now. If failed to do PoW, it will
+        // start syncronization again in next DS block
+        break;
+      }
     }
   };
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1056,6 +1056,7 @@ void Node::StartSynchronization() {
       if (m_mediator.m_lookup->m_startedPoW) {
         // No need to keep on synchronizing now. If failed to do PoW, it will
         // start synchronization again in next DS block
+        LOG_GENERAL(INFO, "PoW already started. Stopping syncronization thread");
         break;
       }
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1056,7 +1056,8 @@ void Node::StartSynchronization() {
       if (m_mediator.m_lookup->m_startedPoW) {
         // No need to keep on synchronizing now. If failed to do PoW, it will
         // start synchronization again in next DS block
-        LOG_GENERAL(INFO, "PoW already started. Stopping syncronization thread");
+        LOG_GENERAL(INFO,
+                    "PoW already started. Stopping syncronization thread");
         break;
       }
     }

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -48,6 +48,7 @@ using namespace std;
 using namespace boost::multiprecision;
 
 bool Node::GetLatestDSBlock() {
+  LOG_MARKER();
   unsigned int counter = 1;
   while (!m_mediator.m_lookup->m_fetchedLatestDSBlock &&
          counter <= FETCH_LOOKUP_MSG_MAX_RETRY) {

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -115,7 +115,7 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
   auto startTime = std::chrono::high_resolution_clock::now();
   int powTimeWindow = POW_WINDOW_IN_SECONDS;
 
-  // Only in guard mode that shard guard can submit diffferent PoW
+  // Only in guard mode that shard guard can submit different PoW
   if (GUARD_MODE && Guard::GetInstance().IsNodeInShardGuardList(
                         m_mediator.m_selfKey.second)) {
     winning_result = POW::GetInstance().PoWMine(
@@ -187,7 +187,8 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
           m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
           StartSynchronization();
         } else {
-          LOG_GENERAL(WARNING, "DS block not recvd, what to do ?");
+          LOG_GENERAL(WARNING, "DS block not recvd, will initiate rejoin");
+          RejoinAsNormal();
         }
       }
     };


### PR DESCRIPTION
## Description
Addresses issue - https://github.com/Zilliqa/Issues/issues/572 and issue - https://github.com/Zilliqa/Issues/issues/575

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
Fix involves basically:
 - ~~Recheck on `m_startedpow` in `StartSyncronization` which avoid calling of `ComposeAndSendGetDirectoryBlocksFromSeed` in most of time.~~  `syncType = NO_SYNC` should take care of this now.
- To handle that remaining small window, used mutex `m_mutexDSBlock` to make sure no `ProcessSetDirectoryBlocksFromSeed` and `ProcessVCDSBlock` are executed at same time.
- `ProcessVCDSBlock` checks for dsblock already and ignore adding to blocklink. Other vcblocks will be ignored already.
- Stop previous `StartSyncronization` start after pow is started. 
- set `syncType = NO_SYNC` in pow state
- skip unwanted processing of DS block in `ProcessSetDSBlockFromSeed` for normal nodes.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
