### PR TITLE
Remove ipMapping.xml only after first DS epoch

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -503,6 +503,12 @@ bool Node::ProcessVCDSBlocksMessage(const bytes& message,
     return false;
   }
 
+  // During RECOVERY_ALL_SYNC, the ipMapping.xml should be removed only after
+  // first DS epoch has passed, because if RejoinAsNormal is triggered during
+  // the first DS epoch, the ipMapping.xml will be needed again to map the DS
+  // committee to the correct IP addresses.
+  RemoveIpMapping();
+
   LogReceivedDSBlockDetails(dsblock);
 
   // Add to block chain and Store the DS block to disk.

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -821,8 +821,6 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         }
       }
     }
-
-    RemoveIpMapping();
   }
 
   bool bInShardStructure = false;

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1031,8 +1031,6 @@ void Node::RemoveIpMapping() {
     } else {
       LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " cannot be removed!");
     }
-  } else {
-    LOG_GENERAL(WARNING, IP_MAPPING_FILE_NAME << " not existed!");
   }
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Currently we delete ipMapping.xml the moment it's been used in `StartRetrieveHistory`.
The safer deletion point is after the first DS epoch has passed.

Tested during upgrade rehearsal.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
