### PR TITLE
Remove data_migrate from build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ if(TESTS)
 endif()
 
 # installation
-set_target_properties(zilliqa sendcmd genkeypair getpub getaddr gentxn signmultisig verifymultisig ZilliqaDaemon_AWS gensigninitialds grepperf getnetworkhistory getrewardhistory validateDB restore genTxnBodiesFromS3 data_migrate
+set_target_properties(zilliqa sendcmd genkeypair getpub getaddr gentxn signmultisig verifymultisig ZilliqaDaemon_AWS gensigninitialds grepperf getnetworkhistory getrewardhistory validateDB restore genTxnBodiesFromS3
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_target_properties(Common Trie ethash NAT

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -92,9 +92,9 @@ add_custom_command(TARGET zilliqa
 target_include_directories(genTxnBodiesFromS3 PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(genTxnBodiesFromS3 PUBLIC AccountData Utils Persistence Server)
 
-add_executable(data_migrate data_migrate.cpp)
-add_custom_command(TARGET zilliqa
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:data_migrate> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
-target_include_directories(data_migrate PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(data_migrate PUBLIC Mediator Utils Persistence AccountData)
+#add_executable(data_migrate data_migrate.cpp)
+#add_custom_command(TARGET zilliqa
+#        POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:data_migrate> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
+#target_include_directories(data_migrate PUBLIC ${CMAKE_SOURCE_DIR}/src)
+#target_link_libraries(data_migrate PUBLIC Mediator Utils Persistence AccountData)


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`data_migrate` was only needed during v5.0.0 network upgrade.  Moving forward, we can exclude it from the build (eventually we can consider removing from src as well).

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
