### PR TITLE
check if dsguard was pod deleted explicitly

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -574,6 +574,7 @@ bool DirectoryService::FinishRejoinAsDS(bool fetchShardingStruct) {
     LOG_GENERAL(
         INFO,
         "Sent ds guard network information update to lookup and ds committee")
+    m_dsguardPodDelete = false;
   }
 
   m_mode = BACKUP_DS;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -542,6 +542,9 @@ class DirectoryService : public Executable {
   bool m_doRejoinAtDSConsensus = false;
   bool m_doRejoinAtFinalConsensus = false;
 
+  // Indicate if its dsguard and its pod got restarted.
+  bool m_dsguardPodDelete = false;
+
   // GetShards
   uint32_t GetNumShards() const;
   /// Force multicast when sending block to shard

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2275,10 +2275,11 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
         }
       }
     }
-  } else if (m_syncType == SyncType::DS_SYNC ||
-             /* Re-assigned DSGUARD-POD allowed to rejoin only in vacaous epoch
-                for now */
-             (m_syncType == SyncType::GUARD_DS_SYNC &&
+  } else if ((m_syncType == SyncType::DS_SYNC ||
+              m_syncType == SyncType::GUARD_DS_SYNC) &&
+             (!m_mediator.m_ds->m_dsguardPodDelete ||
+              /* Re-assigned DSGUARD-POD allowed to rejoin only in vacaous epoch
+                 for now */
               m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)) {
     if (!m_currDSExpired &&
         m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() <

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -307,6 +307,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
         // downloads and sync from the persistence of incremental db and
         // and rejoins the network as ds guard member
         m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+        m_ds.m_dsguardPodDelete = true;
         m_ds.RejoinAsDS(false);
         break;
       case SyncType::DB_VERIF:


### PR DESCRIPTION
## Description
After the dsguard pod/instance is deleted and started back, add explicitly check if dsguard was pod deleted explicitly and continue syncing until vacuous

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
