### PR TITLE
Remove ipMapping for dsnodes

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -824,6 +824,10 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone() {
   m_mediator.m_blocklinkchain.SetBuiltDSComm(*m_mediator.m_DSCommittee);
 
   StartFirstTxEpoch();
+
+  // Reached here, so already at new ds epoch now and safe to remove
+  // ipMapping.xml
+  m_mediator.m_node->RemoveIpMapping();
 }
 
 bool DirectoryService::ProcessDSBlockConsensus(

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -363,8 +363,6 @@ class Node : public Executable {
 
   void GetIpMapping(std::unordered_map<std::string, Peer>& ipMapping);
 
-  void RemoveIpMapping();
-
   void WakeupAtDSEpoch();
 
   void WakeupAtTxEpoch();
@@ -664,6 +662,8 @@ class Node : public Executable {
   void ClearUnconfirmedTxn();
 
   bool IsUnconfirmedTxnEmpty() const;
+
+  void RemoveIpMapping();
 
  private:
   static std::map<NodeState, std::string> NodeStateStrings;


### PR DESCRIPTION
## Description
Currently,  ipMapping.xml is only removed for normal shard nodes after first DS epoch has passed.
Same should apply for dsnodes.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
