### PR TITLE
Check PubKey, not IP, in LoadShardingStructure

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -208,7 +208,7 @@ bool Node::LoadShardingStructure(bool callByRetrieve) {
                                      std::get<SHARD_NODE_PEER>(shardNode));
 
       // Zero out my IP to avoid sending to myself
-      if (m_mediator.m_selfPeer == m_myShardMembers->back().second) {
+      if (m_mediator.m_selfKey.second == m_myShardMembers->back().first) {
         m_consensusMyID = index;  // Set my ID
         m_myShardMembers->back().second = Peer();
         foundMe = true;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`LoadShardingStructure` is using IP to check for self's presence in the list.  This is an issue in cases where IP has changed, particularly when re-bootstrapping the testnet during a recovery operation.

Tested during mainnet recovery rehearsal.

Recent change to libSchnorr git commit is also included in this PR.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
