### PR TITLE
Naming convention fix for struct members of DirectoryService.h file  #378

### DIFF
--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -43,28 +43,28 @@
 class Mediator;
 
 struct PoWSolution {
-  uint64_t nonce;
-  std::array<unsigned char, 32> result;
-  std::array<unsigned char, 32> mixhash;
-  uint32_t lookupId;
-  uint128_t gasPrice;
+  uint64_t m_nonce;
+  std::array<unsigned char, 32> m_result;
+  std::array<unsigned char, 32> m_mixhash;
+  uint32_t m_lookupId;
+  uint128_t m_gasPrice;
 
   PoWSolution()
-      : nonce(0),
-        result({{0}}),
-        mixhash({{0}}),
-        lookupId(uint32_t() - 1),
-        gasPrice(0) {
+      : m_nonce(0),
+        m_result({{0}}),
+        m_mixhash({{0}}),
+        m_lookupId(uint32_t() - 1),
+        m_gasPrice(0) {
 
   }  // The oldest DS (and now new shard node) will have this default value
   PoWSolution(const uint64_t n, const std::array<unsigned char, 32>& r,
               const std::array<unsigned char, 32>& m, uint32_t l,
               const uint128_t& gp)
-      : nonce(n), result(r), mixhash(m), lookupId(l), gasPrice(gp) {}
+      : m_nonce(n), m_result(r), m_mixhash(m), m_lookupId(l), m_gasPrice(gp) {}
   bool operator==(const PoWSolution& rhs) const {
-    return std::tie(nonce, result, mixhash, lookupId, gasPrice) ==
-           std::tie(rhs.nonce, rhs.result, rhs.mixhash, rhs.lookupId,
-                    rhs.gasPrice);
+    return std::tie(m_nonce, m_result, m_mixhash, m_lookupId, m_gasPrice) ==
+           std::tie(rhs.m_nonce, rhs.m_result, rhs.m_mixhash, rhs.m_lookupId,
+                    rhs.m_gasPrice);
   }
 };
 

--- a/src/libDirectoryService/GasPricer.cpp
+++ b/src/libDirectoryService/GasPricer.cpp
@@ -111,8 +111,8 @@ uint128_t DirectoryService::GetIncreasedGasPrice() {
 
   multiset<uint128_t> gasProposals;
   for (const auto& soln : m_allDSPoWs) {
-    if (soln.second.gasPrice <= upperbound) {
-      gasProposals.emplace(soln.second.gasPrice);
+    if (soln.second.m_gasPrice <= upperbound) {
+      gasProposals.emplace(soln.second.m_gasPrice);
     }
   }
   if (gasProposals.empty()) {

--- a/src/libDirectoryService/PoWProcessing.cpp
+++ b/src/libDirectoryService/PoWProcessing.cpp
@@ -367,14 +367,14 @@ bool DirectoryService::VerifyPoWSubmission(const DSPowSolution& sol) {
       m_allPoWConns.emplace(submitterPubKey, submitterPeer);
       if (m_allPoWs.find(submitterPubKey) == m_allPoWs.end()) {
         m_allPoWs[submitterPubKey] = soln;
-      } else if (m_allPoWs[submitterPubKey].result > soln.result) {
+      } else if (m_allPoWs[submitterPubKey].m_result > soln.m_result) {
         // string harderSolnStr, oldSolnStr;
         // DataConversion::charArrToHexStr(soln.result, harderSolnStr);
         // DataConversion::charArrToHexStr(m_allPoWs[submitterPubKey].result,
         // oldSolnStr);
         LOG_GENERAL(INFO, "Replaced");
         m_allPoWs[submitterPubKey] = soln;
-      } else if (m_allPoWs[submitterPubKey].result == soln.result) {
+      } else if (m_allPoWs[submitterPubKey].m_result == soln.m_result) {
         LOG_GENERAL(INFO, "Duplicated");
         return true;
       }
@@ -476,7 +476,7 @@ std::array<unsigned char, 32> DirectoryService::GetDSPoWSoln(
     const PubKey& Pubk) {
   lock_guard<mutex> g(m_mutexAllDSPOWs);
   if (m_allDSPoWs.find(Pubk) != m_allDSPoWs.end()) {
-    return m_allDSPoWs[Pubk].result;
+    return m_allDSPoWs[Pubk].m_result;
   } else {
     LOG_GENERAL(WARNING, "No such element in m_allDSPoWs");
     return array<unsigned char, 32>();

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -1088,14 +1088,14 @@ void AnnouncementShardingStructureToProtobuf(
 
       ProtoPoWSolution* proto_soln = proto_member->mutable_powsoln();
       const auto soln = allPoWs.find(key);
-      proto_soln->set_nonce(soln->second.nonce);
-      proto_soln->set_result(soln->second.result.data(),
-                             soln->second.result.size());
-      proto_soln->set_mixhash(soln->second.mixhash.data(),
-                              soln->second.mixhash.size());
-      proto_soln->set_lookupid(soln->second.lookupId);
+      proto_soln->set_nonce(soln->second.m_nonce);
+      proto_soln->set_result(soln->second.m_result.data(),
+                             soln->second.m_result.size());
+      proto_soln->set_mixhash(soln->second.m_mixhash.data(),
+                              soln->second.m_mixhash.size());
+      proto_soln->set_lookupid(soln->second.m_lookupId);
       NumberToProtobufByteArray<uint128_t, UINT128_SIZE>(
-          soln->second.gasPrice, *proto_soln->mutable_gasprice());
+          soln->second.m_gasPrice, *proto_soln->mutable_gasprice());
     }
   }
 }
@@ -4096,12 +4096,12 @@ bool Messenger::SetDSDSBlockAnnouncement(
                                     *protoDSWinnerPoW->mutable_pubkey());
     ProtoPoWSolution* proto_soln = protoDSWinnerPoW->mutable_powsoln();
     const auto soln = kv.second;
-    proto_soln->set_nonce(soln.nonce);
-    proto_soln->set_result(soln.result.data(), soln.result.size());
-    proto_soln->set_mixhash(soln.mixhash.data(), soln.mixhash.size());
-    proto_soln->set_lookupid(soln.lookupId);
+    proto_soln->set_nonce(soln.m_nonce);
+    proto_soln->set_result(soln.m_result.data(), soln.m_result.size());
+    proto_soln->set_mixhash(soln.m_mixhash.data(), soln.m_mixhash.size());
+    proto_soln->set_lookupid(soln.m_lookupId);
     NumberToProtobufByteArray<uint128_t, UINT128_SIZE>(
-        soln.gasPrice, *proto_soln->mutable_gasprice());
+        soln.m_gasPrice, *proto_soln->mutable_gasprice());
   }
 
   if (!dsblock->IsInitialized()) {


### PR DESCRIPTION
## Description
For PoWSolution in DirectoryService.h, it is recommended to prepend member variables with m_ as per naming convention



## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
- [x] local machine test (commit: 033f822b704c7e2675ee1edd1f0ea366bff64e73)

- [ ] small-scale cloud test
- [x] small-scale cloud test (commit: 033f822b704c7e2675ee1edd1f0ea366bff64e73) 

