### PR TITLE
Remove unused cryptographic sizes constant

### DIFF
--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -38,13 +38,13 @@ const unsigned int UINT128_SIZE = 16;
 const unsigned int INT256_SIZE = 32;
 
 // Cryptographic sizes
-const unsigned int PRIV_KEY_SIZE = 32;
+// const unsigned int PRIV_KEY_SIZE = 32;
 const unsigned int PUB_KEY_SIZE = 33;
 const unsigned int SIGNATURE_CHALLENGE_SIZE = 32;
 const unsigned int SIGNATURE_RESPONSE_SIZE = 32;
-const unsigned int COMMIT_SECRET_SIZE = 32;
-const unsigned int COMMIT_POINT_HASH_SIZE = 32;
-const unsigned int COMMIT_POINT_SIZE = 33;
+// const unsigned int COMMIT_SECRET_SIZE = 32;
+// const unsigned int COMMIT_POINT_HASH_SIZE = 32;
+// const unsigned int COMMIT_POINT_SIZE = 33;
 const unsigned int CHALLENGE_SIZE = 32;
 const unsigned int RESPONSE_SIZE = 32;
 

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -38,13 +38,9 @@ const unsigned int UINT128_SIZE = 16;
 const unsigned int INT256_SIZE = 32;
 
 // Cryptographic sizes
-// const unsigned int PRIV_KEY_SIZE = 32;
 const unsigned int PUB_KEY_SIZE = 33;
 const unsigned int SIGNATURE_CHALLENGE_SIZE = 32;
 const unsigned int SIGNATURE_RESPONSE_SIZE = 32;
-// const unsigned int COMMIT_SECRET_SIZE = 32;
-// const unsigned int COMMIT_POINT_HASH_SIZE = 32;
-// const unsigned int COMMIT_POINT_SIZE = 33;
 const unsigned int CHALLENGE_SIZE = 32;
 const unsigned int RESPONSE_SIZE = 32;
 


### PR DESCRIPTION
## Description
Constants.h still has the constants for cryptographic sizes, which we usually use for serialization.
Since libSchnorr has been moved to its own repo, Zilliqa repo should no longer use those constants.

https://github.com/Zilliqa/Issues/issues/604

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
