### PR TITLE
[release-6.2] replaced ci_make_image.sh

### DIFF
--- a/scripts/ci_make_image.sh
+++ b/scripts/ci_make_image.sh
@@ -40,16 +40,16 @@ set -e
 docker --version
 aws --version
 
-commit=$(git rev-parse --short=7 ${TRAVIS_COMMIT})
+commit_or_tag=$(git rev-parse --short=7 ${TRAVIS_COMMIT})
 test_extra_cmake_args=${TEST_EXTRA_CMAKE_ARGS}
 account_id=$(aws sts get-caller-identity --output text --query 'Account')
 region_id=us-west-2
-source_image=zilliqa:${commit}
-target_image=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit}${TEST_NAME}
+source_image=zilliqa:${commit_or_tag}
+target_image=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit_or_tag}${TEST_NAME}
 
 eval $(aws ecr get-login --no-include-email --region ${region_id})
 set +e
-make -C docker k8s EXTRA_CMAKE_ARGS="${test_extra_cmake_args}" COMMIT="${commit}"  || exit 10
+make -C docker k8s EXTRA_CMAKE_ARGS="${test_extra_cmake_args}" COMMIT_OR_TAG="${commit_or_tag}"  || exit 10
 set -e
 docker tag ${source_image} ${target_image}
 docker push ${target_image}


### PR DESCRIPTION
## Description
Version locks python2 and 3 dependencies to requirement files.

## Backward Compatibility
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
Create a testnet cluster from the image built by this commit (cbe057d) and test functionalities.

## Status

### Implementation
- [x] **ready for review**

### Integration Test (Core Team)
- [x] local machine test (commit: cbe057d)
- [x] small-scale cloud test (commit: cbe057d)
