### PR TITLE
Add automatic increment to isolated server

### DIFF
--- a/ISOLATED_SERVER_setup.md
+++ b/ISOLATED_SERVER_setup.md
@@ -130,6 +130,15 @@ sudo swapon --show
     | **Smart Contract IDE** | https://ide.zilliqa.com/ |
     | **Testnet Wallet** | https://dev-wallet.zilliqa.com/home |
 
+
+## Bootstrap Options
+
+- Accounts File : Use `-f` to refer to the location of json file containing accounts (Required)
+- Port : Use `-p` to configure the local port to start on (Default : 5555)
+- Initial Blocknumber : Use `-b` to configure the initial blocknumber which the server starts with (Default : 1)
+- Time increment : Use `-t` (t > 0) to configure automatic increment of blocknum (in ms) (Disabled by default) 
+
+
 ### Acknowledgements
 
 Isolated server is created by: @KaustubhShamshery

--- a/src/cmd/isolated_server.cpp
+++ b/src/cmd/isolated_server.cpp
@@ -71,7 +71,7 @@ int main(int argc, const char* argv[]) {
   string accountJsonFilePath;
   uint port{5555};
   string blocknum_str{"1"};
-
+  uint timeDelta{0};
   try {
     po::options_description desc("Options");
 
@@ -81,7 +81,10 @@ int main(int argc, const char* argv[]) {
         "port,p", po::value<uint>(&port),
         "Port to run server on {default: 5555")(
         "blocknum,b", po::value<string>(&blocknum_str),
-        "Initial blocknumber {default : 1 }");
+        "Initial blocknumber {default : 1 }")(
+        "time,t", po::value<uint>(&timeDelta),
+        "the automatic blocktime for incrementing block number (in ms)  "
+        "(Disabled by default)");
 
     po::variables_map vm;
 
@@ -145,7 +148,7 @@ int main(int argc, const char* argv[]) {
 
     auto isolatedServerConnector = make_unique<jsonrpc::SafeHttpServer>(port);
     auto isolatedServer = make_shared<IsolatedServer>(
-        mediator, *isolatedServerConnector, blocknum);
+        mediator, *isolatedServerConnector, blocknum, timeDelta);
 
     if (!isolatedServer
              ->jsonrpc::AbstractServer<IsolatedServer>::StartListening()) {

--- a/src/libServer/IsolatedServer.h
+++ b/src/libServer/IsolatedServer.h
@@ -26,10 +26,13 @@ class IsolatedServer : public LookupServer,
                        public jsonrpc::AbstractServer<IsolatedServer> {
   uint64_t m_blocknum;
   uint128_t m_gasPrice{1};
+  std::atomic<uint32_t> m_timeDelta;
+
+  bool StartBlocknumIncrement();
 
  public:
   IsolatedServer(Mediator& mediator, jsonrpc::AbstractServerConnector& server,
-                 const uint64_t& blocknum);
+                 const uint64_t& blocknum, const uint32_t& timeDelta);
   ~IsolatedServer() = default;
 
   inline virtual void CreateTransactionI(const Json::Value& request,
@@ -50,11 +53,17 @@ class IsolatedServer : public LookupServer,
                                           Json::Value& response) {
     response = this->SetMinimumGasPrice(request[0u].asString());
   }
+  inline virtual void GetBlocknumI(const Json::Value& request,
+                                   Json::Value& response) {
+    (void)request;
+    response = this->GetBlocknum();
+  }
 
   std::string GetMinimumGasPrice();
   std::string SetMinimumGasPrice(const std::string& gasPrice);
   Json::Value CreateTransaction(const Json::Value& _json);
   std::string IncreaseBlocknum(const uint32_t& delta);
+  std::string GetBlocknum();
   bool ValidateTxn(const Transaction& tx, const Address& fromAddr,
                    const Account* sender, const uint128_t& gasPrice);
 };


### PR DESCRIPTION
## Description
Add option `-t` to enable time trigger.

For example.
```bash
./build/bin/isolatedServer -f isolated-server-accounts.json -t 100
``` 
would increment the abstract blocknum in isolated server every 100 ms or 0.1 s

<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
