### PR TITLE
[release-6.3] Suppress Mempool_already_present (Error 23)

### DIFF
--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1908,7 +1908,13 @@ bool Node::ProcessTxnPacketFromLookupCore(const bytes& message,
       const auto& ret_pair = m_createdTxns.insert(txn);
       if (!ret_pair.first) {
         {
-          rejectTxns.emplace_back(txn.GetTranID(), ret_pair.second);
+          if (ret_pair.second != ErrTxnStatus::MEMPOOL_ALREADY_PRESENT) {
+            // Skipping MEMPOOL_ALREADY_PRESENT because this is a duplicate
+            // issue, hence if this comes, either the txn should be confirmed or
+            // if it is pending/dropped there should be some other cause which
+            // is primary.
+            rejectTxns.emplace_back(txn.GetTranID(), ret_pair.second);
+          }
           LOG_GENERAL(INFO, "Txn " << txn.GetTranID().hex()
                                    << " rejected by pool due to "
                                    << ret_pair.second);


### PR DESCRIPTION
## Description

The corresponding error can potentially suppress any other primary error related to the same txnhash.


<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
