### PR TITLE
Add mutex to fix duplicate processing of vcblock

### DIFF
--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -428,6 +428,9 @@ class Node : public Executable {
   // DS block information
   std::mutex m_mutexDSBlock;
 
+  // VC block information
+  std::mutex m_mutexVCBlock;
+
   /// The current internal state of this Node instance.
   std::atomic<NodeState> m_state{};
 

--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -103,6 +103,8 @@ bool Node::ProcessVCBlock(const bytes& message, unsigned int cur_offset,
                           [[gnu::unused]] const Peer& from) {
   LOG_MARKER();
 
+  lock_guard<mutex> g(m_mutexVCBlock);
+
   VCBlock vcblock;
 
   if (!Messenger::GetNodeVCBlock(message, cur_offset, vcblock)) {


### PR DESCRIPTION
## Description

Few of the normal nodes went in syncing forever due to its incorrect BlockLink Index.
Incorrect BlockLink Index was due duplicate processing of VC block.

mutex has been added to `ProcessVCblock` to avoid the same.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
