### PR TITLE
Exclude copyright line from license_checker

### DIFF
--- a/scripts/license_checker.sh
+++ b/scripts/license_checker.sh
@@ -19,7 +19,6 @@
 banner_file=$(mktemp)
 
 cat <<EOF > $banner_file
-Copyright (C) 2019 Zilliqa
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -76,8 +75,8 @@ do
     filename=$(basename $file)
     ext="${filename##*.}"
     case "$ext" in
-        cpp|hpp|tpp|h|c) check_license $file 1 3 ;;
-        py|sh) check_license $file 1 2 ;;
+        cpp|hpp|tpp|h|c) check_license $file 2 3 ;;
+        py|sh) check_license $file 2 2 ;;
         *) echo unsupported format;;
     esac
 done


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
license_checker includes the copyright line, which has the year hard-coded to 2019.
This causes the checker to fail for new files with copyright year 2020.
Better to just exclude the copyright line from the check.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
