### PR TITLE
Avoid loading all Tx blocks in valdb

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -275,11 +275,17 @@ void Node::AddGenesisInfo(SyncType syncType) {
 }
 
 bool Node::CheckIntegrity(bool fromIsolatedBinary) {
-  DequeOfNode dsComm;
-
-  for (const auto& dsKey : *m_mediator.m_initialDSCommittee) {
-    dsComm.emplace_back(dsKey, Peer());
+  // Retrieve the latest Tx block from storage
+  TxBlockSharedPtr latestTxBlock;
+  if (!BlockStorage::GetBlockStorage().GetLatestTxBlock(latestTxBlock)) {
+    LOG_GENERAL(WARNING, "BlockStorage::GetLatestTxBlock failed");
+    return false;
   }
+
+  const uint64_t latestTxBlockNum = latestTxBlock->GetHeader().GetBlockNum();
+  const uint64_t latestDSIndex = latestTxBlock->GetHeader().GetDSBlockNum();
+
+  // Load all dir blocks (until latestTxBlockNum) from blocklink chain
   std::list<BlockLink> blocklinks;
   if (!BlockStorage::GetBlockStorage().GetAllBlockLink(blocklinks)) {
     LOG_GENERAL(WARNING, "BlockStorage skipped or incompleted");
@@ -290,20 +296,6 @@ bool Node::CheckIntegrity(bool fromIsolatedBinary) {
     return std::get<BlockLinkIndex::INDEX>(a) <
            std::get<BlockLinkIndex::INDEX>(b);
   });
-
-  std::deque<TxBlockSharedPtr> txBlocks;
-  if (!BlockStorage::GetBlockStorage().GetAllTxBlocks(txBlocks)) {
-    LOG_GENERAL(WARNING, "Failed to get Tx Blocks");
-    return false;
-  }
-
-  sort(txBlocks.begin(), txBlocks.end(),
-       [](const TxBlockSharedPtr& a, const TxBlockSharedPtr& b) {
-         return a->GetHeader().GetBlockNum() < b->GetHeader().GetBlockNum();
-       });
-
-  const auto& latestTxBlockNum = txBlocks.back()->GetHeader().GetBlockNum();
-  const auto& latestDSIndex = txBlocks.back()->GetHeader().GetDSBlockNum();
 
   vector<boost::variant<DSBlock, VCBlock, FallbackBlockWShardingStructure>>
       dirBlocks;
@@ -350,42 +342,102 @@ bool Node::CheckIntegrity(bool fromIsolatedBinary) {
       dirBlocks.emplace_back(*fallbackwshardingstruct);
     }
   }
+
+  // Check the dir blocks
+  DequeOfNode dsComm;
+  for (const auto& dsKey : *m_mediator.m_initialDSCommittee) {
+    dsComm.emplace_back(dsKey, Peer());
+  }
   if (!m_mediator.m_validator->CheckDirBlocks(dirBlocks, dsComm, 1, dsComm)) {
     LOG_GENERAL(WARNING, "Failed to verify Dir Blocks");
     return false;
   }
 
-  if (m_mediator.m_validator->CheckTxBlocks(
-          txBlocks, dsComm, m_mediator.m_blocklinkchain.GetLatestBlockLink()) !=
-      Validator::TxBlockValidationMsg::VALID) {
-    LOG_GENERAL(WARNING, "Failed to verify TxBlocks");
+  // Check the latest Tx Block
+  uint64_t latestDSIndexInBlockLink = get<BlockLinkIndex::DSINDEX>(
+      m_mediator.m_blocklinkchain.GetLatestBlockLink());
+  if (get<BlockLinkIndex::BLOCKTYPE>(
+          m_mediator.m_blocklinkchain.GetLatestBlockLink()) != BlockType::DS) {
+    if (latestDSIndexInBlockLink == 0) {
+      LOG_GENERAL(WARNING, "The latestDSIndex is 0 and blocktype not DS");
+      return false;
+    }
+    latestDSIndexInBlockLink--;
+  }
+  if (latestTxBlock->GetHeader().GetDSBlockNum() != latestDSIndexInBlockLink) {
+    if (latestDSIndexInBlockLink > latestTxBlock->GetHeader().GetDSBlockNum()) {
+      LOG_GENERAL(WARNING, "Latest Tx Block fetched is stale "
+                               << latestDSIndexInBlockLink << " "
+                               << latestTxBlock->GetHeader().GetDSBlockNum());
+      return false;
+    }
+
+    LOG_GENERAL(
+        WARNING,
+        "The latest DS index does not match that of the latest Tx Block DS num"
+            << latestTxBlock->GetHeader().GetDSBlockNum() << " "
+            << latestDSIndexInBlockLink);
     return false;
   }
 
+  if (!m_mediator.m_validator->CheckBlockCosignature(*latestTxBlock, dsComm)) {
+    LOG_GENERAL(WARNING, "CheckBlockCosignature failed");
+    return false;
+  }
+
+  // Check the other Tx blocks
   shared_ptr<bool> result = make_shared<bool>(new bool(true));
 
-  auto validateTxBlock = [&, result, fromIsolatedBinary](
-                             TxBlockSharedPtr txBlock) mutable -> void {
+  // This lambda performs all the checks on one Tx block
+  auto validateOneTxBlock =
+      [&, result, fromIsolatedBinary](uint64_t blockNum) mutable -> void {
+    // Abort checking if overall result is false already
     if (!*result && !fromIsolatedBinary) {
       return;
     }
-    const uint64_t& blockNum = txBlock->GetHeader().GetBlockNum();
     if (fromIsolatedBinary && (blockNum % 100 == 0)) {
-      cout << "On tx block " << blockNum << endl;
+      LOG_GENERAL(INFO, "On Tx block " << blockNum);
     }
 
-    const auto& microblockInfos = txBlock->GetMicroBlockInfos();
+    // Fetch the block
+    TxBlockSharedPtr txBlock;
+    if (!BlockStorage::GetBlockStorage().GetTxBlock(blockNum, txBlock)) {
+      LOG_GENERAL(WARNING, "Missing FB: " << blockNum);
+      *result = false;
+      return;
+    }
 
+    // Check that prevHash field == hash of previous Tx block
+    if (blockNum > 0) {
+      TxBlockSharedPtr txBlockPrev;
+      if (!BlockStorage::GetBlockStorage().GetTxBlock(blockNum - 1,
+                                                      txBlockPrev)) {
+        LOG_GENERAL(WARNING, "Missing FB: " << blockNum - 1);
+        *result = false;
+        return;
+      }
+      const BlockHash& prevHash = txBlock->GetHeader().GetPrevHash();
+      const BlockHash& prevBlockHash = txBlockPrev->GetHeader().GetMyHash();
+      if (prevHash != prevBlockHash) {
+        LOG_CHECK_FAIL("Prev hash", prevHash, prevBlockHash);
+        *result = false;
+        return;
+      }
+    }
+
+    // Check the microblocks
+    const auto& microblockInfos = txBlock->GetMicroBlockInfos();
     for (const auto& mbInfo : microblockInfos) {
       MicroBlockSharedPtr mbptr;
       LOG_GENERAL(INFO, "FB: " << txBlock->GetHeader().GetBlockNum()
                                << " MB: " << mbInfo.m_shardId);
-      /// Skip because empty microblocks are not stored
+      // Skip because empty microblocks are not stored
       if (mbInfo.m_txnRootHash == TxnHash()) {
         continue;
       }
       if (BlockStorage::GetBlockStorage().GetMicroBlock(mbInfo.m_microBlockHash,
                                                         mbptr)) {
+        // Check the transactions
         if (LOOKUP_NODE_MODE) {
           const auto& tranHashes = mbptr->GetTranHashes();
           for (const auto& tranHash : tranHashes) {
@@ -417,12 +469,11 @@ bool Node::CheckIntegrity(bool fromIsolatedBinary) {
   const int MAXJOBSLEFT = NUMTHREADS * 3;
   ThreadPool validatePool(NUMTHREADS, "ValidatePool");
 
-  while (!txBlocks.empty()) {
-    TxBlockSharedPtr txBlock = txBlocks.front();
-    txBlocks.pop_front();
+  uint64_t blockNum = 0;
 
-    validatePool.AddJob([validateTxBlock, txBlock]() mutable -> void {
-      validateTxBlock(txBlock);
+  while (blockNum <= latestTxBlockNum) {
+    validatePool.AddJob([validateOneTxBlock, blockNum]() mutable -> void {
+      validateOneTxBlock(blockNum);
     });
 
     if (!*result && !fromIsolatedBinary) {
@@ -431,6 +482,8 @@ bool Node::CheckIntegrity(bool fromIsolatedBinary) {
 
     while (validatePool.GetJobsLeft() > MAXJOBSLEFT) {
     }
+
+    blockNum++;
   }
 
   while (validatePool.GetJobsLeft() > 0) {

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -190,6 +190,8 @@ class BlockStorage : public Singleton<BlockStorage> {
   /// Retrieves the requested Tx block.
   bool GetTxBlock(const uint64_t& blockNum, TxBlockSharedPtr& block);
 
+  bool GetLatestTxBlock(TxBlockSharedPtr& block);
+
   bool CheckTxBody(const dev::h256& key);
 
   bool ReleaseDB();

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -462,9 +462,8 @@ bool Validator::CheckDirBlocks(
   return ret;
 }
 
-template <class Container>
 Validator::TxBlockValidationMsg Validator::CheckTxBlocks(
-    const Container& txBlocks, const DequeOfNode& dsComm,
+    const std::vector<TxBlock>& txBlocks, const DequeOfNode& dsComm,
     const BlockLink& latestBlockLink) {
   // Verify the last Tx Block
   uint64_t latestDSIndex = get<BlockLinkIndex::DSINDEX>(latestBlockLink);
@@ -477,8 +476,7 @@ Validator::TxBlockValidationMsg Validator::CheckTxBlocks(
     latestDSIndex--;
   }
 
-  const TxBlock& latestTxBlock =
-      GetBlockFromContainer(txBlocks, txBlocks.size() - 1);
+  const TxBlock& latestTxBlock = txBlocks.back();
 
   if (latestTxBlock.GetHeader().GetDSBlockNum() != latestDSIndex) {
     if (latestDSIndex > latestTxBlock.GetHeader().GetDSBlockNum()) {
@@ -508,29 +506,16 @@ Validator::TxBlockValidationMsg Validator::CheckTxBlocks(
   unsigned int sIndex = txBlocks.size() - 2;
 
   for (unsigned int i = 0; i < txBlocks.size() - 1; i++) {
-    if (prevBlockHash !=
-        GetBlockFromContainer(txBlocks, sIndex).GetHeader().GetMyHash()) {
-      LOG_GENERAL(WARNING, "Prev hash "
-                               << prevBlockHash << " and hash of blocknum "
-                               << GetBlockFromContainer(txBlocks, sIndex)
-                                      .GetHeader()
-                                      .GetBlockNum());
+    if (prevBlockHash != txBlocks.at(sIndex).GetHeader().GetMyHash()) {
+      LOG_GENERAL(WARNING,
+                  "Prev hash "
+                      << prevBlockHash << " and hash of blocknum "
+                      << txBlocks.at(sIndex).GetHeader().GetBlockNum());
       return TxBlockValidationMsg::INVALID;
     }
-    prevBlockHash =
-        GetBlockFromContainer(txBlocks, sIndex).GetHeader().GetPrevHash();
+    prevBlockHash = txBlocks.at(sIndex).GetHeader().GetPrevHash();
     sIndex--;
   }
 
   return TxBlockValidationMsg::VALID;
 }
-
-template Validator::TxBlockValidationMsg
-Validator::CheckTxBlocks<std::vector<TxBlock>>(
-    const std::vector<TxBlock>& txBlocks, const DequeOfNode& dsComm,
-    const BlockLink& latestBlockLink);
-
-template Validator::TxBlockValidationMsg
-Validator::CheckTxBlocks<std::deque<TxBlockSharedPtr>>(
-    const std::deque<TxBlockSharedPtr>& txBlocks, const DequeOfNode& dsComm,
-    const BlockLink& latestBlockLink);

--- a/src/libValidator/Validator.h
+++ b/src/libValidator/Validator.h
@@ -54,22 +54,10 @@ class Validator {
       DequeOfNode& newDSComm);
 
   // TxBlocks must be in increasing order or it will fail
-  template <class Container>
-  TxBlockValidationMsg CheckTxBlocks(const Container& txBlocks,
+  TxBlockValidationMsg CheckTxBlocks(const std::vector<TxBlock>& txBlocks,
                                      const DequeOfNode& dsComm,
                                      const BlockLink& latestBlockLink);
   Mediator& m_mediator;
-
- private:
-  const TxBlock& GetBlockFromContainer(const std::vector<TxBlock>& txBlocks,
-                                       unsigned int index) const {
-    return txBlocks.at(index);
-  }
-  const TxBlock& GetBlockFromContainer(
-      const std::deque<std::shared_ptr<TxBlock>>& txBlocks,
-      unsigned int index) const {
-    return *txBlocks.at(index);
-  }
 };
 
 #endif  // ZILLIQA_SRC_LIBVALIDATOR_VALIDATOR_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR removes the use of `GetAllTxBlocks` from `CheckIntegrity`.
It also removes the call to `CheckTxBlocks` which used the output of `GetAllTxBlocks`.

Since `CheckTxBlocks` is no longer called, `CheckTxBlocks` has also been reverted back to its simpler non-template version before PR https://github.com/Zilliqa/Zilliqa/pull/1922 (since `deque` of TxBlocks won't be used anymore).

Performance-wise, checking of Tx blocks is still threaded.
However, blocks are now fetched on the fly.
Each Tx block check requires fetching block `n` and block `n-1` (for prevhash check).

Additional logs are displayed to stdout for easier evaluation of checking time.  Here you can see checking of the Tx blocks for 11 months worth of mainnet chain data takes around 11 minutes.

```
root@antonio3-validator-0:/run/zilliqa# ./validateDB 
[19-12-27T02:22:39] Latest Tx block = 344079
[19-12-27T02:22:39] Latest DS block = 3441
[19-12-27T02:22:39] Loading dir blocks
[19-12-27T02:22:41] Checking dir blocks
[19-12-27T02:23:23] Checking Tx blocks
[19-12-27T02:23:23] On Tx block 0
[19-12-27T02:23:23] On Tx block 1000
[19-12-27T02:23:23] On Tx block 2000
[19-12-27T02:23:23] On Tx block 3000
[19-12-27T02:23:24] On Tx block 4000
[19-12-27T02:23:24] On Tx block 5000
...
[19-12-27T02:34:08] On Tx block 340000
[19-12-27T02:34:11] On Tx block 341000
[19-12-27T02:34:13] On Tx block 342000
[19-12-27T02:34:15] On Tx block 343000
[19-12-27T02:34:17] On Tx block 344000
[19-12-27T02:34:18] Done
```

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
