### PR TITLE
New mining node to block message before its ready

### DIFF
--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -172,6 +172,11 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     LOG_GENERAL(FATAL, "Archvial lookup is true but not lookup ");
   }
 
+  if(SyncType::NEW_SYNC == syncType){
+    // Setting it earliest before even p2pcomm is instantiated
+    m_n.m_runFromLate = true;
+  }
+
   P2PComm::GetInstance().SetSelfPeer(peer);
   P2PComm::GetInstance().SetSelfKey(key);
 

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -172,7 +172,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     LOG_GENERAL(FATAL, "Archvial lookup is true but not lookup ");
   }
 
-  if(SyncType::NEW_SYNC == syncType){
+  if (SyncType::NEW_SYNC == syncType) {
     // Setting it earliest before even p2pcomm is instantiated
     m_n.m_runFromLate = true;
   }


### PR DESCRIPTION
## Description
This PR will fix the corner case where new node can potentially accept any message before its ready.
Issue - https://github.com/Zilliqa/Issues/issues/608

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
