### PR TITLE
Commit deleted trie nodes from mem to disk & compact LevelDB by reopening

### DIFF
--- a/src/depends/libDatabase/LevelDB.h
+++ b/src/depends/libDatabase/LevelDB.h
@@ -41,6 +41,10 @@ class LevelDB
 
     std::shared_ptr<leveldb::DB> m_db;
 
+    leveldb::Options m_options;
+
+    std::string m_open_db_path;
+
 public:
 
     /// Constructor.
@@ -48,6 +52,14 @@ public:
     explicit LevelDB(const std::string& dbName, const std::string& path, const std::string& subdirectory = "");
     /// Destructor.
     ~LevelDB() = default;
+
+    /// manually compact, might be helpful in future
+    void compact () {
+        m_db->CompactRange(NULL, NULL);
+    }
+
+    /// Reopen the leveldb object to trigger compact and cleaning of LOG/MANIFEST files
+    void Reopen();
 
     /// Returns the reference to the leveldb database instance.
     std::shared_ptr<leveldb::DB> GetDB();
@@ -97,10 +109,12 @@ public:
     int Insert(const leveldb::Slice & key, const leveldb::Slice & value);
 
     /// Sets the value at the specified key for multiple such pairs.
-    int BatchInsert(std::unordered_map<dev::h256, std::pair<std::string, unsigned>> & m_main,
-                    std::unordered_map<dev::h256, std::pair<dev::bytes, bool>> & m_aux);
-
+    bool BatchInsert(const std::unordered_map<dev::h256, std::pair<std::string, unsigned>> & m_main,
+                     const std::unordered_map<dev::h256, std::pair<dev::bytes, bool>> & m_aux);
     bool BatchInsert(const std::unordered_map<std::string, std::string>& kv_map);
+
+    /// Remove the kv pair for multiple specified key.
+    bool BatchDelete(const std::vector<dev::h256>& toDelete);
 
     /// Returns true if value corresponding to specified key exists.
     bool Exists(const dev::h256 & key) const;

--- a/src/depends/libDatabase/MemoryDB.h
+++ b/src/depends/libDatabase/MemoryDB.h
@@ -46,7 +46,6 @@ namespace dev
         bool exists(h256 const& _h) const;
         void insert(h256 const& _h, bytesConstRef _v);
         bool kill(h256 const& _h);
-        void purge();
 
         bytes lookupAux(h256 const& _h) const;
         void removeAux(h256 const& _h);
@@ -62,6 +61,11 @@ namespace dev
         std::unordered_map<h256, std::pair<bytes, bool>> m_aux;
 
         mutable bool m_enforceRefs = false;
+
+        /// remove nodes if counter drop to 0 and collect their keys
+        /// set calledWithMutex to false if you *really* know what you are doing
+        void purge(std::vector<h256>& purged, bool calledWithMutex = true);
+        void purgeMain(std::vector<h256>& purged);
     };
 
     class EnforceRefs

--- a/src/depends/libDatabase/OverlayDB.h
+++ b/src/depends/libDatabase/OverlayDB.h
@@ -39,7 +39,7 @@ namespace dev
 		void ResetDB();
 		bool RefreshDB();
 
-		void commit();
+		bool commit();
 		void rollback();
 
 		std::string lookup(h256 const& _h) const;

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -135,12 +135,9 @@ class AccountStore
   /// Use the states in Temp State DB to refresh the state merkle trie
   bool UpdateStateTrieFromTempStateDB();
 
-  /// Clean, and use the states in either memory or temp state db to
-  /// update the state merkle trie
-  bool RepopulateStateTrie(bool retrieveFromTrie = true);
-
   /// commit the in-memory states into persistent storage
-  bool MoveUpdatesToDisk(bool repopulate = false, bool retrieveFromTrie = true);
+  bool MoveUpdatesToDisk();
+
   /// discard all the changes in memory and reset the states from last
   /// checkpoint in persistent storage
   void DiscardUnsavedUpdates();

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -182,12 +182,7 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
 
   if (isVacuousEpoch) {
     auto writeStateToDisk = [this]() -> void {
-      if (!AccountStore::GetInstance().MoveUpdatesToDisk(
-              ENABLE_REPOPULATE && (m_mediator.m_dsBlockChain.GetLastBlock()
-                                            .GetHeader()
-                                            .GetBlockNum() %
-                                        REPOPULATE_STATE_PER_N_DS ==
-                                    REPOPULATE_STATE_IN_DS))) {
+      if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
         LOG_GENERAL(WARNING, "MoveUpdatesToDisk failed, what to do?");
         return;
       } else {

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2579,16 +2579,10 @@ bool Lookup::ProcessSetStateDeltasFromSeed(const bytes& message,
       }
       m_prevStateRootHashTemp = AccountStore::GetInstance().GetStateRootHash();
     }
+
     if ((txBlkNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) {
-      if (ENABLE_REPOPULATE && ((txBlkNum + 1) % (NUM_FINAL_BLOCK_PER_POW *
-                                                  REPOPULATE_STATE_PER_N_DS) ==
-                                REPOPULATE_STATE_IN_DS)) {
-        if (!AccountStore::GetInstance().MoveUpdatesToDisk(true)) {
-          LOG_GENERAL(WARNING, "AccountStore::MoveUpdatesToDisk(true) failed");
-          return false;
-        }
-      } else if (txBlkNum + NUM_FINAL_BLOCK_PER_POW > highBlockNum) {
-        if (!AccountStore::GetInstance().MoveUpdatesToDisk(false)) {
+      if (txBlkNum + NUM_FINAL_BLOCK_PER_POW > highBlockNum) {
+        if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
           LOG_GENERAL(WARNING, "AccountStore::MoveUpdatesToDisk(false) failed");
           return false;
         }

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -804,13 +804,7 @@ bool Node::ProcessFinalBlockCore(const bytes& message, unsigned int offset,
       return false;
     }
     auto writeStateToDisk = [this]() -> void {
-      if (!AccountStore::GetInstance().MoveUpdatesToDisk(
-              LOOKUP_NODE_MODE && ENABLE_REPOPULATE &&
-              (m_mediator.m_dsBlockChain.GetLastBlock()
-                       .GetHeader()
-                       .GetBlockNum() %
-                   REPOPULATE_STATE_PER_N_DS ==
-               REPOPULATE_STATE_IN_DS))) {
+      if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
         LOG_GENERAL(WARNING, "MoveUpdatesToDisk failed, what to do?");
         // return false;
       } else {

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -462,6 +462,7 @@ bool BlockStorage::GetLatestTxBlock(TxBlockSharedPtr& block) {
         latestTxBlockNum = blockNum;
       }
     }
+    delete it;
   }
 
   return GetTxBlock(latestTxBlockNum, block);
@@ -1168,6 +1169,7 @@ void BlockStorage::GetDiagnosticDataNodes(
 
     index++;
   }
+  delete it;
 }
 
 void BlockStorage::GetDiagnosticDataCoinbase(
@@ -1215,6 +1217,7 @@ void BlockStorage::GetDiagnosticDataCoinbase(
 
     index++;
   }
+  delete it;
 }
 
 unsigned int BlockStorage::GetDiagnosticDataNodesCount() {

--- a/src/libPersistence/ContractStorage2.cpp
+++ b/src/libPersistence/ContractStorage2.cpp
@@ -249,7 +249,9 @@ bool ContractStorage2::FetchStateValue(const dev::h160& addr, const bytes& src,
     ++p;
   }
 
-  auto it = m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions());
+  std::unique_ptr<leveldb::Iterator> it(
+      m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions()));
+
   it->Seek({key});
   if (!it->Valid() || it->key().ToString().compare(0, key.size(), key) != 0) {
     // no entry
@@ -355,7 +357,9 @@ void ContractStorage2::DeleteByPrefix(const string& prefix) {
     ++p;
   }
 
-  auto it = m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions());
+  std::unique_ptr<leveldb::Iterator> it(
+      m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions()));
+
   it->Seek({prefix});
   if (!it->Valid() ||
       it->key().ToString().compare(0, prefix.size(), prefix) != 0) {
@@ -580,7 +584,9 @@ void ContractStorage2::FetchStateDataForKey(map<string, bytes>& states,
     ++p;
   }
 
-  auto it = m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions());
+  std::unique_ptr<leveldb::Iterator> it(
+      m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions()));
+
   it->Seek({key});
   if (!it->Valid() || it->key().ToString().compare(0, key.size(), key) != 0) {
     // no entry
@@ -662,7 +668,9 @@ void ContractStorage2::FetchUpdatedStateValuesForAddress(
       ++p;
     }
 
-    auto it = m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions());
+    std::unique_ptr<leveldb::Iterator> it(
+        m_stateDataDB.GetDB()->NewIterator(leveldb::ReadOptions()));
+
     it->Seek({address.hex()});
     if (!it->Valid() || it->key().ToString().compare(0, address.hex().size(),
                                                      address.hex()) != 0) {


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR resolves the size limit of account state trie. 

## Motivation
We used to observe an unlimited growth of disk usage of state trie DB even there is only update operation to it. The old solution is to repopulate the whole trie in the end of a DS epoch, but this may take too long to process if the size of accounts in trie is getting huge. Which is not what we want in the long run.

## Rationale
In the old dependency, the deleted trie nodes were not committed to the disk when we update a specific node in the Merkle Partria Tree. In this fix, we dump all the deleted nodes in memory and delete from LevelDB.

Besides, the deletion doesn't take effects in LevelDB until running compaction. Which is normally triggered when we reopen the DB or run compact mannualy. Since compaction won't eliminate LOG and MANIFEST files which grows unlimitedly as long as the process is running, but which will be reset when the LevelDB is reopened. So reopening by recreating instance linking to the DB in memory solves this issue.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
