### PR TITLE
[Release 5.0] Seednodes to skip itself adding to lookupnodes

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -623,7 +623,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
     uint64_t oldTxNum = m_mediator.m_txBlockChain.GetBlockCount();
 
     if (LOOKUP_NODE_MODE) {
-      if (!m_mediator.m_lookup->GetMyLookupOffline()) {
+      if (!ARCHIVAL_LOOKUP && !m_mediator.m_lookup->GetMyLookupOffline()) {
         LOG_GENERAL(WARNING, "Cannot fetch data from off-line lookup node!");
         return false;
       }


### PR DESCRIPTION
## Description
Fix: For `newlookup` and `level2lookup`
- Don't add itself to lookup node list. --> This resulted in being randomly asked for MicroBlock to himself. 
- skip checking and adding itself (archival nodes) to `OfflineLookupList`.
  Applicable only for lookup nodes.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
