### PR TITLE
AccountStore InitSoft call missing for RejoinAsNewLookup

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3339,10 +3339,9 @@ void Lookup::RejoinAsNewLookup() {
     DetachedFunction(1, func1);
 
     auto func2 = [this]() mutable -> void {
+      AccountStore::GetInstance().InitSoft();
       while (true) {
         this->CleanVariables();
-        m_mediator.m_node->CleanVariables();
-        m_mediator.m_ds->CleanVariables();
         while (!m_mediator.m_node->DownloadPersistenceFromS3()) {
           LOG_GENERAL(
               WARNING,

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -58,7 +58,7 @@ using namespace boost::multiprecision;
 
 Lookup::Lookup(Mediator& mediator, SyncType syncType) : m_mediator(mediator) {
   m_syncType.store(SyncType::NO_SYNC);
-  vector<SyncType> ignorable_syncTypes = {NO_SYNC, RECOVERY_ALL_SYNC, DB_VERIF};
+  vector<SyncType> ignorable_syncTypes = {NO_SYNC, DB_VERIF};
   if (syncType >= SYNC_TYPE_COUNT) {
     LOG_GENERAL(FATAL, "Invalid SyncType");
   }
@@ -2054,7 +2054,9 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
       vector<BlockHash> mbHashes;
 
       for (const auto& mbInfo : txBlock.GetMicroBlockInfos()) {
-        mbHashes.emplace_back(mbInfo.m_microBlockHash);
+        if (mbInfo.m_txnRootHash != TxnHash()) {
+          mbHashes.emplace_back(mbInfo.m_microBlockHash);
+        }
       }
 
       SendGetMicroBlockFromLookup(mbHashes);
@@ -3326,12 +3328,18 @@ void Lookup::RejoinAsNewLookup() {
 
   LOG_MARKER();
   if (m_mediator.m_lookup->GetSyncType() == SyncType::NO_SYNC) {
-    m_lookupServer->StopListening();
-    LOG_GENERAL(INFO, "API Server stopped listen for syncing");
+    m_mediator.m_lookup->SetSyncType(SyncType::NEW_LOOKUP_SYNC);
+    auto func1 = [this]() mutable -> void {
+      if (m_lookupServer) {
+        m_lookupServer->StopListening();
+        LOG_GENERAL(INFO, "API Server stopped listen for syncing");
+      }
+    };
 
-    auto func = [this]() mutable -> void {
+    DetachedFunction(1, func1);
+
+    auto func2 = [this]() mutable -> void {
       while (true) {
-        m_mediator.m_lookup->SetSyncType(SyncType::NEW_LOOKUP_SYNC);
         this->CleanVariables();
         m_mediator.m_node->CleanVariables();
         m_mediator.m_ds->CleanVariables();
@@ -3356,7 +3364,7 @@ void Lookup::RejoinAsNewLookup() {
       }
       InitSync();
     };
-    DetachedFunction(1, func);
+    DetachedFunction(1, func2);
   }
 }
 
@@ -3371,17 +3379,19 @@ void Lookup::RejoinAsLookup() {
   LOG_MARKER();
 
   if (m_mediator.m_lookup->GetSyncType() == SyncType::NO_SYNC) {
-    if (m_lookupServer) {
-      m_lookupServer->StopListening();
-      LOG_GENERAL(INFO, "API Server stopped listen for syncing");
-    }
-
-    auto func = [this]() mutable -> void {
-      m_mediator.m_lookup->SetSyncType(SyncType::LOOKUP_SYNC);
-      StartSynchronization();
+    m_mediator.m_lookup->SetSyncType(SyncType::LOOKUP_SYNC);
+    auto func1 = [this]() mutable -> void {
+      if (m_lookupServer) {
+        m_lookupServer->StopListening();
+        LOG_GENERAL(INFO, "API Server stopped listen for syncing");
+      }
     };
 
-    DetachedFunction(1, func);
+    DetachedFunction(1, func1);
+
+    auto func2 = [this]() -> void { StartSynchronization(); };
+
+    DetachedFunction(1, func2);
   }
 }
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3333,6 +3333,8 @@ void Lookup::RejoinAsNewLookup() {
       while (true) {
         m_mediator.m_lookup->SetSyncType(SyncType::NEW_LOOKUP_SYNC);
         this->CleanVariables();
+        m_mediator.m_node->CleanVariables();
+        m_mediator.m_ds->CleanVariables();
         while (!m_mediator.m_node->DownloadPersistenceFromS3()) {
           LOG_GENERAL(
               WARNING,

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -544,7 +544,11 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
       if (!m_seedTxnBlksBuffer.empty()) {
         LOG_GENERAL(INFO, "Seed synced, processing buffered FBLKS");
         for (const auto& txnblk : m_seedTxnBlksBuffer) {
-          ProcessFinalBlockCore(txnblk, offset, Peer(), true);
+          if (!ProcessFinalBlockCore(txnblk, offset, Peer(), true)) {
+            // ignore bufferred final blocks because rejoin must have been
+            // already
+            break;
+          }
         }
         // clear the buffer since all buffered ones are checked and processed
         m_seedTxnBlksBuffer.clear();

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -273,10 +273,14 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
         m_lookup.StartSynchronization();
         break;
       case SyncType::RECOVERY_ALL_SYNC:
-        LOG_GENERAL(INFO, "Recovery all nodes, no Sync Needed");
+        LOG_GENERAL(INFO, "Recovery all nodes");
+        if (m_mediator.m_lookup->GetSyncType() == SyncType::RECOVERY_ALL_SYNC) {
+          m_lookup.SetSyncType(NO_SYNC);
+        }
         // When doing recovery, make sure to let other lookups know I'm back
         // online
         if (LOOKUP_NODE_MODE) {
+          m_lookup.SetSyncType(NO_SYNC);
           if (!m_mediator.m_lookup->GetMyLookupOnline(true)) {
             LOG_GENERAL(WARNING, "Failed to notify lookups I am back online");
           }


### PR DESCRIPTION
## Description
Clean variables such that AccountStore::InitSoft should be called

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
