### PR TITLE
Handle blacklisting of seed node elegantly

### DIFF
--- a/scripts/miner_info.py
+++ b/scripts/miner_info.py
@@ -110,6 +110,8 @@ def make_options_dictionary(options_dict):
 	options_dict["register_extseed"] = "AddToExtSeedWhitelist"
 	options_dict["deregister_extseed"] = "RemoveFromExtSeedWhitelist"
 	options_dict["reglist_extseed"] = "GetWhitelistedExtSeed"
+	options_dict["seedswhitelist_add"] = "AddToSeedsWhitelist"
+	options_dict["seedswhitelist_remove"] = "RemoveFromSeedsWhitelist"
 	options_dict["ds_difficulty"] = "GetPrevDSDifficulty"
 	options_dict["difficulty"] = "GetPrevDifficulty"
 	options_dict["set_sendsccallstods"] = "ToggleSendSCCallsToDS"
@@ -140,7 +142,7 @@ def ProcessResponse(resp, params, batch):
 def main():
 	options_dictionary = {}
 	make_options_dictionary(options_dictionary)
-	option_param_required = ["checktxn","whitelist_add","whitelist_remove"]
+	option_param_required = ["checktxn","whitelist_add","whitelist_remove","seedswhitelist_add", "seedswhitelist_remove", "register_extseed", "deregister_extseed"]
 	global DEBUG_MODE
 	args = parse_arguments(sorted(options_dictionary.keys()))
 	DEBUG_MODE = args.debug

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -112,6 +112,14 @@ void Lookup::InitSync() {
       SetAboveLayer(m_l2lDataProviders, "node.l2l_data_providers");
     }
 
+    // Send whitelist request to seeds, in case it was blacklisted if was
+    // restarted.
+    if (m_mediator.m_node->ComposeAndSendRemoveNodeFromBlacklist(
+            Node::LOOKUP)) {
+      this_thread::sleep_for(
+          chrono::seconds(REMOVENODEFROMBLACKLIST_DELAY_IN_SECONDS));
+    }
+
     while (GetSyncType() != SyncType::NO_SYNC) {
       if (m_mediator.m_dsBlockChain.GetBlockCount() != 1) {
         dsBlockNum = m_mediator.m_dsBlockChain.GetBlockCount();
@@ -2252,11 +2260,12 @@ bool Lookup::ProcessGetMicroBlockFromLookup(const bytes& message,
 
   // verify if sender is from whitelisted list
   uint128_t ipAddr = from.m_ipAddress;
-  if (!Blacklist::GetInstance().IsWhitelistedIP(ipAddr)) {
-    LOG_GENERAL(WARNING,
-                "Requesting IP : "
-                    << from.GetPrintableIPAddress()
-                    << " is not in whitelisted IP list. Ignore the request");
+  if (!Blacklist::GetInstance().IsWhitelistedSeed(ipAddr)) {
+    LOG_GENERAL(
+        WARNING,
+        "Requesting IP : "
+            << from.GetPrintableIPAddress()
+            << " is not in whitelisted seeds IP list. Ignore the request");
     return false;
   }
 
@@ -3688,11 +3697,12 @@ bool Lookup::ProcessGetTxnsFromLookup([[gnu::unused]] const bytes& message,
 
   // verify if sender is from whitelisted list
   uint128_t ipAddr = from.m_ipAddress;
-  if (!Blacklist::GetInstance().IsWhitelistedIP(ipAddr)) {
-    LOG_GENERAL(WARNING,
-                "Requesting IP : "
-                    << from.GetPrintableIPAddress()
-                    << " is not in whitelisted IP list. Ignore the request");
+  if (!Blacklist::GetInstance().IsWhitelistedSeed(ipAddr)) {
+    LOG_GENERAL(
+        WARNING,
+        "Requesting IP : "
+            << from.GetPrintableIPAddress()
+            << " is not in whitelisted seeds IP list. Ignore the request");
     return false;
   }
 

--- a/src/libNetwork/Blacklist.h
+++ b/src/libNetwork/Blacklist.h
@@ -48,6 +48,9 @@ class Blacklist {
                       // Strict -> Blacklisted for both sending and incoming msg
                       // Relaxed -> Blacklisted for incoming msg only
   std::set<uint128_t> m_whitelistedIP;
+
+  std::mutex m_mutexWhitelistedSeedsIP;
+  std::set<uint128_t> m_whitelistedSeedsIP;
   std::atomic<bool> m_enabled;
 
  public:
@@ -58,7 +61,8 @@ class Blacklist {
   bool Exist(const uint128_t& ip, const bool strict = true);
 
   /// P2PComm may use this function to blacklist certain non responding nodes
-  void Add(const uint128_t& ip, const bool strict = true);
+  void Add(const uint128_t& ip, const bool strict = true,
+           const bool ignoreWhitelist = false);
 
   /// P2PComm may use this function to remove a node form blacklist
   void Remove(const uint128_t& ip);
@@ -81,8 +85,17 @@ class Blacklist {
   /// Remove node from whitelist
   bool RemoveFromWhitelist(const uint128_t& ip);
 
+  /// Seeds node to be whitelisted
+  bool WhitelistSeed(const uint128_t& ip);
+
+  /// Remove node from whitelisted seeds
+  bool RemoveFromWhitelistedSeeds(const uint128_t& ip);
+
   /// Check if given IP is a part of whitelisted ip
   bool IsWhitelistedIP(const uint128_t& ip);
+
+  /// Special case - Whitelisted seeds - exchange seeds, level2lookups, lookups
+  bool IsWhitelistedSeed(const uint128_t& ip);
 };
 
 #endif  // ZILLIQA_SRC_LIBNETWORK_BLACKLIST_H_

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2281,13 +2281,6 @@ bool Node::IsShardNode(const Peer& peerInfo) {
 }
 
 bool Node::ComposeAndSendRemoveNodeFromBlacklist(const RECEIVERTYPE receiver) {
-  if (LOOKUP_NODE_MODE) {
-    LOG_GENERAL(WARNING,
-                "Node::ComposeAndSendRemoveNodeFromBlacklist not "
-                "expected to be called from LookUp node.");
-    return false;
-  }
-
   LOG_MARKER();
   if (Guard::GetInstance().IsNodeInDSGuardList(m_mediator.m_selfKey.second)) {
     LOG_GENERAL(INFO, "I am a ds guard node. So skipping sending...");
@@ -2306,7 +2299,8 @@ bool Node::ComposeAndSendRemoveNodeFromBlacklist(const RECEIVERTYPE receiver) {
     return false;
   }
 
-  if (receiver == RECEIVERTYPE::PEER || receiver == RECEIVERTYPE::BOTH) {
+  if (!LOOKUP_NODE_MODE &&
+      (receiver == RECEIVERTYPE::PEER || receiver == RECEIVERTYPE::BOTH)) {
     // Send the peers
     VectorOfPeer peerList;
     if (m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE)  // DS node

--- a/src/libServer/StatusServer.h
+++ b/src/libServer/StatusServer.h
@@ -55,6 +55,14 @@ class StatusServer : public Server,
                                                     Json::Value& response) {
     response = this->RemoveFromBlacklistExclusion(request[0u].asString());
   }
+  inline virtual void AddToSeedsWhitelistI(const Json::Value& request,
+                                           Json::Value& response) {
+    response = this->AddToSeedsWhitelist(request[0u].asString());
+  }
+  inline virtual void RemoveFromSeedsWhitelistI(const Json::Value& request,
+                                                Json::Value& response) {
+    response = this->RemoveFromSeedsWhitelist(request[0u].asString());
+  }
   inline virtual void GetLatestEpochStatesUpdatedI(const Json::Value& request,
                                                    Json::Value& response) {
     (void)request;
@@ -97,6 +105,8 @@ class StatusServer : public Server,
   bool RemoveFromExtSeedWhitelist(const std::string& pubKeyStr);
   std::string GetWhitelistedExtSeed();
   bool RemoveFromBlacklistExclusion(const std::string& ipAddr);
+  bool AddToSeedsWhitelist(const std::string& ipAddr);
+  bool RemoveFromSeedsWhitelist(const std::string& ipAddr);
   std::string GetNodeState();
   std::string GetLatestEpochStatesUpdated();
   std::string GetEpochFin();


### PR DESCRIPTION
## Description
This PR addresses issue : https://github.com/Zilliqa/Issues/issues/644

**Old behavior:**
The seed nodes registered in multiplier were whitelisted globally. So even if there was connection timeout, they were not blacklisted which resulted in the issue mentioned above.

**New behavior:**
The seed nodes registered in multiplier will be not be whitelisted globally instead will be marked under different category i.e. `seedswhitelist`.
With this, if any of these seed nodes (found in `seedswhitelist` store) results in connection timeout at lookup node, it will be blacklisted under `relaxed` category ( not strict catgeory). This allows such seed node to be relaunched and get itself removed from lookup's blacklist by sending blacklist removal message to lookup.

Also, maintaining separate `seedswhitelist` allows to maintain the existing check of sender in `ProcessGetMicroBlockFromLookup` and `ProcessGetTxnsFromLookup`


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
