### PR TITLE
Support gas mechanics for scilla-checker

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -636,12 +636,13 @@ bool AccountStore::MigrateContractStates() {
         bool ret_checker = true;
         int pid = -1;
         TransactionReceipt receipt;
-        InvokeScillaChecker(checkerPrint, ret_checker, pid, receipt);
+        uint64_t gasRem = UINT64_MAX;
+        InvokeScillaChecker(checkerPrint, ret_checker, pid, gasRem, receipt);
 
         if (ret_checker) {
           bytes map_depth_data;
           if (!ParseContractCheckerOutput(checkerPrint, receipt,
-                                          map_depth_data)) {
+                                          map_depth_data, gasRem)) {
             LOG_GENERAL(WARNING,
                         "Failed to generate map_depth_data from scilla_checker "
                         "print for contract "

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -125,7 +125,8 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   /// get the json format file for the current blocknum
   Json::Value GetBlockStateJson(const uint64_t& BlockNum) const;
   /// get the command for invoking the scilla_checker while deploying
-  std::string GetContractCheckerCmdStr(const std::string& root_w_version);
+  std::string GetContractCheckerCmdStr(const std::string& root_w_version,
+      const uint64_t& available_gas);
   /// get the command for invoking the scilla_runner while deploying
   std::string GetCreateContractCmdStr(
       const std::string& root_w_version, const uint64_t& available_gas,
@@ -167,13 +168,15 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
 
   /// capsulate and expose in protected for using by data migartion
   void InvokeScillaChecker(std::string& checkerPrint, bool& ret_checker,
-                           int& pid, TransactionReceipt& receipt);
+                           int& pid, const uint64_t& gasRemained,
+                           TransactionReceipt& receipt);
 
   /// verify the return from scilla_checker for deployment is valid
   /// expose in protected for using by data migration
   bool ParseContractCheckerOutput(const std::string& checkerPrint,
                                   TransactionReceipt& receipt,
-                                  bytes& map_depth_data);
+                                  bytes& map_depth_datam,
+                                  uint64_t& gasRemained);
 
   /// external interface for processing txn
   bool UpdateAccounts(const uint64_t& blockNum, const unsigned int& numShards,


### PR DESCRIPTION
## Description
`scilla-checker` will soon charge gas for checking contracts. This PR provides a "gas remaining" argument to `scilla-checker` and also check its output for `gas_remaining` to track how much gas was consumed during the process.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Status
No test has been run. This needs to be tested after the corresponding scilla-checker update is complete.
**NOT** ready for merge into `master`. Can possibly be merged to `feature/contractmap` (against which this PR is created).

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
