### PR TITLE
Fix retryCount corner case

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1657,7 +1657,7 @@ bool Lookup::ProcessGetCosigsRewardsFromSeed(
 
   TxBlockSharedPtr txblkPtr;
   int retryCount = MAX_FETCH_BLOCK_RETRIES;
-  while (retryCount-- > 0) {
+  while (retryCount > 0) {
     if (!BlockStorage::GetBlockStorage().GetTxBlock(blockNum, txblkPtr)) {
       LOG_GENERAL(WARNING,
                   "Failed to fetch tx block " << blockNum << " , retry... ");
@@ -1665,6 +1665,8 @@ bool Lookup::ProcessGetCosigsRewardsFromSeed(
     } else {
       break;
     }
+
+    --retryCount;
   }
 
   if (retryCount == 0) {
@@ -1681,7 +1683,7 @@ bool Lookup::ProcessGetCosigsRewardsFromSeed(
     }
     MicroBlockSharedPtr mbptr;
     retryCount = MAX_FETCH_BLOCK_RETRIES;
-    while (retryCount-- > 0) {
+    while (retryCount > 0) {
       if (!BlockStorage::GetBlockStorage().GetMicroBlock(
               mbInfo.m_microBlockHash, mbptr)) {
         LOG_GENERAL(WARNING, "Could not get MicroBlock "
@@ -1690,6 +1692,8 @@ bool Lookup::ProcessGetCosigsRewardsFromSeed(
       } else {
         break;
       }
+
+      --retryCount;
     }
     if (retryCount == 0) {
       LOG_GENERAL(WARNING, "Failed to fetch MicroBlock "


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In `ProcessGetCosigsRewardsFromSeed`, in the event that all retries are exhausted, `retryCount == 0` does not evaluate to true because the check `retryCount-- > 0` changes `retryCount` to -1.  This causes a crash in the lookups.

Tested during upgrade rehearsal.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
