### PR TITLE
Abort RunConsensusOnViewChange on DS_SYNC

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1067,7 +1067,7 @@ bool DirectoryService::Execute(const bytes& message, unsigned int offset,
                        &DirectoryService::ProcessMicroblockSubmission,
                        &DirectoryService::ProcessFinalBlockConsensus,
                        &DirectoryService::ProcessViewChangeConsensus,
-                       &DirectoryService::ProcessGetDSTxBlockMessage,
+                       &DirectoryService::ProcessVCPushLatestDSTxBlock,
                        &DirectoryService::ProcessPoWPacketSubmission,
                        &DirectoryService::ProcessNewDSGuardNetworkInfo,
                        &DirectoryService::ProcessCosigsRewardsFromSeed});

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -241,8 +241,8 @@ class DirectoryService : public Executable {
                                 const Peer& from);
   bool ProcessPushLatestTxBlock(const bytes& message, unsigned int offset,
                                 const Peer& from);
-  bool ProcessGetDSTxBlockMessage(const bytes& message, unsigned int offset,
-                                  const Peer& from);
+  bool ProcessVCPushLatestDSTxBlock(const bytes& message, unsigned int offset,
+                                    const Peer& from);
   bool ProcessNewDSGuardNetworkInfo(const bytes& message, unsigned int offset,
                                     const Peer& from);
 

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -279,6 +279,11 @@ void DirectoryService::RunConsensusOnViewChange() {
     }
   }
 
+  if (m_mediator.m_lookup->GetSyncType() == SyncType::DS_SYNC) {
+    LOG_GENERAL(INFO, "Node is in DS_SYNC. Skipping view change consensus.");
+    return;
+  }
+
   // Blacklist::GetInstance().Clear();
 
   uint16_t faultyLeaderIndex;
@@ -738,14 +743,14 @@ bytes DirectoryService::ComposeVCGetDSTxBlockMessage() {
   return getDSTxBlockMessage;
 }
 
-bool DirectoryService::ProcessGetDSTxBlockMessage(
+bool DirectoryService::ProcessVCPushLatestDSTxBlock(
     const bytes& message, unsigned int offset,
     [[gnu::unused]] const Peer& from) {
   LOG_MARKER();
 
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
-                "DirectoryService::ProcessGetDSTxBlockMessage not expected "
+                "DirectoryService::ProcessVCPushLatestDSTxBlock not expected "
                 "to be called from LookUp node.");
     return true;
   }
@@ -753,7 +758,7 @@ bool DirectoryService::ProcessGetDSTxBlockMessage(
   if (m_state != VIEWCHANGE_CONSENSUS_PREP) {
     LOG_EPOCH(
         WARNING, m_mediator.m_currentEpochNum,
-        "Unable to process ProcessGetDSTxBlockMessage as current state is "
+        "Unable to process ProcessVCPushLatestDSTxBlock as current state is "
             << to_string(m_state));
   }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This addresses VC8 test issue where multiple nodes perform `RunConsensusOnViewChange` due to the processing of buffered final blocks.

Also, renamed `ProcessGetDSTxBlockMessage` to `ProcessVCPushLatestDSTxBlock` since the message name is `VCPUSHLATESTDSTXBLOCK`.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
