### PR TITLE
Fix during retieving history the new block stored issue

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -531,7 +531,7 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
     return false;
   }
 
-  if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP && !buffered) {
+  if (LOOKUP_NODE_MODE && !buffered) {
     if (m_mediator.m_lookup->GetSyncType() != SyncType::NO_SYNC) {
       // Buffer the Final Block
       lock_guard<mutex> g(m_mutexSeedTxnBlksBuffer);

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -634,7 +634,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
       }
 
       unique_lock<mutex> lock(m_mediator.m_lookup->m_MutexCVSetTxBlockFromSeed);
-      m_mediator.m_lookup->SetSyncType(SyncType::LOOKUP_SYNC);
+      m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
 
       do {
         m_mediator.m_lookup->GetTxBlockFromSeedNodes(


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
1. Fix during retieving history the new block stored issue
2. Fix normal node use LOOKUP_SYNC problem
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
https://github.com/Zilliqa/Issues/issues/581

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
