### PR TITLE
Enhancement - Use IPConverter namespace's utility function for Printing Peer IP address

### DIFF
--- a/src/libNetwork/Peer.cpp
+++ b/src/libNetwork/Peer.cpp
@@ -52,11 +52,7 @@ bool Peer::operator<(const Peer& r) const {
 }
 
 const string Peer::GetPrintableIPAddress() const {
-  char str[INET_ADDRSTRLEN];
-  struct sockaddr_in serv_addr {};
-  serv_addr.sin_addr.s_addr = m_ipAddress.convert_to<unsigned long>();
-  inet_ntop(AF_INET, &(serv_addr.sin_addr), str, INET_ADDRSTRLEN);
-  return string(str);
+  return IPConverter::ToStrFromNumericalIP(m_ipAddress);
 }
 
 unsigned int Peer::Serialize(bytes& dst, unsigned int offset) const {

--- a/tests/Network/CMakeLists.txt
+++ b/tests/Network/CMakeLists.txt
@@ -30,3 +30,8 @@ add_executable (Test_ReputationManager Test_ReputationManager.cpp)
 target_include_directories (Test_ReputationManager PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_ReputationManager PUBLIC Network Utils)
 add_test(NAME Test_ReputationManager COMMAND Test_ReputationManager)
+
+add_executable (Test_Peer Test_Peer.cpp)
+target_include_directories (Test_Peer PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries (Test_Peer PUBLIC Network)
+add_test(NAME Test_Peer COMMAND Test_Peer)

--- a/tests/Network/Test_Peer.cpp
+++ b/tests/Network/Test_Peer.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include "libNetwork/Peer.h"
+
+#define BOOST_TEST_MODULE peer_test
+#include <boost/test/included/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(peer_test)
+
+BOOST_AUTO_TEST_CASE(test_print_ip_numerical_to_String) {
+  Peer p((boost::multiprecision::uint128_t)16777343, 0);
+  std::string result = p.GetPrintableIPAddress();
+  BOOST_CHECK_MESSAGE(result == "127.0.0.1",
+                      "Expected: 127.0.0.1 , Result: " + result);
+  Peer p1;
+  result = p1.GetPrintableIPAddress();
+  BOOST_CHECK_MESSAGE(result == "0.0.0.0",
+                      "Expected: 0.0.0.0 , Result: " + result);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
The goal of the PR is use IPConverter utility function for printing IP address for debugging purpose.

The PR addresses one of the review comment mentioned in the below issue.
https://github.com/Zilliqa/Zilliqa/pull/528

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
