### PR TITLE
Optimize GenerateShardCounts to minimize number of unsharded nodes

### DIFF
--- a/src/libUtils/ShardSizeCalculator.cpp
+++ b/src/libUtils/ShardSizeCalculator.cpp
@@ -64,13 +64,18 @@ static void GenerateShardCountsCore(const vector<uint32_t>& shardSizeValues,
   if (numNodesForSharding < shardSizeValues[0]) {
     // Distribute these nodes among the existing shards
     if ((numNodesForSharding > 0) && (currentResult.size() > 0)) {
+      uint32_t toAddPerShard = numNodesForSharding / currentResult.size();
+      if ((numNodesForSharding % currentResult.size()) > 0) {
+        toAddPerShard++;
+      }
       for (auto& shardInCurrentResult : currentResult) {
         // Don't add more nodes than the max threshold
-        uint32_t toadd = min(
-            numNodesForSharding,
-            shardSizeValues[shardSizeValues.size() - 1] - shardInCurrentResult);
-        shardInCurrentResult += toadd;
-        numNodesForSharding -= toadd;
+        uint32_t actualToAdd =
+            min(toAddPerShard, shardSizeValues[shardSizeValues.size() - 1] -
+                                   shardInCurrentResult);
+        actualToAdd = min(actualToAdd, numNodesForSharding);
+        shardInCurrentResult += actualToAdd;
+        numNodesForSharding -= actualToAdd;
       }
     }
 

--- a/src/libUtils/ShardSizeCalculator.cpp
+++ b/src/libUtils/ShardSizeCalculator.cpp
@@ -55,12 +55,65 @@ uint32_t ShardSizeCalculator::CalculateShardSize(const uint32_t numberOfNodes) {
   return result[index];
 }
 
+static void GenerateShardCountsCore(const vector<uint32_t>& shardSizeValues,
+                                    uint32_t numNodesForSharding,
+                                    vector<uint32_t>& currentResult,
+                                    vector<uint32_t>& bestResult,
+                                    uint32_t& leastWaste) {
+  // If number of remaining unsharded nodes is less than minimum threshold
+  if (numNodesForSharding < shardSizeValues[0]) {
+    // Distribute these nodes among the existing shards
+    if ((numNodesForSharding > 0) && (currentResult.size() > 0)) {
+      for (auto& shardInCurrentResult : currentResult) {
+        // Don't add more nodes than the max threshold
+        uint32_t toadd = min(
+            numNodesForSharding,
+            shardSizeValues[shardSizeValues.size() - 1] - shardInCurrentResult);
+        shardInCurrentResult += toadd;
+        numNodesForSharding -= toadd;
+      }
+    }
+
+    // If we don't have a best result yet, this one is the best for now
+    if (bestResult.empty()) {
+      bestResult = currentResult;
+      leastWaste = numNodesForSharding;
+    }
+    // If we have a best result already from a previous recursion
+    else {
+      // If this current result is as good as the best one, but achieves it with
+      // fewer shards
+      if ((numNodesForSharding == leastWaste) &&
+          (bestResult.size() > currentResult.size())) {
+        bestResult = currentResult;
+      }
+      // If this current result is better than the best one
+      else if (numNodesForSharding < leastWaste) {
+        bestResult = currentResult;
+        leastWaste = numNodesForSharding;
+      }
+    }
+  }
+  // If number of remaining unsharded nodes is still more than minimum threshold
+  else {
+    // Recursively try adding another shard with the 3 values (low threshold,
+    // shard size, high threshold)
+    for (const auto& value : shardSizeValues) {
+      if (numNodesForSharding < value) {
+        break;
+      }
+      currentResult.push_back(value);
+      GenerateShardCountsCore(shardSizeValues, numNodesForSharding - value,
+                              currentResult, bestResult, leastWaste);
+      currentResult.pop_back();
+    }
+  }
+}
+
 void ShardSizeCalculator::GenerateShardCounts(
     const uint32_t shardSize, const uint32_t shardSizeToleranceLo,
     const uint32_t shardSizeToleranceHi, const uint32_t numNodesForSharding,
-    vector<uint32_t>& shardCounts, bool logDetails) {
-  // LOG_MARKER();
-
+    vector<uint32_t>& shardCounts) {
   if (shardSizeToleranceLo >= shardSize) {
     LOG_GENERAL(
         WARNING,
@@ -70,71 +123,20 @@ void ShardSizeCalculator::GenerateShardCounts(
   const uint32_t shard_threshold_lo = shardSize - shardSizeToleranceLo;
   const uint32_t shard_threshold_hi = shardSize + shardSizeToleranceHi;
 
-  if (logDetails) {
-    LOG_GENERAL(INFO, "Default shard size          = " << shardSize);
-    LOG_GENERAL(INFO, "Minimum allowed shard size  = " << shard_threshold_lo);
-    LOG_GENERAL(INFO, "Maximum allowed shard size  = " << shard_threshold_hi);
-  }
-
   // Abort if total number of nodes is below shard_threshold_lo
   if (numNodesForSharding < shard_threshold_lo) {
-    if (logDetails) {
-      LOG_GENERAL(WARNING, "Number of PoWs for sharding ("
-                               << numNodesForSharding
-                               << ") is not enough for even one shard.");
-    }
+    LOG_GENERAL(WARNING, "Number of PoWs for sharding ("
+                             << numNodesForSharding
+                             << ") is not enough for even one shard.");
     return;
   }
 
-  // Get the number of full shards that can be formed
-  const uint32_t numOfCompleteShards = numNodesForSharding / shardSize;
-
-  if (numOfCompleteShards == 0) {
-    // If can't form one full shard, set first shard count to 0
-    shardCounts.resize(1);
-    shardCounts.at(0) = 0;
-  } else {
-    // If can form one or more full shards, set shard count to shardSize
-    shardCounts.resize(numOfCompleteShards);
-    fill(shardCounts.begin(), shardCounts.end(), shardSize);
-  }
-
-  // Get the remaining count of unsharded nodes
-  uint32_t numUnshardedNodes =
-      numNodesForSharding - (numOfCompleteShards * shardSize);
-
-  if (numUnshardedNodes == numNodesForSharding) {
-    // Remaining count = original node count -> set first shard count to
-    // remaining count
-    shardCounts.at(0) = numUnshardedNodes;
-  } else if ((numUnshardedNodes < shard_threshold_lo) &&
-             (shard_threshold_hi > 0)) {
-    // If remaining count is less than shard_threshold_lo, distribute among the
-    // shards
-    for (auto& shardCount : shardCounts) {
-      // Add just enough nodes to each shard such that we don't go over
-      // shard_threshold_hi
-      const uint32_t nodesToAdd =
-          min(shard_threshold_hi - shardCount, numUnshardedNodes);
-      shardCount += nodesToAdd;
-      numUnshardedNodes -= nodesToAdd;
-
-      if (numUnshardedNodes == 0) {
-        break;
-      }
-    }
-  } else {
-    // If remaining count is greater than or equal to shard_threshold_lo, allow
-    // formation of another shard
-    shardCounts.emplace_back(numUnshardedNodes);
-  }
-
-  if (logDetails) {
-    LOG_GENERAL(INFO, "Final computed shard sizes:");
-    for (unsigned int i = 0; i < shardCounts.size(); i++) {
-      LOG_GENERAL(INFO, "Shard " << i << " = " << shardCounts.at(i));
-    }
-  }
+  const vector<uint32_t> shardSizeValues = {shard_threshold_lo, shardSize,
+                                            shard_threshold_hi};
+  vector<uint32_t> currentResult;
+  uint32_t leastWaste = numNodesForSharding;
+  GenerateShardCountsCore(shardSizeValues, numNodesForSharding, currentResult,
+                          shardCounts, leastWaste);
 }
 
 uint32_t ShardSizeCalculator::GetTrimmedShardCount(
@@ -145,7 +147,7 @@ uint32_t ShardSizeCalculator::GetTrimmedShardCount(
   vector<uint32_t> shardCounts;
 
   GenerateShardCounts(shardSize, shardSizeToleranceLo, shardSizeToleranceHi,
-                      numNodesForSharding, shardCounts, false);
+                      numNodesForSharding, shardCounts);
 
   if (shardCounts.empty()) {
     return numNodesForSharding;

--- a/src/libUtils/ShardSizeCalculator.cpp
+++ b/src/libUtils/ShardSizeCalculator.cpp
@@ -64,6 +64,7 @@ static void GenerateShardCountsCore(const vector<uint32_t>& shardSizeValues,
   if (numNodesForSharding < shardSizeValues[0]) {
     // Distribute these nodes among the existing shards
     if ((numNodesForSharding > 0) && (currentResult.size() > 0)) {
+      const uint32_t upperLimit = shardSizeValues[shardSizeValues.size() - 1];
       uint32_t toAddPerShard = numNodesForSharding / currentResult.size();
       if ((numNodesForSharding % currentResult.size()) > 0) {
         toAddPerShard++;
@@ -71,8 +72,7 @@ static void GenerateShardCountsCore(const vector<uint32_t>& shardSizeValues,
       for (auto& shardInCurrentResult : currentResult) {
         // Don't add more nodes than the max threshold
         uint32_t actualToAdd =
-            min(toAddPerShard, shardSizeValues[shardSizeValues.size() - 1] -
-                                   shardInCurrentResult);
+            min(toAddPerShard, upperLimit - shardInCurrentResult);
         actualToAdd = min(actualToAdd, numNodesForSharding);
         shardInCurrentResult += actualToAdd;
         numNodesForSharding -= actualToAdd;

--- a/src/libUtils/ShardSizeCalculator.h
+++ b/src/libUtils/ShardSizeCalculator.h
@@ -31,8 +31,7 @@ class ShardSizeCalculator {
                                   const uint32_t shardSizeToleranceLo,
                                   const uint32_t shardSizeToleranceHi,
                                   const uint32_t numNodesForSharding,
-                                  std::vector<uint32_t>& shardCounts,
-                                  bool logDetails = true);
+                                  std::vector<uint32_t>& shardCounts);
 
   static uint32_t GetTrimmedShardCount(const uint32_t shardSize,
                                        const uint32_t shardSizeToleranceLo,

--- a/tests/Utils/Test_ShardSizeCalculator.cpp
+++ b/tests/Utils/Test_ShardSizeCalculator.cpp
@@ -101,6 +101,7 @@ void ShardCountTestMain(const uint32_t shardSize,
                   << shardSize + shardSizeToleranceHi << "] Nodes="
                   << numNodesForSharding << " Shards=[ " << shardsString.str()
                   << "] Unsharded=" << numNodesForSharding - totalSharded);
+    BOOST_CHECK(totalSharded <= numNodesForSharding);
   }
 }
 

--- a/tests/Utils/Test_ShardSizeCalculator.cpp
+++ b/tests/Utils/Test_ShardSizeCalculator.cpp
@@ -86,9 +86,9 @@ void ShardCountTestMain(const uint32_t shardSize,
 
   for (uint32_t numNodesForSharding = nodeCountStart;
        numNodesForSharding <= nodeCountEnd; numNodesForSharding++) {
-    ShardSizeCalculator::GenerateShardCounts(
-        shardSize, shardSizeToleranceLo, shardSizeToleranceHi,
-        numNodesForSharding, shardCounts, false);
+    ShardSizeCalculator::GenerateShardCounts(shardSize, shardSizeToleranceLo,
+                                             shardSizeToleranceHi,
+                                             numNodesForSharding, shardCounts);
     ostringstream shardsString;
     uint32_t totalSharded = 0;
     for (const auto& shard : shardCounts) {
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(test_shard_count_generation) {
   // ShardCountTestMain(600, 0, 0, 590, 610);
   // ShardCountTestMain(600, 100, 0, 490, 610);
   // ShardCountTestMain(600, 50, 50, 540, 660);
-  ShardCountTestMain(600, 100, 0, 590, 1810);
+  ShardCountTestMain(600, 100, 0, 490, 1810);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Reference: https://github.com/Zilliqa/Issues/issues/593

The current `GenerateShardCounts` algorithm tries to fill up as many `COMM_SIZE` shards as possible, before allowing an additional shard to be less than `COMM_SIZE`. For example:

```
Low threshold = 500
Shard size = 600
Num nodes = 1099
Result = [ 600 ] -> Unsharded nodes = 499
```

After this PR, `GenerateShardCounts` will go through all possible sharding scenarios and pick the configuration with the least amount of wastage:

```
Low threshold = 500
Shard size = 600
Num nodes = 1099
Result = [ 550, 549 ] -> Unsharded nodes = 0
```

Here's a sample test run across some values:
```
Shard lo,mid,hi=[500,600,600] Nodes=499 Shards=[ ] Unsharded=499
Shard lo,mid,hi=[500,600,600] Nodes=500 Shards=[ 500 ] Unsharded=0
...
Shard lo,mid,hi=[500,600,600] Nodes=599 Shards=[ 599 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=600 Shards=[ 600 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=601 Shards=[ 600 ] Unsharded=1
Shard lo,mid,hi=[500,600,600] Nodes=602 Shards=[ 600 ] Unsharded=2
...
Shard lo,mid,hi=[500,600,600] Nodes=998 Shards=[ 600 ] Unsharded=398
Shard lo,mid,hi=[500,600,600] Nodes=999 Shards=[ 600 ] Unsharded=399
Shard lo,mid,hi=[500,600,600] Nodes=1000 Shards=[ 500 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1001 Shards=[ 501 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1002 Shards=[ 501 501 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1003 Shards=[ 502 501 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1004 Shards=[ 502 502 ] Unsharded=0
...
Shard lo,mid,hi=[500,600,600] Nodes=1200 Shards=[ 600 600 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1201 Shards=[ 600 600 ] Unsharded=1
Shard lo,mid,hi=[500,600,600] Nodes=1202 Shards=[ 600 600 ] Unsharded=2
...
Shard lo,mid,hi=[500,600,600] Nodes=1499 Shards=[ 600 600 ] Unsharded=299
Shard lo,mid,hi=[500,600,600] Nodes=1500 Shards=[ 500 500 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1501 Shards=[ 501 500 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1502 Shards=[ 501 501 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1503 Shards=[ 501 501 501 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1504 Shards=[ 502 502 500 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1505 Shards=[ 502 502 501 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1506 Shards=[ 502 502 502 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1507 Shards=[ 503 503 501 ] Unsharded=0
...
Shard lo,mid,hi=[500,600,600] Nodes=1796 Shards=[ 599 599 598 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1797 Shards=[ 599 599 599 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1798 Shards=[ 600 600 598 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1799 Shards=[ 600 600 599 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1800 Shards=[ 600 600 600 ] Unsharded=0
Shard lo,mid,hi=[500,600,600] Nodes=1801 Shards=[ 600 600 600 ] Unsharded=1
Shard lo,mid,hi=[500,600,600] Nodes=1802 Shards=[ 600 600 600 ] Unsharded=2
```

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->
Please build and execute `./build/tests/Utils/Test_ShardSizeCalculator` to see the test results for all node counts from 490 up to 1810 for the current threshold and `COMM_SIZE` in the mainnet.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
