### PR TITLE
Fix/python dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,10 @@
 ARG BASE=zilliqa/scilla:v0.7.0
 FROM ${BASE}
 
+COPY requirements2.txt ./
+COPY requirements2.preq.txt ./
+COPY requirements3.txt ./
+
 # Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update \
     && apt-get install -y software-properties-common \
@@ -54,9 +58,9 @@ RUN apt-get update \
     python3-setuptools \
     libsecp256k1-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install 'setuptools<45' \
-    && pip install request requests clint futures \
-    && pip3 install requests clint future
+    && pip install -r requirements2.preq.txt \
+    && pip install -r requirements2.txt \
+    && pip3 install -r requirements3.txt
 
 # Manually input tag or commit, can be overwritten by docker build-args
 ARG COMMIT_OR_TAG=v6.3.0-alpha.0

--- a/docker/Dockerfile.k8s
+++ b/docker/Dockerfile.k8s
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 # This Dockerfile is incomplete and should only be used with other Dockerfiles
+
+COPY requirements2.k8s.txt ./
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsutils \
     gdb \
@@ -24,6 +27,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     trickle \
     vim \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install 'setuptools<45' \
-    && pip install urllib3 kubernetes netaddr==0.7.19 boto3 awscli clint request
+    && pip install -r requirements2.k8s.txt
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,7 +27,7 @@ check-commit:
 # build zilliqa docker image for Kubernetes usage
 k8s: check-commit
 	cat Dockerfile Dockerfile.k8s | docker build -t zilliqa:$(commit_or_tag) \
-		--build-arg COMMIT_OR_TAG=$(commit_or_tag) --build-arg EXTRA_CMAKE_ARGS="$(cmake_extra_args)" -
+		--build-arg COMMIT_OR_TAG=$(commit_or_tag) --build-arg EXTRA_CMAKE_ARGS="$(cmake_extra_args)" -f- .
 
 # build release version docker image for public usage
 release:

--- a/docker/requirements2.k8s.txt
+++ b/docker/requirements2.k8s.txt
@@ -1,0 +1,5 @@
+urllib3==1.25.9
+kubernetes==11.0.0
+netaddr==0.7.19
+boto3==1.14.9
+awscli==1.18.68

--- a/docker/requirements2.preq.txt
+++ b/docker/requirements2.preq.txt
@@ -1,0 +1,1 @@
+setuptools==44.1.1

--- a/docker/requirements2.txt
+++ b/docker/requirements2.txt
@@ -1,0 +1,4 @@
+request==2019.4.13
+requests==2.24.0
+clint==0.5.1
+futures==3.3.0

--- a/docker/requirements3.txt
+++ b/docker/requirements3.txt
@@ -1,0 +1,3 @@
+clint==0.5.1
+future==0.18.2
+requests==2.24.0


### PR DESCRIPTION
## Description
Version locks python2 and 3 dependencies to requirement files.

## Backward Compatibility
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
Create a testnet cluster from the image built by this commit (2aab02a) and test functionalities.

## Status

### Implementation
- [x] **ready for review**

### Integration Test (Core Team)
- [x] local machine test (commit: 2aab02a)
- [x] small-scale cloud test (commit: 2aab02a)
