### PR TITLE
MINING_PROXY_TIMEOUT_IN_MS constant added to control connection timout.

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -206,6 +206,7 @@
         <OPENCL_GPU_MINE>false</OPENCL_GPU_MINE>
         <REMOTE_MINE>false</REMOTE_MINE>
         <MINING_PROXY_URL>http://127.0.0.1:4202/api</MINING_PROXY_URL>
+        <MINING_PROXY_TIMEOUT_IN_MS>15000</MINING_PROXY_TIMEOUT_IN_MS>
         <MAX_RETRY_SEND_POW_TIME>5</MAX_RETRY_SEND_POW_TIME>
         <!-- Every interval seconds to check if mining proxy has the PoW result -->
         <CHECK_MINING_RESULT_INTERVAL>5</CHECK_MINING_RESULT_INTERVAL>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -205,6 +205,7 @@
         <OPENCL_GPU_MINE>false</OPENCL_GPU_MINE>
         <REMOTE_MINE>false</REMOTE_MINE>
         <MINING_PROXY_URL>http://127.0.0.1:4202/api</MINING_PROXY_URL>
+        <MINING_PROXY_TIMEOUT_IN_MS>15000</MINING_PROXY_TIMEOUT_IN_MS>
         <MAX_RETRY_SEND_POW_TIME>5</MAX_RETRY_SEND_POW_TIME>
         <!-- Every interval seconds to check if mining proxy has the PoW result -->
         <CHECK_MINING_RESULT_INTERVAL>5</CHECK_MINING_RESULT_INTERVAL>

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -402,6 +402,8 @@ const bool REMOTE_MINE{ReadConstantString("REMOTE_MINE", "node.pow.") ==
                        "true"};
 const std::string MINING_PROXY_URL{
     ReadConstantString("MINING_PROXY_URL", "node.pow.")};
+const unsigned int MINING_PROXY_TIMEOUT_IN_MS{
+    ReadConstantNumeric("MINING_PROXY_TIMEOUT_IN_MS", "node.pow.")};
 const unsigned int MAX_RETRY_SEND_POW_TIME{
     ReadConstantNumeric("MAX_RETRY_SEND_POW_TIME", "node.pow.")};
 const unsigned int CHECK_MINING_RESULT_INTERVAL{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -311,6 +311,7 @@ extern const bool FULL_DATASET_MINE;
 extern const bool OPENCL_GPU_MINE;
 extern const bool REMOTE_MINE;
 extern const std::string MINING_PROXY_URL;
+extern const unsigned int MINING_PROXY_TIMEOUT_IN_MS;
 extern const unsigned int MAX_RETRY_SEND_POW_TIME;
 extern const unsigned int CHECK_MINING_RESULT_INTERVAL;
 extern const bool GETWORK_SERVER_MINE;

--- a/src/libPOW/pow.cpp
+++ b/src/libPOW/pow.cpp
@@ -46,6 +46,7 @@ POW::POW() {
 
   if (REMOTE_MINE) {
     m_httpClient = std::make_unique<jsonrpc::HttpClient>(MINING_PROXY_URL);
+    m_httpClient->SetTimeout(MINING_PROXY_TIMEOUT_IN_MS);
   }
 
   if (!GETWORK_SERVER_MINE && FULL_DATASET_MINE && !CUDA_GPU_MINE &&


### PR DESCRIPTION
## Description
support `MINING_PROXY_TIMEOUT_IN_MS` constant, to control pow proxy connection timout.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
