### PR TITLE
support uploading to incremental db every two epoch instead of one epoch

### DIFF
--- a/scripts/upload_incr_DB.py
+++ b/scripts/upload_incr_DB.py
@@ -33,7 +33,7 @@ from logging import handlers
 PERSISTENCE_SNAPSHOT_NAME='incremental'
 STATEDELTA_DIFF_NAME='statedelta'
 BUCKET_NAME='BUCKET_NAME'
-NUM_TXBLOCK = 1
+NUM_TXBLOCK = 2
 NUM_DSBLOCK= "PUT_INCRDB_DSNUMS_WITH_STATEDELTAS_HERE"
 NUM_FINAL_BLOCK_PER_POW= "PUT_NUM_FINAL_BLOCK_PER_POW_HERE"
 TESTNET_NAME= "TEST_NET_NAME"
@@ -365,8 +365,11 @@ def main():
 					time.sleep(1)
 					continue
 
-			if ( (lastBlockNum == 0 and blockNum > -1) or (blockNum >= lastBlockNum + NUM_TXBLOCK)):
-				# try syncing every N txn blks or if its vacaous epoch
+			if ( (lastBlockNum == 0 and blockNum > -1) or 
+				 (blockNum >= lastBlockNum + NUM_TXBLOCK) or
+			     ((blockNum > lastBlockNum) and
+				 (((blockNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) or blockNum % NUM_FINAL_BLOCK_PER_POW == 0)) ):
+				# try syncing every N txn blks or if its vacaous epoch or if its first txblk of new ds epoch
 					logging.info("TxBlk: " + str(blockNum))
 					SetLock()
 					# create temp copy of local persistence

--- a/scripts/upload_incr_DB.py
+++ b/scripts/upload_incr_DB.py
@@ -366,9 +366,9 @@ def main():
 					continue
 
 			if ( (lastBlockNum == 0 and blockNum > -1) or 
-				 (blockNum >= lastBlockNum + NUM_TXBLOCK) or
-			     ((blockNum > lastBlockNum) and
-				 (((blockNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) or blockNum % NUM_FINAL_BLOCK_PER_POW == 0)) ):
+				(blockNum >= lastBlockNum + NUM_TXBLOCK) or
+				((blockNum > lastBlockNum) and
+				(((blockNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) or blockNum % NUM_FINAL_BLOCK_PER_POW == 0)) ):
 				# try syncing every N txn blks or if its vacaous epoch or if its first txblk of new ds epoch
 					logging.info("TxBlk: " + str(blockNum))
 					SetLock()


### PR DESCRIPTION
## Description
This PR will allow reducing of txblk time which could have been blocker for joining and rejoining.
i.e. downloadIncrDB would have gone in loop with small txblk time.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
