### PR TITLE
Fix access null pointer

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -281,8 +281,10 @@ void Node::Init() {
   // set consensusID for first epoch to 1.
   LOG_MARKER();
 
-  m_retriever->CleanAll();
-  m_retriever.reset();
+  if (m_retriever) {
+    m_retriever->CleanAll();
+    m_retriever.reset();
+  }
   m_mediator.m_dsBlockChain.Reset();
   m_mediator.m_txBlockChain.Reset();
   m_mediator.m_blocklinkchain.Reset();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Fix access null pointer, the m_retriever is initialized in StartRetrieveHistory function, but for a new node, StartRetrieveHistory function is not called.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/573

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
