### PR TITLE
Optimize AddPendingTxn mutex locking code

### DIFF
--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1281,22 +1281,22 @@ bool Node::AddPendingTxn(const HashCodeMap& pendingTxns, const PubKey& pubkey,
   {
     lock_guard<mutex> g(m_mediator.m_ds->m_mutexShards);
     size = m_mediator.m_ds->m_shards.size();
+    if (shardId > size) {
+      LOG_GENERAL(WARNING, "Shard id exceeds shards: " << shardId);
+      return false;
+    } else if (shardId < size) {
+      if (!Lookup::VerifySenderNode(m_mediator.m_ds->m_shards.at(shardId),
+                                    pubkey)) {
+        LOG_GENERAL(WARNING, "Could not find PubKey in shard " << shardId);
+        return false;
+      }
+    }
   }
-  if (shardId > size) {
-    LOG_GENERAL(WARNING, "Shard id exceeds shards: " << shardId);
-    return false;
-  } else if (shardId == size) {
+  if (shardId == size) {
     // DS Committee
     lock_guard<mutex> g(m_mediator.m_mutexDSCommittee);
     if (!Lookup::VerifySenderNode(*m_mediator.m_DSCommittee, pubkey)) {
       LOG_GENERAL(WARNING, "Could not find pubkey in ds committee");
-      return false;
-    }
-  } else {
-    lock_guard<mutex> g(m_mediator.m_ds->m_mutexShards);
-    if (!Lookup::VerifySenderNode(m_mediator.m_ds->m_shards.at(shardId),
-                                  pubkey)) {
-      LOG_GENERAL(WARNING, "Could not find PubKey in shard " << shardId);
       return false;
     }
   }


### PR DESCRIPTION
## Description
The goal of the PR is to optimize `AddPendingTxn` function where the mutex `m_mutexShards` is acquired twice in one flow.
The code is changed to acquire `m_mutexShards` onetime.


Please refer to below PR for more details:
https://github.com/Zilliqa/Zilliqa/pull/2086#discussion_r435901498


<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

- [x] local machine test
<!-- - [ ] local machine test (commit: 6d13e8250e6fd9198862d830dccb4467f775220c) -->

- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: 6d13e8250e6fd9198862d830dccb4467f775220c) -->

