### PR TITLE
fix(libRumorSpreading): set peer size to class variable other than function argument

### DIFF
--- a/src/libRumorSpreading/RumorHolder.cpp
+++ b/src/libRumorSpreading/RumorHolder.cpp
@@ -120,7 +120,7 @@ RumorHolder::RumorHolder(const std::unordered_set<int>& peers, int maxRoundsInB,
       m_statistics(),
       m_maxNeighborsPerRound(maxNeighborsPerRound) {
   if (maxNeighborsPerRound > (int)peers.size()) {
-    maxNeighborsPerRound = peers.size();
+    m_maxNeighborsPerRound = peers.size();
   }
   toVector(peers);
 }


### PR DESCRIPTION
## Description
This PR is to fix a small issue about setting class filed `m_maxNeighborsPerRound`.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
