### PR TITLE
Make txblock check in Node::CheckIntegrity threaded

### DIFF
--- a/src/cmd/restore.cpp
+++ b/src/cmd/restore.cpp
@@ -73,7 +73,7 @@ bool RollBackDSComm(const BlockLink& lastBlockLink,
 }
 
 bool PutStateDeltaInLocalPersistence(uint32_t lastBlockNum,
-                                     const list<TxBlockSharedPtr>& blocks) {
+                                     const deque<TxBlockSharedPtr>& blocks) {
   if ((lastBlockNum + 1) %
           (INCRDB_DSNUMS_WITH_STATEDELTAS * NUM_FINAL_BLOCK_PER_POW) ==
       0) {
@@ -245,15 +245,16 @@ int main(int argc, char* argv[]) {
            std::get<BlockLinkIndex::INDEX>(b);
   });
 
-  std::list<TxBlockSharedPtr> txblocks;
+  std::deque<TxBlockSharedPtr> txblocks;
   if (!BlockStorage::GetBlockStorage().GetAllTxBlocks(txblocks)) {
     cout << "Failed to get TxBlocks" << endl;
     return PERSISTENCE_ERROR;
   }
 
-  txblocks.sort([](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
-    return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
-  });
+  sort(txblocks.begin(), txblocks.end(),
+       [](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
+         return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
+       });
 
   const auto latestTxBlockNum = txblocks.back()->GetHeader().GetBlockNum();
   const auto& latestDSIndex = txblocks.back()->GetHeader().GetDSBlockNum();

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1908,7 +1908,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
         txBlocks, m_mediator.m_blocklinkchain.GetBuiltDSComm(),
         m_mediator.m_blocklinkchain.GetLatestBlockLink());
     switch (res) {
-      case ValidatorBase::TxBlockValidationMsg::VALID:
+      case Validator::TxBlockValidationMsg::VALID:
 #ifdef SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW
         if (LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP) {
           LOG_GENERAL(INFO,
@@ -1919,11 +1919,11 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
 #endif  // SJ_TEST_SJ_TXNBLKS_PROCESS_SLOW
         CommitTxBlocks(txBlocks);
         break;
-      case ValidatorBase::TxBlockValidationMsg::INVALID:
+      case Validator::TxBlockValidationMsg::INVALID:
         LOG_GENERAL(INFO, "[TxBlockVerif]"
                               << "Invalid blocks");
         break;
-      case ValidatorBase::TxBlockValidationMsg::STALEDSINFO:
+      case Validator::TxBlockValidationMsg::STALEDSINFO:
         LOG_GENERAL(INFO, "[TxBlockVerif]"
                               << "Saved to buffer");
         m_txBlockBuffer.clear();
@@ -3734,28 +3734,27 @@ bool Lookup::ProcessSetDirectoryBlocksFromSeed(
 
 void Lookup::CheckBufferTxBlocks() {
   if (!m_txBlockBuffer.empty()) {
-    ValidatorBase::TxBlockValidationMsg res =
-        m_mediator.m_validator->CheckTxBlocks(
-            m_txBlockBuffer, m_mediator.m_blocklinkchain.GetBuiltDSComm(),
-            m_mediator.m_blocklinkchain.GetLatestBlockLink());
+    Validator::TxBlockValidationMsg res = m_mediator.m_validator->CheckTxBlocks(
+        m_txBlockBuffer, m_mediator.m_blocklinkchain.GetBuiltDSComm(),
+        m_mediator.m_blocklinkchain.GetLatestBlockLink());
 
     switch (res) {
-      case ValidatorBase::TxBlockValidationMsg::VALID:
+      case Validator::TxBlockValidationMsg::VALID:
         CommitTxBlocks(m_txBlockBuffer);
         m_txBlockBuffer.clear();
         break;
-      case ValidatorBase::TxBlockValidationMsg::STALEDSINFO:
+      case Validator::TxBlockValidationMsg::STALEDSINFO:
         LOG_GENERAL(WARNING,
                     "Even after the recving latest ds info, the information "
                     "is stale ");
         break;
-      case ValidatorBase::TxBlockValidationMsg::INVALID:
+      case Validator::TxBlockValidationMsg::INVALID:
         LOG_GENERAL(WARNING, "The blocks in buffer are invalid ");
         m_txBlockBuffer.clear();
         break;
       default:
         LOG_GENERAL(WARNING,
-                    "The return value of ValidatorBase::CheckTxBlocks does not "
+                    "The return value of Validator::CheckTxBlocks does not "
                     "match any type");
     }
   }

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -52,7 +52,7 @@ Mediator::Mediator(const PairOfKey& key, const Peer& peer)
 Mediator::~Mediator() {}
 
 void Mediator::RegisterColleagues(DirectoryService* ds, Node* node,
-                                  Lookup* lookup, ValidatorBase* validator) {
+                                  Lookup* lookup, Validator* validator) {
   m_ds = ds;
   m_node = node;
   m_lookup = lookup;

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -48,7 +48,7 @@ class Mediator {
   Lookup* m_lookup;
 
   /// Pointer to the Validator instance.
-  ValidatorBase* m_validator;
+  Validator* m_validator;
 
   /// The transient DS blockchain.
   DSBlockChain m_dsBlockChain;
@@ -101,7 +101,7 @@ class Mediator {
 
   /// Sets the references to the subclass instances.
   void RegisterColleagues(DirectoryService* ds, Node* node, Lookup* lookup,
-                          ValidatorBase* validator);
+                          Validator* validator);
 
   /// Updates the DS blockchain random for PoW.
   void UpdateDSBlockRand(bool isGenesis = false);

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -565,7 +565,7 @@ bool BlockStorage::GetAllDSBlocks(std::list<DSBlockSharedPtr>& blocks) {
   return true;
 }
 
-bool BlockStorage::GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks) {
+bool BlockStorage::GetAllTxBlocks(std::deque<TxBlockSharedPtr>& blocks) {
   LOG_MARKER();
 
   shared_lock<shared_timed_mutex> g(m_mutexTxBlockchain);

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -244,7 +244,7 @@ class BlockStorage : public Singleton<BlockStorage> {
   bool GetAllDSBlocks(std::list<DSBlockSharedPtr>& blocks);
 
   /// Retrieves all the TxBlocks
-  bool GetAllTxBlocks(std::list<TxBlockSharedPtr>& blocks);
+  bool GetAllTxBlocks(std::deque<TxBlockSharedPtr>& blocks);
 
   /// Retrieves all the TxBodiesTmp
   bool GetAllTxBodiesTmp(std::list<TxnHash>& txnHashes);

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -32,16 +32,17 @@ Retriever::Retriever(Mediator& mediator) : m_mediator(mediator) {}
 
 bool Retriever::RetrieveTxBlocks(bool trimIncompletedBlocks) {
   LOG_MARKER();
-  std::list<TxBlockSharedPtr> blocks;
+  std::deque<TxBlockSharedPtr> blocks;
   std::vector<bytes> extraStateDeltas;
   if (!BlockStorage::GetBlockStorage().GetAllTxBlocks(blocks)) {
     LOG_GENERAL(WARNING, "RetrieveTxBlocks skipped or incompleted");
     return false;
   }
 
-  blocks.sort([](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
-    return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
-  });
+  sort(blocks.begin(), blocks.end(),
+       [](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
+         return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
+       });
 
   unsigned int lastBlockNum = blocks.back()->GetHeader().GetBlockNum();
 

--- a/src/libUtils/ThreadPool.h
+++ b/src/libUtils/ThreadPool.h
@@ -128,6 +128,12 @@ class ThreadPool {
   /// anything else you might want to do
   std::vector<std::thread>& GetThreads() { return _threads; }
 
+  /// Returns the number of jobs in the queue
+  int GetJobsLeft() {
+    std::lock_guard<std::mutex> lock(_jobsLeftMutex);
+    return _jobsLeft;
+  }
+
  private:
   /**
    *  Take the next job in the queue and run it.

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -456,8 +456,9 @@ bool Validator::CheckDirBlocks(
   return ret;
 }
 
-ValidatorBase::TxBlockValidationMsg Validator::CheckTxBlocks(
-    const vector<TxBlock>& txBlocks, const DequeOfNode& dsComm,
+template <class Container>
+Validator::TxBlockValidationMsg Validator::CheckTxBlocks(
+    const Container& txBlocks, const DequeOfNode& dsComm,
     const BlockLink& latestBlockLink) {
   // Verify the last Tx Block
   uint64_t latestDSIndex = get<BlockLinkIndex::DSINDEX>(latestBlockLink);
@@ -470,7 +471,8 @@ ValidatorBase::TxBlockValidationMsg Validator::CheckTxBlocks(
     latestDSIndex--;
   }
 
-  const TxBlock& latestTxBlock = txBlocks.back();
+  const TxBlock& latestTxBlock =
+      GetBlockFromContainer(txBlocks, txBlocks.size() - 1);
 
   if (latestTxBlock.GetHeader().GetDSBlockNum() != latestDSIndex) {
     if (latestDSIndex > latestTxBlock.GetHeader().GetDSBlockNum()) {
@@ -500,16 +502,29 @@ ValidatorBase::TxBlockValidationMsg Validator::CheckTxBlocks(
   unsigned int sIndex = txBlocks.size() - 2;
 
   for (unsigned int i = 0; i < txBlocks.size() - 1; i++) {
-    if (prevBlockHash != txBlocks.at(sIndex).GetHeader().GetMyHash()) {
-      LOG_GENERAL(WARNING,
-                  "Prev hash "
-                      << prevBlockHash << " and hash of blocknum "
-                      << txBlocks.at(sIndex).GetHeader().GetBlockNum());
+    if (prevBlockHash !=
+        GetBlockFromContainer(txBlocks, sIndex).GetHeader().GetMyHash()) {
+      LOG_GENERAL(WARNING, "Prev hash "
+                               << prevBlockHash << " and hash of blocknum "
+                               << GetBlockFromContainer(txBlocks, sIndex)
+                                      .GetHeader()
+                                      .GetBlockNum());
       return TxBlockValidationMsg::INVALID;
     }
-    prevBlockHash = txBlocks.at(sIndex).GetHeader().GetPrevHash();
+    prevBlockHash =
+        GetBlockFromContainer(txBlocks, sIndex).GetHeader().GetPrevHash();
     sIndex--;
   }
 
   return TxBlockValidationMsg::VALID;
 }
+
+template Validator::TxBlockValidationMsg
+Validator::CheckTxBlocks<std::vector<TxBlock>>(
+    const std::vector<TxBlock>& txBlocks, const DequeOfNode& dsComm,
+    const BlockLink& latestBlockLink);
+
+template Validator::TxBlockValidationMsg
+Validator::CheckTxBlocks<std::deque<TxBlockSharedPtr>>(
+    const std::deque<TxBlockSharedPtr>& txBlocks, const DequeOfNode& dsComm,
+    const BlockLink& latestBlockLink);

--- a/src/libValidator/Validator.h
+++ b/src/libValidator/Validator.h
@@ -29,39 +29,19 @@
 
 class Mediator;
 
-class ValidatorBase {
+class Validator {
  public:
   enum TxBlockValidationMsg { VALID = 0, STALEDSINFO, INVALID };
-  virtual ~ValidatorBase() {}
-  virtual std::string name() const = 0;
-
-  virtual bool CheckCreatedTransaction(const Transaction& tx,
-                                       TransactionReceipt& receipt) const = 0;
-
-  virtual bool CheckCreatedTransactionFromLookup(const Transaction& tx) = 0;
-
-  virtual bool CheckDirBlocks(
-      const std::vector<boost::variant<
-          DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
-      const DequeOfNode& initDsComm, const uint64_t& index_num,
-      DequeOfNode& newDSComm) = 0;
-  virtual TxBlockValidationMsg CheckTxBlocks(
-      const std::vector<TxBlock>& txblocks, const DequeOfNode& dsComm,
-      const BlockLink& latestBlockLink) = 0;
-};
-
-class Validator : public ValidatorBase {
- public:
   Validator(Mediator& mediator);
   ~Validator();
-  std::string name() const override { return "Validator"; }
+  std::string name() const { return "Validator"; }
 
   static bool VerifyTransaction(const Transaction& tran);
 
   bool CheckCreatedTransaction(const Transaction& tx,
-                               TransactionReceipt& receipt) const override;
+                               TransactionReceipt& receipt) const;
 
-  bool CheckCreatedTransactionFromLookup(const Transaction& tx) override;
+  bool CheckCreatedTransactionFromLookup(const Transaction& tx);
 
   template <class Container, class DirectoryBlock>
   bool CheckBlockCosignature(const DirectoryBlock& block,
@@ -71,12 +51,25 @@ class Validator : public ValidatorBase {
       const std::vector<boost::variant<
           DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
       const DequeOfNode& initDsComm, const uint64_t& index_num,
-      DequeOfNode& newDSComm) override;
+      DequeOfNode& newDSComm);
+
   // TxBlocks must be in increasing order or it will fail
-  TxBlockValidationMsg CheckTxBlocks(const std::vector<TxBlock>& txBlocks,
+  template <class Container>
+  TxBlockValidationMsg CheckTxBlocks(const Container& txBlocks,
                                      const DequeOfNode& dsComm,
-                                     const BlockLink& latestBlockLink) override;
+                                     const BlockLink& latestBlockLink);
   Mediator& m_mediator;
+
+ private:
+  const TxBlock& GetBlockFromContainer(const std::vector<TxBlock>& txBlocks,
+                                       unsigned int index) const {
+    return txBlocks.at(index);
+  }
+  const TxBlock& GetBlockFromContainer(
+      const std::deque<std::shared_ptr<TxBlock>>& txBlocks,
+      unsigned int index) const {
+    return *txBlocks.at(index);
+  }
 };
 
 #endif  // ZILLIQA_SRC_LIBVALIDATOR_VALIDATOR_H_

--- a/src/libZilliqa/Zilliqa.h
+++ b/src/libZilliqa/Zilliqa.h
@@ -34,7 +34,7 @@ class Zilliqa {
   Mediator m_mediator;
   DirectoryService m_ds;
   Lookup m_lookup;
-  std::shared_ptr<ValidatorBase> m_validator;
+  std::shared_ptr<Validator> m_validator;
   Node m_n;
   // ConsensusUser m_cu; // Note: This is just a test class to demo Consensus
   // usage

--- a/tests/Data/AccountData/Test_Transaction.cpp
+++ b/tests/Data/AccountData/Test_Transaction.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(test1) {
   Address toAddr;
 
   Mediator* m = nullptr;
-  unique_ptr<ValidatorBase> m_validator = make_unique<Validator>(*m);
+  unique_ptr<Validator> m_validator = make_unique<Validator>(*m);
 
   for (unsigned int i = 0; i < toAddr.asArray().size(); i++) {
     toAddr.asArray().at(i) = i + 4;

--- a/tests/Persistence/Test_TxPersistence.cpp
+++ b/tests/Persistence/Test_TxPersistence.cpp
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(testRetrieveAllTheTxBlocksInDB) {
       in_blocks.emplace_back(block);
     }
 
-    std::list<TxBlockSharedPtr> ref_blocks;
+    std::deque<TxBlockSharedPtr> ref_blocks;
     std::list<TxBlock> out_blocks;
     BOOST_CHECK_MESSAGE(
         BlockStorage::GetBlockStorage().GetAllTxBlocks(ref_blocks),
@@ -321,7 +321,8 @@ BOOST_AUTO_TEST_CASE(testRetrieveAllTheTxBlocksInDB) {
       out_blocks.emplace_back(*i);
     }
     BOOST_CHECK_MESSAGE(
-        in_blocks == out_blocks,
+        (in_blocks.size() == out_blocks.size()) &&
+            equal(in_blocks.begin(), in_blocks.end(), out_blocks.begin()),
         "DSBlocks shouldn't change after writting to/ reading from disk");
   }
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
The goal of this PR is to speed up the operation of `Node::CheckIntegrity`, particularly in the part where we check each TxBlock for the presence of both microblocks and transaction bodies. The idea is to perform concurrent checking across a fixed number of threads.

1. Changed `BlockStorage::GetAllTxBlocks` result from `list` to `deque` since `deque` has random element access
1. Templatized `Validator::CheckTxBlocks` so that it supports both these containers of txblocks:
   - `deque<TxBlockSharedPtr>` which we get from `BlockStorage::GetAllTxBlocks`
   - `vector<TxBlock>` which is the type of `Lookup::m_txBlockBuffer`
1. Removed `ValidatorBase` because doing step 2 above complicates the hierarchy, and also because we never actually have other derived classes besides `Validator`
1. Removed the step where the sorted `BlockStorage::GetAllTxBlocks` result is moved to a `vector` since this is no longer necessary after step 2 above
1. Added new lambda `validateTxBlock` inside `Node::CheckIntegrity` which takes in one txblock and does the checking on it
1. Modified the txblocks check inside `Node::CheckIntegrity` to basically use a job pool of size `NUMTHREADS`, with each job/thread running the lambda
1. For each txblock processed we also remove it from the `deque` to slowly gain back the memory
1. Once pool capacity is beyond `MAXJOBSLEFT`, we wait indefinitely before adding more jobs

For testing:
1. `CheckIntegrity` change needs to be tested in 2 scenarios
   - [x] `validateDB`
   - [ ] ~~Startup with sync type `DB_VERIF`~~ (no longer in use)
1. `CheckTxBlocks` using `deque` needs to be tested in 2 scenarios
   - [x] `validateDB`
   - [ ] ~~Send `SetDirectoryBlocksFromSeed` with `m_txBlockBuffer` not empty~~ (skipped)
1. `CheckTxBlocks` using `vector` needs to be tested in 1 scenario
   - [x] Send `SetTxBlockFromSeed`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
