### PR TITLE
Use Buffered address when append and add DEPTH in transition field

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -119,7 +119,7 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   /// Contract Calling
   /// verify the return from scilla_runner for calling is valid
   bool ParseCallContract(uint64_t& gasRemained, const std::string& runnerPrint,
-                         TransactionReceipt& receipt);
+                         TransactionReceipt& receipt, uint32_t tree_depth);
   /// convert the interpreter output into parsable json object for calling
   bool ParseCallContractOutput(Json::Value& jsonOutput,
                                const std::string& runnerPrint,
@@ -127,7 +127,8 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   /// parse the output from interpreter for calling and update states
   bool ParseCallContractJsonOutput(const Json::Value& _json,
                                    uint64_t& gasRemained,
-                                   TransactionReceipt& receipt);
+                                   TransactionReceipt& receipt,
+                                   uint32_t tree_depth);
 
   /// Utility functions
   /// get the json format file for the current blocknum

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -1209,6 +1209,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
   Account* account = nullptr;
 
   if (!ret) {
+    // Buffer the Addr for current caller
     Address curContractAddr = m_curContractAddr;
     for (const auto& msg : _json["messages"]) {
       LOG_GENERAL(INFO, "Process new message");
@@ -1265,7 +1266,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
       }
 
       m_storageRootUpdateBufferAtomic.emplace(curContractAddr);
-      receipt.AddTransition(m_curContractAddr, msg);
+      receipt.AddTransition(curContractAddr, msg);
 
       if (ENABLE_CHECK_PERFORMANCE_LOG) {
         LOG_GENERAL(DEBUG,

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -1399,7 +1399,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
 
       m_curSenderAddr = curContractAddr;
       m_curContractAddr = recipient;
-      if (!ParseCallContract(gasRemained, runnerPrint, receipt, tree_depth++)) {
+      if (!ParseCallContract(gasRemained, runnerPrint, receipt, tree_depth + 1)) {
         LOG_GENERAL(WARNING, "ParseCallContract failed of calling contract: "
                                  << recipient);
         return false;

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -1399,7 +1399,8 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
 
       m_curSenderAddr = curContractAddr;
       m_curContractAddr = recipient;
-      if (!ParseCallContract(gasRemained, runnerPrint, receipt, tree_depth + 1)) {
+      if (!ParseCallContract(gasRemained, runnerPrint, receipt,
+                             tree_depth + 1)) {
         LOG_GENERAL(WARNING, "ParseCallContract failed of calling contract: "
                                  << recipient);
         return false;

--- a/src/libData/AccountData/TransactionReceipt.cpp
+++ b/src/libData/AccountData/TransactionReceipt.cpp
@@ -24,7 +24,7 @@ using namespace boost::multiprecision;
 
 TransactionReceipt::TransactionReceipt() {
   update();
-  m_errorObj[to_string(m_depth)] = Json::arrayValue;
+  m_errorObj[to_string(m_edge)] = Json::arrayValue;
 }
 
 bool TransactionReceipt::Serialize(bytes& dst, unsigned int offset) const {
@@ -66,15 +66,15 @@ void TransactionReceipt::SetResult(const bool& result) {
   }
 }
 
-void TransactionReceipt::AddDepth() {
+void TransactionReceipt::AddEdge() {
   LOG_MARKER();
-  m_depth++;
-  m_errorObj[to_string(m_depth)] = Json::arrayValue;
+  m_edge++;
+  m_errorObj[to_string(m_edge)] = Json::arrayValue;
 }
 
 void TransactionReceipt::AddError(const unsigned int& errCode) {
   LOG_GENERAL(INFO, "AddError: " << errCode);
-  m_errorObj[to_string(m_depth)].append(errCode);
+  m_errorObj[to_string(m_edge)].append(errCode);
 }
 
 void TransactionReceipt::SetCumGas(const uint64_t& cumGas) {
@@ -100,10 +100,12 @@ void TransactionReceipt::AddEntry(const LogEntry& entry) {
 }
 
 void TransactionReceipt::AddTransition(const Address& addr,
-                                       const Json::Value& transition) {
+                                       const Json::Value& transition,
+                                       uint32_t tree_depth) {
   Json::Value _json;
   _json["addr"] = "0x" + addr.hex();
   _json["msg"] = transition;
+  _json["depth"] = tree_depth;
   m_tranReceiptObj["transitions"].append(_json);
 }
 
@@ -119,7 +121,7 @@ void TransactionReceipt::clear() {
   m_tranReceiptStr.clear();
   m_tranReceiptObj.clear();
   m_errorObj.clear();
-  m_depth = 0;
+  m_edge = 0;
   update();
 }
 

--- a/src/libData/AccountData/TransactionReceipt.h
+++ b/src/libData/AccountData/TransactionReceipt.h
@@ -58,7 +58,7 @@ class TransactionReceipt : public SerializableDataBlock {
   Json::Value m_tranReceiptObj = Json::nullValue;
   std::string m_tranReceiptStr;
   uint64_t m_cumGas = 0;
-  unsigned int m_depth = 0;
+  unsigned int m_edge = 0;
   Json::Value m_errorObj;
 
  public:
@@ -67,12 +67,13 @@ class TransactionReceipt : public SerializableDataBlock {
   bool Deserialize(const bytes& src, unsigned int offset) override;
   void SetResult(const bool& result);
   void AddError(const unsigned int& errCode);
-  void AddDepth();
+  void AddEdge();
   void InstallError();
   void SetCumGas(const uint64_t& cumGas);
   void SetEpochNum(const uint64_t& epochNum);
   void AddEntry(const LogEntry& entry);
-  void AddTransition(const Address& addr, const Json::Value& transition);
+  void AddTransition(const Address& addr, const Json::Value& transition,
+                     uint32_t tree_depth);
   void RemoveAllTransitions();
   void CleanEntry();
   const std::string& GetString() const { return m_tranReceiptStr; }

--- a/src/libData/AccountData/TransactionReceipt.h
+++ b/src/libData/AccountData/TransactionReceipt.h
@@ -117,7 +117,6 @@ class TransactionWithReceipt : public SerializableDataBlock {
 
     SHA2<HashType::HASH_VARIANT_256> sha2;
     for (const auto& tr : txrs) {
-      LOG_GENERAL(INFO, "receipt: " << tr.GetTransactionReceipt().GetString());
       sha2.Update(DataConversion::StringToCharArray(
           tr.GetTransactionReceipt().GetString()));
     }

--- a/src/libData/AccountData/TransactionReceipt.h
+++ b/src/libData/AccountData/TransactionReceipt.h
@@ -117,6 +117,7 @@ class TransactionWithReceipt : public SerializableDataBlock {
 
     SHA2<HashType::HASH_VARIANT_256> sha2;
     for (const auto& tr : txrs) {
+      LOG_GENERAL(INFO, "receipt: " << tr.GetTransactionReceipt().GetString());
       sha2.Update(DataConversion::StringToCharArray(
           tr.GetTransactionReceipt().GetString()));
     }

--- a/tests/Data/AccountData/Test_TransactionReceipt.cpp
+++ b/tests/Data/AccountData/Test_TransactionReceipt.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(accountstoretest)
 
 void setDepth(TransactionReceipt& tr, uint8_t depth) {
   for (int i = 0; i < depth; i++) {
-    tr.AddDepth();
+    tr.AddEdge();
   }
 }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
- Change m_curContractAddr -> curContractAddr to avoid chain call affecting the current caller address;
- Change m_depth -> m_edge with more relevant meaning
- Add "depth" field in receipt transition field to indicate the current depth in the transition tree of the message

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
