### PR TITLE
Add StakingServer

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -154,6 +154,9 @@
         <SCILLA_IPC_SOCKET_PATH>/tmp/zilliqa.sock</SCILLA_IPC_SOCKET_PATH>
         <ENABLE_WEBSOCKET>false</ENABLE_WEBSOCKET>
         <WEBSOCKET_PORT>4401</WEBSOCKET_PORT>
+        <!-- Only for lookup nodes used for staking data retrieval -->
+        <ENABLE_STAKING_RPC>false</ENABLE_STAKING_RPC>
+        <STAKING_RPC_PORT>4501</STAKING_RPC_PORT>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -153,6 +153,9 @@
         <SCILLA_IPC_SOCKET_PATH>/tmp/zilliqa.sock</SCILLA_IPC_SOCKET_PATH>
         <ENABLE_WEBSOCKET>false</ENABLE_WEBSOCKET>
         <WEBSOCKET_PORT>4401</WEBSOCKET_PORT>
+        <!-- Only for lookup nodes used for staking data retrieval -->
+        <ENABLE_STAKING_RPC>false</ENABLE_STAKING_RPC>
+        <STAKING_RPC_PORT>4501</STAKING_RPC_PORT>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -305,9 +305,13 @@ const unsigned int HEARTBEAT_INTERVAL_IN_SECONDS{
 // RPC Constants
 const unsigned int LOOKUP_RPC_PORT{
     ReadConstantNumeric("LOOKUP_RPC_PORT", "node.jsonrpc.")};
+const unsigned int STAKING_RPC_PORT{
+    ReadConstantNumeric("STAKING_RPC_PORT", "node.jsonrpc.")};
 const unsigned int STATUS_RPC_PORT{
     ReadConstantNumeric("STATUS_RPC_PORT", "node.jsonrpc.")};
 const std::string IP_TO_BIND{ReadConstantString("IP_TO_BIND", "node.jsonrpc.")};
+const bool ENABLE_STAKING_RPC{
+    ReadConstantString("ENABLE_STAKING_RPC", "node.jsonrpc.") == "true"};
 const bool ENABLE_STATUS_RPC{
     ReadConstantString("ENABLE_STATUS_RPC", "node.jsonrpc.") == "true"};
 const unsigned int NUM_SHARD_PEER_TO_REVEAL{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -259,9 +259,11 @@ extern const unsigned int HEARTBEAT_INTERVAL_IN_SECONDS;
 
 // RPC Constants
 extern const unsigned int LOOKUP_RPC_PORT;
+extern const unsigned int STAKING_RPC_PORT;
 extern const unsigned int STATUS_RPC_PORT;
 extern const std::string IP_TO_BIND;  // Only for non-lookup nodes
-extern const bool ENABLE_STATUS_RPC;  //
+extern const bool ENABLE_STAKING_RPC;
+extern const bool ENABLE_STATUS_RPC;
 extern const unsigned int NUM_SHARD_PEER_TO_REVEAL;
 extern const std::string SCILLA_IPC_SOCKET_PATH;
 extern bool ENABLE_WEBSOCKET;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -47,6 +47,7 @@
 #include "libPersistence/BlockStorage.h"
 #include "libServer/GetWorkServer.h"
 #include "libServer/LookupServer.h"
+#include "libServer/StakingServer.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/DetachedFunction.h"
 #include "libUtils/GetTxnFromFile.h"
@@ -2314,6 +2315,14 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
             }
           }
           m_isFirstLoop = true;
+
+          if (m_stakingServer) {
+            if (m_stakingServer->StartListening()) {
+              LOG_GENERAL(INFO, "Staking Server started to listen again");
+            } else {
+              LOG_GENERAL(WARNING, "Staking Server couldn't start");
+            }
+          }
         }
         m_currDSExpired = false;
       }
@@ -2603,6 +2612,14 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
             LOG_GENERAL(WARNING, "API Server couldn't start");
           }
         }
+
+        if (m_stakingServer) {
+          if (m_stakingServer->StartListening()) {
+            LOG_GENERAL(INFO, "Staking Server started to listen again");
+          } else {
+            LOG_GENERAL(WARNING, "Staking Server couldn't start");
+          }
+        }
       }
     }
     m_currDSExpired = false;
@@ -2641,6 +2658,14 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
           LOG_GENERAL(INFO, "API Server started to listen again");
         } else {
           LOG_GENERAL(WARNING, "API Server couldn't start");
+        }
+      }
+
+      if (m_stakingServer) {
+        if (m_stakingServer->StartListening()) {
+          LOG_GENERAL(INFO, "Staking Server started to listen again");
+        } else {
+          LOG_GENERAL(WARNING, "Staking Server couldn't start");
         }
       }
     }
@@ -3550,6 +3575,10 @@ void Lookup::RejoinAsNewLookup(bool fromLookup) {
         m_lookupServer->StopListening();
         LOG_GENERAL(INFO, "API Server stopped listen for syncing");
       }
+      if (m_stakingServer) {
+        m_stakingServer->StopListening();
+        LOG_GENERAL(INFO, "Staking Server stopped listen for syncing");
+      }
     };
     DetachedFunction(1, func1);
 
@@ -3605,6 +3634,10 @@ void Lookup::RejoinAsLookup() {
       if (m_lookupServer) {
         m_lookupServer->StopListening();
         LOG_GENERAL(INFO, "API Server stopped listen for syncing");
+      }
+      if (m_stakingServer) {
+        m_stakingServer->StopListening();
+        LOG_GENERAL(INFO, "Staking Server stopped listen for syncing");
       }
     };
 

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -48,6 +48,7 @@
 class Mediator;
 class Synchronizer;
 class LookupServer;
+class StakingServer;
 
 // The "first" element in the pair is a map of shard to its transactions
 // The "second" element in the pair counts the total number of transactions in
@@ -132,6 +133,7 @@ class Lookup : public Executable {
   std::vector<TxBlock> m_txBlockBuffer;
 
   std::shared_ptr<LookupServer> m_lookupServer;
+  std::shared_ptr<StakingServer> m_stakingServer;
 
   bytes ComposeGetDSInfoMessage(bool initialDS = false);
   bytes ComposeGetStateMessage();
@@ -408,6 +410,10 @@ class Lookup : public Executable {
 
   void SetLookupServer(std::shared_ptr<LookupServer> lookupServer) {
     m_lookupServer = std::move(lookupServer);
+  }
+
+  void SetStakingServer(std::shared_ptr<StakingServer> stakingServer) {
+    m_stakingServer = std::move(stakingServer);
   }
 
   bool m_fetchedOfflineLookups = false;

--- a/src/libServer/CMakeLists.txt
+++ b/src/libServer/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Server Server.cpp ScillaIPCServer.cpp JSONConversion.cpp GetWorkServer.cpp LookupServer.cpp StatusServer.cpp WebsocketServer.cpp)
+add_library(Server Server.cpp ScillaIPCServer.cpp JSONConversion.cpp GetWorkServer.cpp LookupServer.cpp StakingServer.cpp StatusServer.cpp WebsocketServer.cpp)
 
 add_dependencies(Server jsonrpc-project)
 target_include_directories(Server PUBLIC ${PROJECT_SOURCE_DIR}/src ${JSONRPC_INCLUDE_DIR} ${WEBSOCKETPP_INCLUDE_DIR})

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -89,6 +89,26 @@ const Json::Value JSONConversion::convertTxBlocktoJson(const TxBlock& txblock) {
   return ret;
 }
 
+const Json::Value JSONConversion::convertRawTxBlocktoJson(
+    const TxBlock& txblock) {
+  Json::Value ret;
+  bytes raw;
+  string rawstr;
+
+  if (!txblock.Serialize(raw, 0)) {
+    LOG_GENERAL(WARNING, "Raw TxBlock conversion failed");
+    return ret;
+  }
+
+  if (!DataConversion::Uint8VecToHexStr(raw, rawstr)) {
+    LOG_GENERAL(WARNING, "Raw TxBlock conversion failed");
+    return ret;
+  }
+
+  ret["data"] = rawstr;
+  return ret;
+}
+
 const Json::Value JSONConversion::convertDSblocktoJson(const DSBlock& dsblock) {
   Json::Value ret;
   Json::Value ret_header;
@@ -118,6 +138,26 @@ const Json::Value JSONConversion::convertDSblocktoJson(const DSBlock& dsblock) {
 
   ret["signature"] = ret_sign;
 
+  return ret;
+}
+
+const Json::Value JSONConversion::convertRawDSBlocktoJson(
+    const DSBlock& dsblock) {
+  Json::Value ret;
+  bytes raw;
+  string rawstr;
+
+  if (!dsblock.Serialize(raw, 0)) {
+    LOG_GENERAL(WARNING, "Raw DSBlock conversion failed");
+    return ret;
+  }
+
+  if (!DataConversion::Uint8VecToHexStr(raw, rawstr)) {
+    LOG_GENERAL(WARNING, "Raw DSBlock conversion failed");
+    return ret;
+  }
+
+  ret["data"] = rawstr;
   return ret;
 }
 

--- a/src/libServer/JSONConversion.h
+++ b/src/libServer/JSONConversion.h
@@ -32,8 +32,12 @@ class JSONConversion {
       const std::vector<MicroBlockInfo>& v);
   // converts a TxBlock to JSON object
   static const Json::Value convertTxBlocktoJson(const TxBlock& txblock);
+  // converts raw TxBlock to JSON object (for staking)
+  static const Json::Value convertRawTxBlocktoJson(const TxBlock& txblock);
   // converts a DSBlocck to JSON object
   static const Json::Value convertDSblocktoJson(const DSBlock& dsblock);
+  // converts raw DSBlock to JSON object (for staking)
+  static const Json::Value convertRawDSBlocktoJson(const DSBlock& dsblock);
   // converts a JSON to Tx
   static const Transaction convertJsontoTx(const Json::Value& _json);
   // check if a Json is a valid Tx

--- a/src/libServer/StakingServer.cpp
+++ b/src/libServer/StakingServer.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2020 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "StakingServer.h"
+#include "JSONConversion.h"
+#include "libUtils/Logger.h"
+
+using namespace jsonrpc;
+using namespace std;
+
+StakingServer::StakingServer(Mediator& mediator,
+                             jsonrpc::AbstractServerConnector& server)
+    : Server(mediator),
+      jsonrpc::AbstractServer<StakingServer>(server,
+                                             jsonrpc::JSONRPC_SERVER_V2) {
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("GetRawDSBlock", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_OBJECT, "param01", jsonrpc::JSON_STRING,
+                         NULL),
+      &StakingServer::GetRawDSBlockI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("GetRawTxBlock", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_OBJECT, "param01", jsonrpc::JSON_STRING,
+                         NULL),
+      &StakingServer::GetRawTxBlockI);
+}
+
+Json::Value StakingServer::GetRawDSBlock(const string& blockNum) {
+  if (!LOOKUP_NODE_MODE) {
+    throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
+  }
+
+  try {
+    uint64_t BlockNum = stoull(blockNum);
+    return JSONConversion::convertRawDSBlocktoJson(
+        m_mediator.m_dsBlockChain.GetBlock(BlockNum));
+  } catch (const JsonRpcException& je) {
+    throw je;
+  } catch (runtime_error& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "String not numeric");
+  } catch (invalid_argument& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid arugment");
+  } catch (out_of_range& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "Out of range");
+  } catch (exception& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process");
+  }
+}
+
+Json::Value StakingServer::GetRawTxBlock(const string& blockNum) {
+  if (!LOOKUP_NODE_MODE) {
+    throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
+  }
+
+  try {
+    uint64_t BlockNum = stoull(blockNum);
+    return JSONConversion::convertRawTxBlocktoJson(
+        m_mediator.m_txBlockChain.GetBlock(BlockNum));
+  } catch (const JsonRpcException& je) {
+    throw je;
+  } catch (runtime_error& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "String not numeric");
+  } catch (invalid_argument& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid arugment");
+  } catch (out_of_range& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_INVALID_PARAMS, "Out of range");
+  } catch (exception& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process");
+  }
+}

--- a/src/libServer/StakingServer.h
+++ b/src/libServer/StakingServer.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ZILLIQA_SRC_LIBSERVER_STAKINGSERVER_H_
+#define ZILLIQA_SRC_LIBSERVER_STAKINGSERVER_H_
+
+#include "Server.h"
+
+class Mediator;
+
+class StakingServer : public Server,
+                      public jsonrpc::AbstractServer<StakingServer> {
+  inline virtual void GetRawDSBlockI(const Json::Value& request,
+                                     Json::Value& response) {
+    response = this->GetRawDSBlock(request[0u].asString());
+  }
+  Json::Value GetRawDSBlock(const std::string& blockNum);
+  inline virtual void GetRawTxBlockI(const Json::Value& request,
+                                     Json::Value& response) {
+    response = this->GetRawTxBlock(request[0u].asString());
+  }
+  Json::Value GetRawTxBlock(const std::string& blockNum);
+
+ public:
+  StakingServer(Mediator& mediator, jsonrpc::AbstractServerConnector& server);
+  ~StakingServer() = default;
+};
+
+#endif  // ZILLIQA_SRC_LIBSERVER_STAKINGSERVER_H_

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -413,6 +413,28 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
         }
       }
     }
+
+    if (ENABLE_STAKING_RPC) {
+      m_stakingServerConnector = make_unique<SafeHttpServer>(STAKING_RPC_PORT);
+      m_stakingServer =
+          make_shared<StakingServer>(m_mediator, *m_stakingServerConnector);
+
+      if (m_stakingServer == nullptr) {
+        LOG_GENERAL(WARNING, "m_stakingServer NULL");
+      } else {
+        m_lookup.SetStakingServer(m_stakingServer);
+        if (m_lookup.GetSyncType() == SyncType::NO_SYNC) {
+          if (m_stakingServer->StartListening()) {
+            LOG_GENERAL(INFO, "Staking Server started successfully");
+          } else {
+            LOG_GENERAL(WARNING, "Staking Server couldn't start");
+          }
+        } else {
+          LOG_GENERAL(WARNING,
+                      "This lookup node not sync yet, don't start listen");
+        }
+      }
+    }
   };
   DetachedFunction(1, func);
 }

--- a/src/libZilliqa/Zilliqa.h
+++ b/src/libZilliqa/Zilliqa.h
@@ -26,6 +26,7 @@
 #include "libNetwork/Peer.h"
 #include "libNode/Node.h"
 #include "libServer/LookupServer.h"
+#include "libServer/StakingServer.h"
 #include "libServer/StatusServer.h"
 #include "libUtils/ThreadPool.h"
 
@@ -40,10 +41,12 @@ class Zilliqa {
   // usage
   boost::lockfree::queue<std::pair<bytes, Peer>*> m_msgQueue;
 
-  std::unique_ptr<StatusServer> m_statusServer;
   std::shared_ptr<LookupServer> m_lookupServer;
-  std::unique_ptr<jsonrpc::AbstractServerConnector> m_statusServerConnector;
+  std::shared_ptr<StakingServer> m_stakingServer;
+  std::unique_ptr<StatusServer> m_statusServer;
   std::unique_ptr<jsonrpc::AbstractServerConnector> m_lookupServerConnector;
+  std::unique_ptr<jsonrpc::AbstractServerConnector> m_stakingServerConnector;
+  std::unique_ptr<jsonrpc::AbstractServerConnector> m_statusServerConnector;
 
   ThreadPool m_queuePool{MAXMESSAGE, "QueuePool"};
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR adds a new `StakingServer` RPC server that listens on port `4501` (default `STAKING_RPC_PORT` value in `constants.xml`).
This server supports two queries: `GetRawDSBlock` and `GetRawTxBlock`.
The implementation (including setup) mirrors `LookupServer`.

`StakingServer` will be enabled for level2lookup nodes by setting `ENABLE_STAKING_RPC=true` in `constants.xml`.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
