### PR TITLE
Add DisablePoW

### DIFF
--- a/scripts/miner_info.py
+++ b/scripts/miner_info.py
@@ -116,6 +116,7 @@ def make_options_dictionary(options_dict):
 	options_dict["difficulty"] = "GetPrevDifficulty"
 	options_dict["set_sendsccallstods"] = "ToggleSendSCCallsToDS"
 	options_dict["get_sendsccallstods"] = "GetSendSCCallsToDS"
+	options_dict["disable_pow"] = "DisablePoW"
 
 
 def ProcessResponseCore(resp, param):

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -45,7 +45,8 @@ Mediator::Mediator(const PairOfKey& key, const Peer& peer)
       m_txBlockRand({{0}}),
       m_isRetrievedHistory(false),
       m_isVacuousEpoch(false),
-      m_curSWInfo() {
+      m_curSWInfo(),
+      m_disablePoW(false) {
   SetupLogLevel();
 }
 

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -18,6 +18,7 @@
 #ifndef ZILLIQA_SRC_LIBMEDIATOR_MEDIATOR_H_
 #define ZILLIQA_SRC_LIBMEDIATOR_MEDIATOR_H_
 
+#include <atomic>
 #include <deque>
 
 #include <Schnorr.h>
@@ -92,6 +93,9 @@ class Mediator {
 
   /// Record current software information which already downloaded to this node
   SWInfo m_curSWInfo;
+
+  /// Prevent node from mining PoW at the next DS epoch
+  std::atomic<bool> m_disablePoW;
 
   /// Constructor.
   Mediator(const PairOfKey& key, const Peer& peer);

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -281,13 +281,14 @@ void Node::InitiatePoW() {
     return;
   }
 
+  SetState(POW_SUBMISSION);
+
   if (m_mediator.m_disablePoW) {
     LOG_GENERAL(INFO, "Skipping PoW");
     m_mediator.m_disablePoW = false;
     return;
   }
 
-  SetState(POW_SUBMISSION);
   POW::GetInstance().EthashConfigureClient(
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1,
       FULL_DATASET_MINE);

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -281,6 +281,12 @@ void Node::InitiatePoW() {
     return;
   }
 
+  if (m_mediator.m_disablePoW) {
+    LOG_GENERAL(INFO, "Skipping PoW");
+    m_mediator.m_disablePoW = false;
+    return;
+  }
+
   SetState(POW_SUBMISSION);
   POW::GetInstance().EthashConfigureClient(
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1,

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -285,7 +285,6 @@ void Node::InitiatePoW() {
 
   if (m_mediator.m_disablePoW) {
     LOG_GENERAL(INFO, "Skipping PoW");
-    m_mediator.m_disablePoW = false;
     return;
   }
 

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -90,6 +90,10 @@ StatusServer::StatusServer(Mediator& mediator,
       jsonrpc::Procedure("GetSendSCCallsToDS", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, NULL),
       &StatusServer::GetSendSCCallsToDSI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("DisablePoW", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_OBJECT, NULL),
+      &StatusServer::DisablePoWI);
 }
 
 string StatusServer::GetLatestEpochStatesUpdated() {
@@ -240,4 +244,12 @@ bool StatusServer::GetSendSCCallsToDS() {
                            "Not to be queried on non-lookup or seed");
   }
   return m_mediator.m_lookup->m_sendSCCallsToDS;
+}
+
+bool StatusServer::DisablePoW() {
+  if (LOOKUP_NODE_MODE) {
+    throw JsonRpcException(RPC_INVALID_REQUEST, "Not to be queried on lookup");
+  }
+  m_mediator.m_disablePoW = true;
+  return true;
 }

--- a/src/libServer/StatusServer.h
+++ b/src/libServer/StatusServer.h
@@ -67,6 +67,11 @@ class StatusServer : public Server,
     (void)request;
     response = this->GetSendSCCallsToDS();
   }
+  inline virtual void DisablePoWI(const Json::Value& request,
+                                  Json::Value& response) {
+    (void)request;
+    response = this->DisablePoW();
+  }
 
   Json::Value IsTxnInMemPool(const std::string& tranID);
   bool AddToBlacklistExclusion(const std::string& ipAddr);
@@ -77,6 +82,7 @@ class StatusServer : public Server,
   Json::Value GetDSCommittee();
   bool ToggleSendSCCallsToDS();
   bool GetSendSCCallsToDS();
+  bool DisablePoW();
 };
 
 #endif  // ZILLIQA_SRC_LIBSERVER_STATUSSERVER_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR provides a clean way of taking down a node.

The local API DisablePoW prevents the node from mining in the next epoch, thereby excluding it from being sharded. Once excluded, it is then easier to take down the node permanently.

This way is "clean" as opposed to taking down a node in the middle of an epoch, which interrupts the progress of consensus.

Before disabling:
```
root@nunez2-normal-10:/run/zilliqa# python /zilliqa/scripts/miner_info.py type
Shard Node of shard 0
```

Disable:
```
root@nunez2-normal-10:/run/zilliqa# python /zilliqa/scripts/miner_info.py disable_pow
True
```

After disabling, node stays stuck in vacuous epoch:
```
root@nunez2-normal-10:/run/zilliqa# python /zilliqa/scripts/miner_info.py epoch
5
```

Sample log:
```
[INFO][  175][20-02-12T04:29:36.369][ibNode/Node.cpp:1881][SetState            ] [Epoch 5] Node State = POW_SUBMISSION
[INFO][  175][20-02-12T04:29:36.369][ckProcessing.cpp:287][InitiatePoW         ] Skipping PoW
[INFO][  175][20-02-12T04:29:36.369][ckProcessing.cpp:543][ProcessFinalBlockCor] END
[INFO][  175][20-02-12T04:29:36.369][ckProcessing.cpp:536][ProcessFinalBlock   ] END
[INFO][  394][20-02-12T04:29:36.369][AccountStore.cpp:221][MoveUpdatesToDisk   ] BEG
[INFO][  394][20-02-12T04:29:36.369][ractStorage2.cpp:968][CommitStateDB       ] BEG
[INFO][  394][20-02-12T04:29:36.369][actStorage2.cpp:1006][InitTempState       ] BEG
[INFO][  394][20-02-12T04:29:36.369][actStorage2.cpp:1006][InitTempState       ] END
[INFO][  394][20-02-12T04:29:36.369][ractStorage2.cpp:968][CommitStateDB       ] END
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:696][PutStateRoot        ] BEG
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:696][PutStateRoot        ] END
[INFO][  394][20-02-12T04:29:36.369][AccountStore.cpp:221][MoveUpdatesToDisk   ] END
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:703][PutLatestEpochStates] BEG
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:703][PutLatestEpochStates] END
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:689][PutMetadata         ] BEG
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:689][PutMetadata         ] END
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:711][PutEpochFin         ] BEG
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:689][PutMetadata         ] BEG
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:689][PutMetadata         ] END
[INFO][  394][20-02-12T04:29:36.369][BlockStorage.cpp:711][PutEpochFin         ] END
```

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
