### PR TITLE
ShardGuard Pod deletion and few optimization/bug fix

### DIFF
--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -60,7 +60,8 @@ enum NodeInstructionType : unsigned char {
   DSGUARDNODENETWORKINFOUPDATE = 0x0C,
   REMOVENODEFROMBLACKLIST = 0x0D,
   PENDINGTXN = 0x0E,
-  VCFINALBLOCK = 0x0F
+  VCFINALBLOCK = 0x0F,
+  NEWSHARDGUARDIDENTITY = 0x10
 };
 
 enum LookupInstructionType : unsigned char {

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -656,6 +656,12 @@ class DirectoryService : public Executable {
   // For DS guard to update it's network information while in GUARD_MODE
   bool UpdateDSGuardIdentity();
 
+  // Update shard node's network info
+  bool UpdateShardNodeNetworkInfo(const Peer& shardNodeNetworkInfo,
+                                  const PubKey& pubKey);
+
+  bool CheckIfShardNode(const PubKey& submitterPubKey);
+
   // Get entire network peer info
   void GetEntireNetworkPeerInfo(VectorOfNode& peers,
                                 std::vector<PubKey>& pubKeys);
@@ -695,7 +701,6 @@ class DirectoryService : public Executable {
   void ClearVCBlockVector();
   bool RunConsensusOnFinalBlockWhenDSPrimary();
   bool CheckIfDSNode(const PubKey& submitterPubKey);
-  bool CheckIfShardNode(const PubKey& submitterPubKey);
   void RemoveDSMicroBlock();
 };
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3209,6 +3209,8 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
                 INFO, "I was not in any shard in current ds epoch previously");
             m_mediator.m_node->m_confirmedNotInNetwork = true;
           } else if (m_mediator.m_node->LoadShardingStructure()) {
+            LOG_GENERAL(INFO,
+                        "I was already part of shard in current ds epoch");
             if (!m_currDSExpired &&
                 m_mediator.m_dsBlockChain.GetLastBlock()
                         .GetHeader()
@@ -3220,7 +3222,8 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
               m_mediator.m_node->ComposeAndSendRemoveNodeFromBlacklist(
                   Node::PEER);
 
-              m_mediator.m_node->StartFirstTxEpoch();
+              m_mediator.m_node->StartFirstTxEpoch(
+                  true);  // Starts with WAITING_FINALBLOCK
             }
           }
           m_currDSExpired = false;

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -8996,6 +8996,94 @@ bool Messenger::GetVCNodeSetDSTxBlockFromSeed(const bytes& src,
   return true;
 }
 
+bool Messenger::SetNodeNewShardGuardNetworkInfo(
+    bytes& dst, const unsigned int offset, const uint64_t dsEpochNumber,
+    const Peer& shardGuardNewNetworkInfo, const uint64_t timestamp,
+    const PairOfKey& shardGuardkey) {
+  LOG_MARKER();
+  NodeSetShardGuardNetworkInfoUpdate result;
+
+  result.mutable_data()->set_dsepochnumber(dsEpochNumber);
+  SerializableToProtobufByteArray(
+      shardGuardkey.second, *result.mutable_data()->mutable_shardguardpubkey());
+  PeerToProtobuf(shardGuardNewNetworkInfo,
+                 *result.mutable_data()->mutable_shardguardnewnetworkinfo());
+  result.mutable_data()->set_timestamp(timestamp);
+
+  if (!result.data().IsInitialized()) {
+    LOG_GENERAL(
+        WARNING,
+        "NodeSetShardGuardNetworkInfoUpdate.Data initialization failed");
+    return false;
+  }
+
+  bytes tmp(result.data().ByteSize());
+  result.data().SerializeToArray(tmp.data(), tmp.size());
+
+  Signature signature;
+  if (!Schnorr::Sign(tmp, shardGuardkey.first, shardGuardkey.second,
+                     signature)) {
+    LOG_GENERAL(WARNING, "Failed to sign shard guard identity update");
+    return false;
+  }
+
+  SerializableToProtobufByteArray(signature, *result.mutable_signature());
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING,
+                "NodeSetShardGuardNetworkInfoUpdate initialization failed");
+    return false;
+  }
+
+  return SerializeToArray(result, dst, offset);
+}
+
+bool Messenger::GetNodeNewShardGuardNetworkInfo(const bytes& src,
+                                                const unsigned int offset,
+                                                uint64_t& dsEpochNumber,
+                                                Peer& shardGuardNewNetworkInfo,
+                                                uint64_t& timestamp,
+                                                PubKey& shardGuardPubkey) {
+  LOG_MARKER();
+
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  NodeSetShardGuardNetworkInfoUpdate result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized() || !result.data().IsInitialized()) {
+    LOG_GENERAL(WARNING,
+                "NodeSetShardGuardNetworkInfoUpdate initialization failed");
+    return false;
+  }
+
+  // First deserialize the fields needed just for signature check
+  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.data().shardguardpubkey(),
+                                  shardGuardPubkey);
+  Signature signature;
+  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.signature(), signature);
+
+  // Check signature
+  bytes tmp(result.data().ByteSize());
+  result.data().SerializeToArray(tmp.data(), tmp.size());
+  if (!Schnorr::Verify(tmp, 0, tmp.size(), signature, shardGuardPubkey)) {
+    LOG_GENERAL(WARNING, "NodeSetShardGuardNetworkInfoUpdate signature wrong");
+    return false;
+  }
+
+  // Deserialize the remaining fields
+  dsEpochNumber = result.data().dsepochnumber();
+  ProtobufToPeer(result.data().shardguardnewnetworkinfo(),
+                 shardGuardNewNetworkInfo);
+  timestamp = result.data().timestamp();
+
+  return true;
+}
+
 bool Messenger::SetDSLookupNewDSGuardNetworkInfo(
     bytes& dst, const unsigned int offset, const uint64_t dsEpochNumber,
     const Peer& dsGuardNewNetworkInfo, const uint64_t timestamp,

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -923,6 +923,22 @@ class Messenger {
                                             PubKey& lookupPubKey);
 
   // ============================================================================
+  // Shard Guard network information update
+  // ============================================================================
+
+  static bool SetNodeNewShardGuardNetworkInfo(
+      bytes& dst, const unsigned int offset, const uint64_t dsEpochNumber,
+      const Peer& shardGuardNewNetworkInfo, const uint64_t timestamp,
+      const PairOfKey& shardGuardkey);
+
+  static bool GetNodeNewShardGuardNetworkInfo(const bytes& src,
+                                              const unsigned int offset,
+                                              uint64_t& dsEpochNumber,
+                                              Peer& shardGuardNewNetworkInfo,
+                                              uint64_t& timestamp,
+                                              PubKey& shardGuardPubkey);
+
+  // ============================================================================
   // DS Guard network information update
   // ============================================================================
 

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -1097,6 +1097,24 @@ message VCNodeSetDSTxBlockFromSeed
 }
 
 // ============================================================================
+// Shard Guard identity update
+// ============================================================================
+
+// From Shard Guard to lookup/dsCommittee. New Shard guard node network info.
+message NodeSetShardGuardNetworkInfoUpdate
+{
+    message Data
+    {
+        uint64 dsepochnumber               = 1;
+        ByteArray shardguardpubkey         = 2;
+        ProtoPeer shardguardnewnetworkinfo = 3;
+        uint64 timestamp                   = 4;
+    }
+    Data data                              = 1;
+    ByteArray signature                    = 2;
+}
+
+// ============================================================================
 // DS Guard identity update
 // ============================================================================
 

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -997,6 +997,13 @@ void P2PComm::InitializeRumorManager(
   }
 }
 
+void P2PComm::UpdatePeerInfoInRumorManager(const Peer& peer,
+                                           const PubKey& pubKey) {
+  LOG_MARKER();
+
+  m_rumorManager.UpdatePeerInfo(peer, pubKey);
+}
+
 Signature P2PComm::SignMessage(const bytes& message) {
   // LOG_MARKER();
 

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -130,6 +130,9 @@ class P2PComm {
 
   void InitializeRumorManager(const VectorOfNode& peers,
                               const std::vector<PubKey>& fullNetworkKeys);
+
+  void UpdatePeerInfoInRumorManager(const Peer& peers, const PubKey& pubKey);
+
   inline static bool IsHostHavingNetworkIssue();
   inline static bool IsNodeNotRunning();
   static void ClearPeerConnectionCount();

--- a/src/libNetwork/RumorManager.cpp
+++ b/src/libNetwork/RumorManager.cpp
@@ -17,6 +17,8 @@
 
 #include "RumorManager.h"
 
+#include <boost/bimap/support/lambda.hpp>
+
 #include <chrono>
 #include <string>
 #include <thread>
@@ -176,6 +178,24 @@ bool RumorManager::Initialize(const VectorOfNode& peers, const Peer& myself,
                                      (ROUND_TIME_IN_MS);  // milliseconds
 
   return true;
+}
+
+void RumorManager::UpdatePeerInfo(const Peer& newPeerInfo,
+                                  const PubKey& pubKey) {
+  std::lock_guard<std::mutex> guard(m_mutex);  // critical section
+  auto it = m_pubKeyPeerBiMap.left.find(pubKey);
+  if (it != m_pubKeyPeerBiMap.left.end()) {
+    Peer oldPeerInfo = it->second;
+    m_pubKeyPeerBiMap.left.modify_data(it, boost::bimaps::_data = newPeerInfo);
+    auto it2 = m_peerIdPeerBimap.right.find(oldPeerInfo);
+    if (it2 != m_peerIdPeerBimap.right.end()) {
+      m_peerIdPeerBimap.right.modify_key(it2,
+                                         boost::bimaps::_key = newPeerInfo);
+      LOG_GENERAL(INFO, "Updated peer info successfully!");
+      return;
+    }
+  }
+  LOG_GENERAL(WARNING, "Failed to updated peer info!");
 }
 
 void RumorManager::SpreadBufferedRumors() {

--- a/src/libNetwork/RumorManager.h
+++ b/src/libNetwork/RumorManager.h
@@ -122,6 +122,8 @@ class RumorManager {
       const RawBytes& message, const RRS::Message::Type& t, const Peer& from);
 
   void AppendKeyAndSignature(RawBytes& result, const RawBytes& messageToSig);
+
+  void UpdatePeerInfo(const Peer& newPeerInfo, const PubKey& pubKey);
   // CONST METHODS
   const RumorIdRumorBimap& rumors() const;
 };

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -759,7 +759,15 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
     // Missed some final block, rejoin
     else if (txBlock.GetHeader().GetBlockNum() > m_mediator.m_currentEpochNum) {
       if (!LOOKUP_NODE_MODE) {
-        RejoinAsNormal();
+        if (txBlock.GetHeader().GetBlockNum() - m_mediator.m_currentEpochNum <=
+            NUM_FINAL_BLOCK_PER_POW) {
+          LOG_GENERAL(INFO, "Syncing as normal node from seeds ...");
+          m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
+          auto func = [this]() mutable -> void { StartSynchronization(); };
+          DetachedFunction(1, func);
+        } else {
+          RejoinAsNormal();
+        }
       } else if (ARCHIVAL_LOOKUP) {
         // Too many txblks ( and corresponding mb/txns) to be fetch from lookup.
         // so sync from S3 instead

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -629,6 +629,32 @@ void Node::Prepare(bool runInitializeGenesisBlocks) {
       FULL_DATASET_MINE);
 }
 
+void Node::WaitForNextTwoBlocksBeforeRejoin() {
+  // wait until next two txblocks are mined to give lookup enough time to
+  // upload incr data to S3.
+  unique_lock<mutex> lock(m_mediator.m_lookup->m_MutexCVSetTxBlockFromSeed);
+  m_mediator.m_lookup->SetSyncType(SyncType::RECOVERY_ALL_SYNC);
+
+  uint64_t oldBlkCount = m_mediator.m_txBlockChain.GetBlockCount();
+  LOG_GENERAL(INFO, "Wait until next two txblock are recvd from lookup..");
+  while (true) {
+    do {
+      m_mediator.m_lookup->GetTxBlockFromSeedNodes(
+          m_mediator.m_txBlockChain.GetBlockCount(), 0);
+    } while (m_mediator.m_lookup->cv_setTxBlockFromSeed.wait_for(
+                 lock, chrono::seconds(RECOVERY_SYNC_TIMEOUT)) ==
+             cv_status::timeout);
+
+    if (m_mediator.m_txBlockChain.GetBlockCount() > oldBlkCount + 1) {
+      LOG_GENERAL(INFO, "Received next two txblocks. Ok to rejoin now!")
+      break;
+    }
+    this_thread::sleep_for(chrono::seconds(RECOVERY_SYNC_TIMEOUT));
+  }
+
+  m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+}
+
 bool Node::StartRetrieveHistory(const SyncType syncType,
                                 bool rejoiningAfterRecover) {
   LOG_MARKER();
@@ -931,6 +957,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
   }
 
   bool bInShardStructure = false;
+  bool bIpChanged = false;
 
   if (bDS) {
     m_myshardId = m_mediator.m_ds->m_shards.size();
@@ -943,6 +970,10 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
           LOG_GENERAL(
               INFO, "This node belongs to sharding structure #" << m_myshardId);
           bInShardStructure = true;
+          if (get<SHARD_NODE_PEER>(shardNode).m_ipAddress !=
+              m_mediator.m_selfPeer.m_ipAddress) {
+            bIpChanged = true;
+          }
           break;
         }
       }
@@ -958,35 +989,23 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         m_mediator.m_ds->m_mapNodeReputation);
   }
 
-  if (REJOIN_NODE_NOT_IN_NETWORK && !LOOKUP_NODE_MODE && !bDS &&
-      !bInShardStructure) {
-    LOG_GENERAL(WARNING,
-                "Node " << m_mediator.m_selfKey.second
-                        << " is not in network, apply re-join process instead");
-    // wait until next two txblocks are mined to give lookup enough time to
-    // upload incr data to S3.
-    unique_lock<mutex> lock(m_mediator.m_lookup->m_MutexCVSetTxBlockFromSeed);
-    m_mediator.m_lookup->SetSyncType(SyncType::RECOVERY_ALL_SYNC);
-
-    uint64_t oldBlkCount = m_mediator.m_txBlockChain.GetBlockCount();
-    LOG_GENERAL(INFO, "Wait until next two txblock are recvd from lookup..");
-    while (true) {
-      do {
-        m_mediator.m_lookup->GetTxBlockFromSeedNodes(
-            m_mediator.m_txBlockChain.GetBlockCount(), 0);
-      } while (m_mediator.m_lookup->cv_setTxBlockFromSeed.wait_for(
-                   lock, chrono::seconds(RECOVERY_SYNC_TIMEOUT)) ==
-               cv_status::timeout);
-
-      if (m_mediator.m_txBlockChain.GetBlockCount() > oldBlkCount + 1) {
-        LOG_GENERAL(INFO, "Received next two txblocks. Ok to rejoin now!")
-        break;
+  if (REJOIN_NODE_NOT_IN_NETWORK && !LOOKUP_NODE_MODE && !bDS) {
+    if (!bInShardStructure) {
+      LOG_GENERAL(
+          WARNING,
+          "Node " << m_mediator.m_selfKey.second
+                  << " is not in network, apply re-join process instead");
+      WaitForNextTwoBlocksBeforeRejoin();
+      return false;
+    } else if (bIpChanged) {
+      LOG_GENERAL(
+          INFO,
+          "My IP has been changed. So will broadcast my new IP to network");
+      if (!UpdateShardGuardIdentity()) {
+        WaitForNextTwoBlocksBeforeRejoin();
+        return false;
       }
-      this_thread::sleep_for(chrono::seconds(RECOVERY_SYNC_TIMEOUT));
     }
-
-    m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
-    return false;
   }
 
   m_mediator.m_consensusID =
@@ -2427,6 +2446,195 @@ bool Node::ProcessDoRejoin(const bytes& message, unsigned int offset,
   return true;
 }
 
+// This feature is only available to shard guard node. This allows guard node to
+// change it's network information (IP and/or port).
+// Pre-condition: Must still have access to existing public and private keypair
+bool Node::UpdateShardGuardIdentity() {
+  LOG_MARKER();
+
+  if (!GUARD_MODE) {
+    LOG_GENERAL(
+        WARNING,
+        "Not in guard mode. Unable to update shard guard network info.");
+    return false;
+  }
+
+  if (!Guard::GetInstance().IsNodeInShardGuardList(
+          m_mediator.m_selfKey.second)) {
+    return false;
+  }
+
+  LOG_GENERAL(WARNING,
+              "Current node is a shard guard node. Updating "
+              "network info.");
+
+  // To provide current pubkey, new IP, new Port and current timestamp
+  bytes updateshardguardidentitymessage = {
+      MessageType::NODE, NodeInstructionType::NEWSHARDGUARDIDENTITY};
+
+  uint64_t curDSEpochNo =
+      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1;
+
+  if (!Messenger::SetNodeNewShardGuardNetworkInfo(
+          updateshardguardidentitymessage, MessageOffset::BODY, curDSEpochNo,
+          m_mediator.m_selfPeer, get_time_as_int(), m_mediator.m_selfKey)) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+              "Messenger::SetNodeNewShardGuardNetworkInfo failed.");
+    return false;
+  }
+
+  // Send to all lookups
+  m_mediator.m_lookup->SendMessageToLookupNodesSerial(
+      updateshardguardidentitymessage);
+
+  // Send to all upper seed nodes
+  m_mediator.m_lookup->SendMessageToSeedNodes(updateshardguardidentitymessage);
+
+  vector<Peer> peerInfo;
+  {
+    // Multicast to all my shard peers
+    lock_guard<mutex> g(m_mutexShardMember);
+    for (auto& it : *m_myShardMembers) {
+      peerInfo.push_back(it.second);
+    }
+  }
+
+  {
+    // Multicast to all DS committee
+    lock_guard<mutex> lock(m_mediator.m_mutexDSCommittee);
+    for (auto const& i : *m_mediator.m_DSCommittee) {
+      peerInfo.push_back(i.second);
+    }
+  }
+
+  P2PComm::GetInstance().SendMessage(peerInfo, updateshardguardidentitymessage);
+
+  return true;
+}
+
+bool Node::ProcessNewShardGuardNetworkInfo(const bytes& message,
+                                           unsigned int offset,
+                                           const Peer& from) {
+  LOG_MARKER();
+
+  if (!GUARD_MODE) {
+    LOG_GENERAL(
+        WARNING,
+        "Not in guard mode. Unable to update shard guard network info.");
+    return false;
+  }
+
+  uint64_t dsEpochNumber;
+  Peer shardGuardNewNetworkInfo;
+  uint64_t timestamp;
+  PubKey shardGuardPubkey;
+
+  if (!Messenger::GetNodeNewShardGuardNetworkInfo(
+          message, offset, dsEpochNumber, shardGuardNewNetworkInfo, timestamp,
+          shardGuardPubkey)) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+              "Messenger::GetNodeNewShardGuardNetworkInfo failed.");
+    return false;
+  }
+
+  if (from.GetIpAddress() != shardGuardNewNetworkInfo.GetIpAddress()) {
+    LOG_CHECK_FAIL("IP Address",
+                   shardGuardNewNetworkInfo.GetPrintableIPAddress(),
+                   from.GetPrintableIPAddress());
+    return false;
+  }
+
+  if (m_mediator.m_selfKey.second == shardGuardPubkey) {
+    LOG_GENERAL(INFO,
+                "[update shard guard] Node to be updated is current node. No "
+                "update needed.");
+    return false;
+  }
+
+  uint64_t currentDSEpochNumber =
+      m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1;
+
+  if (dsEpochNumber != currentDSEpochNumber) {
+    LOG_GENERAL(
+        WARNING,
+        "Update of shard guard network info failure  - dsepoch in message: "
+            << dsEpochNumber
+            << " does not match current dsepoch: " << currentDSEpochNumber);
+    return false;
+  }
+
+  if (!Guard::GetInstance().IsNodeInShardGuardList(shardGuardPubkey)) {
+    LOG_GENERAL(WARNING,
+                "Update of shard guard requested by non-shard guard node, So "
+                "ignore the request");
+    return false;
+  }
+  // I am lookup node
+  if (LOOKUP_NODE_MODE) {
+    m_mediator.m_ds->UpdateShardNodeNetworkInfo(shardGuardNewNetworkInfo,
+                                                shardGuardPubkey);
+    if (!BlockStorage::GetBlockStorage().PutShardStructure(
+            m_mediator.m_ds->m_shards, 0)) {
+      LOG_GENERAL(WARNING, "BlockStorage::PutShardStructure failed");
+    }
+  }
+  // I am sharded node and requestor is also from my shard
+  else if (m_mediator.m_ds->m_mode == DirectoryService::IDLE) {
+    // update requestor's ( ShardGuard ) new IP
+    lock_guard<mutex> g(m_mutexShardMember);
+
+    unsigned int indexOfShardNode;
+    for (indexOfShardNode = 0; indexOfShardNode < m_myShardMembers->size();
+         indexOfShardNode++) {
+      if (m_myShardMembers->at(indexOfShardNode).first == shardGuardPubkey) {
+        LOG_GENERAL(
+            INFO, "[update shard guard] shard guard to be updated is at index "
+                      << indexOfShardNode << " "
+                      << m_myShardMembers->at(indexOfShardNode).second << " -> "
+                      << shardGuardNewNetworkInfo);
+        m_myShardMembers->at(indexOfShardNode).second =
+            shardGuardNewNetworkInfo;
+        if (BROADCAST_GOSSIP_MODE) {
+          // Update peer info for gossip
+          P2PComm::GetInstance().UpdatePeerInfoInRumorManager(
+              shardGuardNewNetworkInfo, shardGuardPubkey);
+        }
+
+        // Put the sharding structure to disk
+        if (!BlockStorage::GetBlockStorage().PutShardStructure(
+                m_mediator.m_ds->m_shards, m_mediator.m_node->m_myshardId)) {
+          LOG_GENERAL(WARNING, "BlockStorage::PutShardStructure failed");
+        }
+        break;
+      }
+    }
+    if (indexOfShardNode == m_myShardMembers->size()) {
+      LOG_GENERAL(WARNING, "PubKey of sender "
+                               << from
+                               << " does not match any of my shard members");
+      return false;
+    }
+  }
+  // I am ds node and requestor is from one of shards
+  else if (m_mediator.m_ds->m_mode != DirectoryService::IDLE) {
+    if (!m_mediator.m_ds->UpdateShardNodeNetworkInfo(shardGuardNewNetworkInfo,
+                                                     shardGuardPubkey)) {
+      LOG_GENERAL(WARNING, "PubKey of sender "
+                               << from
+                               << " does not match any of my shard members");
+      return false;
+    }
+
+    // Put the sharding structure to disk
+    if (!BlockStorage::GetBlockStorage().PutShardStructure(
+            m_mediator.m_ds->m_shards, m_mediator.m_node->m_myshardId)) {
+      LOG_GENERAL(WARNING, "BlockStorage::PutShardStructure failed");
+    }
+  }
+
+  return true;
+}
+
 void Node::QueryLookupForDSGuardNetworkInfoUpdate() {
   if (!GUARD_MODE) {
     LOG_GENERAL(WARNING,
@@ -2714,7 +2922,8 @@ bool Node::Execute(const bytes& message, unsigned int offset,
                                        &Node::ProcessDSGuardNetworkInfoUpdate,
                                        &Node::ProcessRemoveNodeFromBlacklist,
                                        &Node::ProcessPendingTxn,
-                                       &Node::ProcessVCFinalBlock};
+                                       &Node::ProcessVCFinalBlock,
+                                       &Node::ProcessNewShardGuardNetworkInfo};
 
   const unsigned char ins_byte = message.at(offset);
   const unsigned int ins_handlers_count =

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -284,6 +284,9 @@ class Node : public Executable {
   bool ProcessDSGuardNetworkInfoUpdate(const bytes& message,
                                        unsigned int offset, const Peer& from);
 
+  bool ProcessNewShardGuardNetworkInfo(const bytes& message,
+                                       unsigned int offset, const Peer& from);
+
   // bool ProcessCreateAccounts(const bytes & message,
   // unsigned int offset, const Peer & from);
   bool ProcessVCDSBlocksMessage(const bytes& message, unsigned int cur_offset,
@@ -626,7 +629,8 @@ class Node : public Executable {
   void SetMyshardId(uint32_t shardId);
 
   /// Used by oldest DS node to finish setup as a new shard node
-  void StartFirstTxEpoch();
+  /// And also used by shard node rejoining back
+  void StartFirstTxEpoch(bool fbWaitState = false);
 
   /// Used for start consensus on microblock
   bool RunConsensusOnMicroBlock();
@@ -722,6 +726,10 @@ class Node : public Executable {
   void RemoveIpMapping();
 
   void CleanLocalRawStores();
+
+  void WaitForNextTwoBlocksBeforeRejoin();
+
+  bool UpdateShardGuardIdentity();
 
  private:
   static std::map<NodeState, std::string> NodeStateStrings;


### PR DESCRIPTION
## Description
This PR cover following:

- Shard guard pod deletion scenario where new IP of shard guard is broadcasted to its shard and it joins to shard eventually.

- Recovered shardguard and miner node which is already part of shard will now starts at state `WAITING_FINALBLOCK` instead of `MICROBLOCK_CONSENSUS`. This allows get rid of timing issue and starts with being ready to receive next FinalBlock.
 Note: If the recovery takes time which usually will be the case, it will get some missing finalblock which will trigger `RejoinAsNormal`.
   - Optimization is done now to check if number of missing txblocks are not more than `NUM_FINALBLOCK_NUM`. If so, it synchronizes those missing ones from seed nodes instead which will be quick. If not, it continues from S3 as usual. 

- Fix the deadlock issue due to `mutex m_mutexShardMember` in `Node::StartFirstTxEpoch`.

- Code refactoring `WaitForNextTwoBlocksBeforeRejoin`


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
