### PR TITLE
Refactor LoadInitialDS

### DIFF
--- a/src/libUtils/UpgradeManager.cpp
+++ b/src/libUtils/UpgradeManager.cpp
@@ -73,8 +73,6 @@ UpgradeManager::UpgradeManager() {
     LOG_GENERAL(WARNING, "curl initialization fail!");
     curl_global_cleanup();
   }
-
-  boost::filesystem::create_directories(DOWNLOAD_FOLDER);
 }
 
 UpgradeManager::~UpgradeManager() {
@@ -197,6 +195,7 @@ string UpgradeManager::DownloadFile(const char* fileTail,
   curl_easy_setopt(m_curl, CURLOPT_URL, downloadFilePath.data());
   curl_easy_setopt(m_curl, CURLOPT_VERBOSE, 1L);
   curl_easy_setopt(m_curl, CURLOPT_NOPROGRESS, 1L);
+  boost::filesystem::create_directories(DOWNLOAD_FOLDER);
   unique_ptr<FILE, decltype(&fclose)> fp(fopen(fileName.data(), "wb"), &fclose);
 
   if (!fp) {
@@ -285,4 +284,8 @@ bool UpgradeManager::LoadInitialDS(vector<PubKey>& initialDSCommittee) {
     LOG_GENERAL(WARNING, e.what());
     return false;
   }
+}
+
+void UpgradeManager::CleanInitialDS() {
+  boost::filesystem::remove(DOWNLOAD_FOLDER);
 }

--- a/src/libUtils/UpgradeManager.h
+++ b/src/libUtils/UpgradeManager.h
@@ -45,6 +45,7 @@ class UpgradeManager {
                            const char* releaseUrl = nullptr);
 
   bool LoadInitialDS(std::vector<PubKey>& initialDSCommittee);
+  void CleanInitialDS();
 };
 
 #endif  // ZILLIQA_SRC_LIBUTILS_UPGRADEMANAGER_H_


### PR DESCRIPTION
## Description
As https://github.com/Zilliqa/Issues/issues/616 saying, we need to provide following:

- [x] Move the `download` folder creation into `LoadInitialDS`
- [x] Write a cleaner function `CleanInitialDS` to remove `download` folder
- [ ] Once `dsnodes.xml` is needless anymore, call the cleaner function `CleanInitialDS`
- [ ] Rename `UpgradeManager` class to a reasonable name

<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
