### PR TITLE
Check m_sendSCCallsToDS in CreateTransaction

### DIFF
--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -493,7 +493,7 @@ Json::Value LookupServer::CreateTransaction(
       }
 
       toAccountExist = (toAccount != nullptr);
-      toAccountIsContract = toAccount->isContract();
+      toAccountIsContract = toAccountExist && toAccount->isContract();
     }
 
     const unsigned int shard = Transaction::GetShardIndex(fromAddr, num_shards);
@@ -540,9 +540,10 @@ Json::Value LookupServer::CreateTransaction(
 
         unsigned int to_shard =
             Transaction::GetShardIndex(tx.GetToAddr(), num_shards);
-        bool sendToDs = false;
+        // Use m_sendSCCallsToDS as initial setting
+        bool sendToDs = m_mediator.m_lookup->m_sendSCCallsToDS;
         if (_json.isMember("priority")) {
-          sendToDs = _json["priority"].asBool();
+          sendToDs = sendToDs || _json["priority"].asBool();
         }
         if ((to_shard == shard) && !sendToDs) {
           if (tx.GetGasLimit() > SHARD_MICROBLOCK_GAS_LIMIT) {

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -223,9 +223,10 @@ class LookupServer : public Server,
   }
 
   std::string GetNetworkId();
-  static Json::Value CreateTransaction(
-      const Json::Value& _json, const unsigned int num_shards,
-      const uint128_t& gasPrice, const CreateTransactionTargetFunc& targetFunc);
+  Json::Value CreateTransaction(const Json::Value& _json,
+                                const unsigned int num_shards,
+                                const uint128_t& gasPrice,
+                                const CreateTransactionTargetFunc& targetFunc);
   Json::Value GetTransaction(const std::string& transactionHash);
   Json::Value GetDsBlock(const std::string& blockNum);
   Json::Value GetTxBlock(const std::string& blockNum);

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -320,9 +320,9 @@ Json::Value StatusServer::IsTxnInMemPool(const string& tranID) {
 }
 
 bool StatusServer::ToggleSendSCCallsToDS() {
-  if (!LOOKUP_NODE_MODE || ARCHIVAL_LOOKUP) {
+  if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST,
-                           "Not to be queried on non-lookup or seed");
+                           "Not to be queried on non-lookup");
   }
   m_mediator.m_lookup->m_sendSCCallsToDS =
       !(m_mediator.m_lookup->m_sendSCCallsToDS);
@@ -330,9 +330,9 @@ bool StatusServer::ToggleSendSCCallsToDS() {
 }
 
 bool StatusServer::GetSendSCCallsToDS() {
-  if (!LOOKUP_NODE_MODE || ARCHIVAL_LOOKUP) {
+  if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST,
-                           "Not to be queried on non-lookup or seed");
+                           "Not to be queried on non-lookup");
   }
   return m_mediator.m_lookup->m_sendSCCallsToDS;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
PR #1976 only enforces sending contract call transactions to DS inside `ProcessForwardTxn`, which is called when a lookup receives txn packets from seed nodes.

This means if a lookup node directly processes `CreateTransaction` itself, the enforcement is not triggered.

This PR adds the checking for `m_sendSCCallsToDS` inside `CreateTransaction` so that the enforcement is covered here as well. It will use the `priority` field only if `m_sendSCCallsToDS` is false, to preserve original behavior.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
