### PR TITLE
Optimize StartRetrieveHistory->RetrieveTxBlocks

### DIFF
--- a/src/libData/BlockChainData/BlockChain.h
+++ b/src/libData/BlockChainData/BlockChain.h
@@ -69,19 +69,12 @@ class BlockChain {
       LOG_GENERAL(WARNING,
                   "BlockNum too high " << blockNum << " Dummy block used");
       return T();
-    } else if (blockNum + m_blocks.capacity() < m_blocks.size()) {
+    } else if (blockNum + m_blocks.capacity() < m_blocks.size() ||
+               m_blocks[blockNum].GetHeader().GetBlockNum() != blockNum) {
       return GetBlockFromPersistentStorage(blockNum);
+    } else {
+      return m_blocks[blockNum];
     }
-
-    if (m_blocks[blockNum].GetHeader().GetBlockNum() != blockNum) {
-      LOG_GENERAL(WARNING,
-                  "BlockNum : " << blockNum << " != GetBlockNum() : "
-                                << m_blocks[blockNum].GetHeader().GetBlockNum()
-                                << ", a dummy block will be used and abnormal "
-                                   "behavior may happen!");
-      return T();
-    }
-    return m_blocks[blockNum];
   }
 
   /// Adds a block to the chain.


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Related Issue:
https://github.com/Zilliqa/Issues/issues/614 

Actually the retrieval of all the txn blocks into memory is not essential, which were used to serve getting the lastest block number...
Besides, `CircularArray` was also modified so no need to populate the array with every blocks in history to get the latest view of the blockchain.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
