### PR TITLE
Force serialization of primitive proto fields for block and tx data

### DIFF
--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -19,10 +19,10 @@ message ByteArray
 // Used in database "blockLinks"
 message ProtoBlockLink
 {
-    uint32 version   = 1; // Added in: v1.0, Deprecated in: N/A
-    uint64 index     = 2; // Added in: v1.0, Deprecated in: N/A
-    uint64 dsindex   = 3; // Added in: v1.0, Deprecated in: N/A
-    uint32 blocktype = 4; // Added in: v1.0, Deprecated in: N/A
+    oneof oneof1 { uint32 version   = 1; } // Added in: v1.0, Deprecated in: N/A
+    oneof oneof2 { uint64 index     = 2; } // Added in: v1.0, Deprecated in: N/A
+    oneof oneof3 { uint64 dsindex   = 3; } // Added in: v1.0, Deprecated in: N/A
+    oneof oneof4 { uint32 blocktype = 4; } // Added in: v1.0, Deprecated in: N/A
     bytes blockhash  = 5; // Added in: v1.0, Deprecated in: N/A
     // Add new members here
 }
@@ -68,8 +68,8 @@ message ProtoDSBlock
         uint32 difficulty                    = 3;  // Added in: v1.0, Deprecated in: N/A, Only LSB used
         bytes prevhash                       = 4;  // Added in: v1.0, Deprecated in: N/A, 32 bytes
         ByteArray leaderpubkey               = 5;  // Added in: v1.0, Deprecated in: N/A
-        uint64 blocknum                      = 6;  // Added in: v1.0, Deprecated in: N/A
-        uint64 epochnum                      = 7;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof6 { uint64 blocknum       = 6; } // Added in: v1.0, Deprecated in: N/A
+        oneof oneof7 { uint64 epochnum       = 7; } // Added in: v1.0, Deprecated in: N/A
         ByteArray gasprice                   = 8;  // Added in: v1.0, Deprecated in: N/A
         ByteArray swinfo                     = 9;  // Added in: v1.0, Deprecated in: N/A
         message PowDSWinners
@@ -110,14 +110,14 @@ message ProtoMicroBlock
     message MicroBlockHeader
     {
         ProtoBlockHeaderBase blockheaderbase = 1;  // Added in: v1.0, Deprecated in: N/A
-        uint32 shardid                       = 2;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof2 { uint32 shardid        = 2; } // Added in: v1.0, Deprecated in: N/A
         uint64 gaslimit                      = 3;  // Added in: v1.0, Deprecated in: N/A
-        uint64 gasused                       = 4;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof4 { uint64 gasused        = 4; } // Added in: v1.0, Deprecated in: N/A
         ByteArray rewards                    = 5;  // Added in: v1.0, Deprecated in: N/A
         bytes prevhash                       = 6;  // Added in: v1.0, Deprecated in: N/A
-        uint64 epochnum                      = 7;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof7 { uint64 epochnum       = 7; } // Added in: v1.0, Deprecated in: N/A
         bytes txroothash                     = 8;  // Added in: v1.0, Deprecated in: N/A
-        uint32 numtxs                        = 9;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof9 { uint32 numtxs         = 9; } // Added in: v1.0, Deprecated in: N/A
         ByteArray minerpubkey                = 10; // Added in: v1.0, Deprecated in: N/A
         uint64 dsblocknum                    = 11; // Added in: v1.0, Deprecated in: N/A
         bytes statedeltahash                 = 12; // Added in: v1.0, Deprecated in: N/A
@@ -137,7 +137,7 @@ message ProtoShardingStructure
     {
         ByteArray pubkey   = 1; // Added in: v1.0, Deprecated in: N/A
         ByteArray peerinfo = 2; // Added in: v1.0, Deprecated in: N/A
-        uint32 reputation  = 3; // Added in: v1.0, Deprecated in: N/A
+        oneof oneof3 { uint32 reputation  = 3; } // Added in: v1.0, Deprecated in: N/A
         // Add new members here
     }
     message Shard
@@ -155,7 +155,7 @@ message ProtoMbInfo
 {
     bytes mbhash   = 1; // Added in: v1.0, Deprecated in: N/A
     bytes txroot   = 2; // Added in: v1.0, Deprecated in: N/A
-    uint32 shardid = 3; // Added in: v1.0, Deprecated in: N/A
+    oneof oneof3 { uint32 shardid = 3; } // Added in: v1.0, Deprecated in: N/A
     // Add new members here
 }
 
@@ -173,12 +173,12 @@ message ProtoTxBlock
     {
         ProtoBlockHeaderBase blockheaderbase = 1;  // Added in: v1.0, Deprecated in: N/A
         uint64 gaslimit                      = 2;  // Added in: v1.0, Deprecated in: N/A
-        uint64 gasused                       = 3;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof3 { uint64 gasused        = 3; } // Added in: v1.0, Deprecated in: N/A
         ByteArray rewards                    = 4;  // Added in: v1.0, Deprecated in: N/A
         bytes prevhash                       = 5;  // Added in: v1.0, Deprecated in: N/A
         uint64 blocknum                      = 6;  // Added in: v1.0, Deprecated in: N/A
         TxBlockHashSet hash                  = 7;  // Added in: v1.0, Deprecated in: N/A
-        uint32 numtxs                        = 8;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof8 { uint32 numtxs         = 8; } // Added in: v1.0, Deprecated in: N/A
         ByteArray minerpubkey                = 9;  // Added in: v1.0, Deprecated in: N/A
         uint64 dsblocknum                    = 10; // Added in: v1.0, Deprecated in: N/A
         // Add new members here
@@ -197,10 +197,10 @@ message ProtoVCBlock
         ProtoBlockHeaderBase blockheaderbase = 1; // Added in: v1.0, Deprecated in: N/A
         uint64 viewchangedsepochno           = 2; // Added in: v1.0, Deprecated in: N/A
         uint64 viewchangeepochno             = 3; // Added in: v1.0, Deprecated in: N/A
-        uint32 viewchangestate               = 4; // Added in: v1.0, Deprecated in: N/A, Only LSB used
+        oneof oneof4 { uint32 viewchangestate = 4; } // Added in: v1.0, Deprecated in: N/A, Only LSB used
         ByteArray candidateleadernetworkinfo = 5; // Added in: v1.0, Deprecated in: N/A
         ByteArray candidateleaderpubkey      = 6; // Added in: v1.0, Deprecated in: N/A
-        uint32 vccounter                     = 7; // Added in: v1.0, Deprecated in: N/A
+        oneof oneof7 { uint32 vccounter      = 7; } // Added in: v1.0, Deprecated in: N/A
         repeated ProtoDSNode faultyleaders            = 8; // Added in: v1.0, Deprecated in: N/A
         bytes prevhash                       = 9; // Added in: v1.0, Deprecated in: N/A
         // Add new members here
@@ -264,7 +264,7 @@ message ProtoAccountBase
 {
     uint32 version    = 1; // Added in: v1.0, Deprecated in: N/A
     ByteArray balance = 2; // Added in: v1.0, Deprecated in: N/A
-    uint64 nonce      = 3; // Added in: v1.0, Deprecated in: N/A
+    oneof oneof3 { uint64 nonce = 3; } // Added in: v1.0, Deprecated in: N/A
     bytes codehash    = 4; // Added in: v1.0, Deprecated in: N/A
     bytes storageroot = 5; // Added in: v1.0, Deprecated in: N/A
 }
@@ -310,7 +310,7 @@ message ProtoAccountStore
 message ProtoPeer
 {
     ByteArray ipaddress    = 1;
-    uint32 listenporthost  = 2;
+    oneof oneof2 { uint32 listenporthost  = 2; }
 }
 
 message ProtoPoWSolution
@@ -318,7 +318,7 @@ message ProtoPoWSolution
     uint64 nonce        = 1;
     bytes result        = 2;
     bytes mixhash       = 3;
-    uint32 lookupid     = 4;
+    oneof oneof4 { uint32 lookupid     = 4; }
     ByteArray gasprice  = 5;
 }
 
@@ -333,7 +333,7 @@ message ProtoShardingStructureWithPoWSolns
     {
         ByteArray pubkey         = 1;
         ByteArray peerinfo       = 2;
-        uint32 reputation        = 3;
+        oneof oneof3 { uint32 reputation = 3; }
         ProtoPoWSolution powsoln = 4;
     }
     message Shard
@@ -352,13 +352,13 @@ message ProtoDSWinnerPoW
 message ProtoTransactionCoreInfo
 {
     uint32 version         = 1;
-    uint64 nonce           = 2;
+    oneof oneof2 { uint64 nonce = 2; }
     bytes toaddr           = 3;
     ByteArray senderpubkey = 4;
     ByteArray amount       = 5;
     ByteArray gasprice     = 6;
     uint64 gaslimit        = 7;
-    bytes code             = 8;
+    oneof oneof8 { bytes code = 8; }
     bytes data             = 9;
 }
 
@@ -383,7 +383,7 @@ message ProtoTransactionArray
 message ProtoTransactionReceipt
 {
     bytes receipt    = 1;
-    uint64 cumgas = 2;
+    oneof oneof2 { uint64 cumgas = 2; }
 }
 
 message ProtoTransactionWithReceipt

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -359,7 +359,7 @@ message ProtoTransactionCoreInfo
     ByteArray gasprice     = 6;
     uint64 gaslimit        = 7;
     oneof oneof8 { bytes code = 8; }
-    bytes data             = 9;
+    oneof oneof9 { bytes data = 9; }
 }
 
 message ProtoTransaction

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -173,14 +173,14 @@ message ProtoTxBlock
     {
         ProtoBlockHeaderBase blockheaderbase = 1;  // Added in: v1.0, Deprecated in: N/A
         uint64 gaslimit                      = 2;  // Added in: v1.0, Deprecated in: N/A
-        oneof oneof3 { uint64 gasused        = 3; } // Added in: v1.0, Deprecated in: N/A
+        oneof oneof3 { uint64 gasused        = 3;} // Added in: v1.0, Deprecated in: N/A
         ByteArray rewards                    = 4;  // Added in: v1.0, Deprecated in: N/A
         bytes prevhash                       = 5;  // Added in: v1.0, Deprecated in: N/A
-        uint64 blocknum                      = 6;  // Added in: v1.0, Deprecated in: N/A
+        oneof oneof6 {uint64 blocknum        = 6;} // Added in: v1.0, Deprecated in: N/A
         TxBlockHashSet hash                  = 7;  // Added in: v1.0, Deprecated in: N/A
-        oneof oneof8 { uint32 numtxs         = 8; } // Added in: v1.0, Deprecated in: N/A
+        oneof oneof8 { uint32 numtxs         = 8;} // Added in: v1.0, Deprecated in: N/A
         ByteArray minerpubkey                = 9;  // Added in: v1.0, Deprecated in: N/A
-        uint64 dsblocknum                    = 10; // Added in: v1.0, Deprecated in: N/A
+        oneof oneof10 {uint64 dsblocknum     = 10;}// Added in: v1.0, Deprecated in: N/A
         // Add new members here
     }
     TxBlockHeader header      = 1;  // Added in: v1.0, Deprecated in: N/A


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Proto3 does not serialize fields that are set to default value ([reference](https://developers.google.com/protocol-buffers/docs/proto3))

This is a breaking change from proto2, and will be problematic for any of our code that relies on byte consistency (e.g., hashes based on serialized blocks).

To fix this, we force the serialization of these fields by wrapping each one in a `oneof`. ([reference](https://stackoverflow.com/questions/37034746/do-not-set-default-values-in-optional-protobuf-fields-to-minimize-data-sent-over))

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
