### PR TITLE
Add ToggleDisableTxns to local server

### DIFF
--- a/scripts/miner_info.py
+++ b/scripts/miner_info.py
@@ -112,6 +112,7 @@ def make_options_dictionary(options_dict):
 	options_dict["set_sendsccallstods"] = "ToggleSendSCCallsToDS"
 	options_dict["get_sendsccallstods"] = "GetSendSCCallsToDS"
 	options_dict["disable_pow"] = "DisablePoW"
+	options_dict["disabletxns"] = "ToggleDisableTxns"
 
 def ProcessResponseCore(resp, param):
 	if param:

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -4380,6 +4380,11 @@ void Lookup::SendTxnPacketToNodes(const uint32_t oldNumShards,
     return;
   }
 
+  if (m_mediator.m_disableTxns) {
+    LOG_GENERAL(INFO, "Txns disabled - skipping dispatch to shards");
+    return;
+  }
+
   const uint32_t numShards = newNumShards;
 
   map<uint32_t, vector<Transaction>> mp;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -4580,6 +4580,11 @@ bool Lookup::ProcessForwardTxn(const bytes& message, unsigned int offset,
                 "non-lookup node");
   }
 
+  if (m_mediator.m_disableTxns) {
+    LOG_GENERAL(INFO, "Txns disabled - dropping txn packet");
+    return false;
+  }
+
   vector<Transaction> txnsShard;
   vector<Transaction> txnsDS;
 

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -28,6 +28,8 @@
 
 using namespace std;
 
+std::atomic<bool> Mediator::m_disableTxns(false);
+
 Mediator::Mediator(const PairOfKey& key, const Peer& peer)
     : m_selfKey(key),
       m_selfPeer(peer),

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -97,6 +97,9 @@ class Mediator {
   /// Prevent node from mining PoW at the next DS epoch
   std::atomic<bool> m_disablePoW;
 
+  /// Prevent transactions from being created, forwarded, and dispatched
+  static std::atomic<bool> m_disableTxns;
+
   /// Constructor.
   Mediator(const PairOfKey& key, const Peer& peer);
 

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -276,6 +276,11 @@ bool LookupServer::StartCollectorThread() {
       txnsShard.clear();
       txnsDS.clear();
 
+      if (m_mediator.m_disableTxns) {
+        LOG_GENERAL(INFO, "Txns disabled - skipping forwarding to upper seed");
+        continue;
+      }
+
       if (m_mediator.m_lookup->GetSyncType() != SyncType::NO_SYNC) {
         LOG_GENERAL(INFO, "This new lookup (Seed) is not yet synced..");
         continue;
@@ -425,6 +430,11 @@ Json::Value LookupServer::CreateTransaction(
 
   if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
+  }
+
+  if (Mediator::m_disableTxns) {
+    LOG_GENERAL(INFO, "Txns disabled - rejecting new txn");
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable to Process");
   }
 
   try {

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -94,6 +94,10 @@ StatusServer::StatusServer(Mediator& mediator,
       jsonrpc::Procedure("DisablePoW", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_OBJECT, NULL),
       &StatusServer::DisablePoWI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("ToggleDisableTxns", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_OBJECT, NULL),
+      &StatusServer::ToggleDisableTxnsI);
 }
 
 string StatusServer::GetLatestEpochStatesUpdated() {
@@ -252,4 +256,13 @@ bool StatusServer::DisablePoW() {
   }
   m_mediator.m_disablePoW = true;
   return true;
+}
+
+bool StatusServer::ToggleDisableTxns() {
+  if (!LOOKUP_NODE_MODE) {
+    throw JsonRpcException(RPC_INVALID_REQUEST,
+                           "Not to be queried on non-lookup");
+  }
+  m_mediator.m_disableTxns = !m_mediator.m_disableTxns;
+  return m_mediator.m_disableTxns;
 }

--- a/src/libServer/StatusServer.h
+++ b/src/libServer/StatusServer.h
@@ -72,6 +72,11 @@ class StatusServer : public Server,
     (void)request;
     response = this->DisablePoW();
   }
+  inline virtual void ToggleDisableTxnsI(const Json::Value& request,
+                                         Json::Value& response) {
+    (void)request;
+    response = this->ToggleDisableTxns();
+  }
 
   Json::Value IsTxnInMemPool(const std::string& tranID);
   bool AddToBlacklistExclusion(const std::string& ipAddr);
@@ -83,6 +88,7 @@ class StatusServer : public Server,
   bool ToggleSendSCCallsToDS();
   bool GetSendSCCallsToDS();
   bool DisablePoW();
+  bool ToggleDisableTxns();
 };
 
 #endif  // ZILLIQA_SRC_LIBSERVER_STATUSSERVER_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`ToggleDisableTxns` is added to the `StatusServer` API, which will set or reset `Mediator::m_disableTxns`.

It's used in 4 places:
1. `LookupServer::CreateTransaction` to prevent new transactions
2. `LookupServer::StartCollectorThread` to prevent forwarding packets to upper seeds
3. `Lookup::SendTxnPacketToNodes` to prevent dispatching packets to shards
4. `Lookup::ProcessForwardTxn` to prevent processing forwarded packets

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
