### PR TITLE
In-node validation using StatusServer

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -316,6 +316,32 @@
         <VERIFIER_PATH>./historicalDB</VERIFIER_PATH>
         <VERIFIER_PUBKEY/>
         <SEED_PORT>33133</SEED_PORT>
+        <exclusion_list>
+            <entry>
+                <TXBLOCK>175334</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>1</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>2</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175701</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175701</TXBLOCK>
+                <MICROBLOCK>1</MICROBLOCK>
+            </entry>
+        </exclusion_list>
     </verifier>
     <viewchange>
         <POST_VIEWCHANGE_BUFFER>10</POST_VIEWCHANGE_BUFFER>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -315,6 +315,32 @@
         <VERIFIER_PATH>./historicalDB</VERIFIER_PATH>
         <VERIFIER_PUBKEY/>
         <SEED_PORT>33133</SEED_PORT>
+        <exclusion_list>
+            <entry>
+                <TXBLOCK>175334</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>1</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175637</TXBLOCK>
+                <MICROBLOCK>2</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175701</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+            <entry>
+                <TXBLOCK>175701</TXBLOCK>
+                <MICROBLOCK>1</MICROBLOCK>
+            </entry>
+        </exclusion_list>
     </verifier>
     <viewchange>
         <POST_VIEWCHANGE_BUFFER>5</POST_VIEWCHANGE_BUFFER>

--- a/scripts/miner_info.py
+++ b/scripts/miner_info.py
@@ -118,6 +118,8 @@ def make_options_dictionary(options_dict):
 	options_dict["get_sendsccallstods"] = "GetSendSCCallsToDS"
 	options_dict["disable_pow"] = "DisablePoW"
 	options_dict["disabletxns"] = "ToggleDisableTxns"
+	options_dict["set_validatedb"] = "SetValidateDB"
+	options_dict["get_validatedb"] = "GetValidateDB"
 
 def ProcessResponseCore(resp, param):
 	if param:

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -67,6 +67,17 @@ const vector<string> ReadAccountsFromConstantsFile(const string& propName) {
   return result;
 }
 
+const vector<pair<uint64_t, uint32_t>>
+ReadVerifierExclusionListFromConstantsFile() {
+  auto pt = PTree::GetInstance();
+  vector<pair<uint64_t, uint32_t>> result;
+  for (auto& entry : pt.get_child("node.verifier.exclusion_list")) {
+    result.emplace_back(make_pair(entry.second.get<uint64_t>("TXBLOCK"),
+                                  entry.second.get<uint32_t>("MICROBLOCK")));
+  }
+  return result;
+}
+
 // General constants
 const unsigned int DEBUG_LEVEL{ReadConstantNumeric("DEBUG_LEVEL")};
 const bool ENABLE_DO_REJOIN{ReadConstantString("ENABLE_DO_REJOIN") == "true"};
@@ -631,3 +642,5 @@ const std::string VERIFIER_PUBKEY{
     ReadConstantString("VERIFIER_PUBKEY", "node.verifier.")};
 const unsigned int SEED_PORT{
     ReadConstantNumeric("SEED_PORT", "node.verifier.")};
+const vector<pair<uint64_t, uint32_t>> VERIFIER_EXCLUSION_LIST{
+    ReadVerifierExclusionListFromConstantsFile()};

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -91,6 +91,8 @@ enum SyncType : unsigned int {
   SYNC_TYPE_COUNT
 };
 
+enum class ValidateState : unsigned char { IDLE = 0, INPROGRESS, DONE, ERROR };
+
 namespace Contract {
 using VName = std::string;
 using Mutable = bool;
@@ -426,4 +428,5 @@ extern const std::vector<std::string> GENESIS_KEYS;
 extern const std::string VERIFIER_PATH;
 extern const std::string VERIFIER_PUBKEY;
 extern const unsigned int SEED_PORT;
+extern const std::vector<std::pair<uint64_t, uint32_t>> VERIFIER_EXCLUSION_LIST;
 #endif  // ZILLIQA_SRC_COMMON_CONSTANTS_H_

--- a/src/libData/BlockChainData/BlockLinkChain.h
+++ b/src/libData/BlockChainData/BlockLinkChain.h
@@ -39,7 +39,7 @@ class BlockLinkChain {
   DequeOfNode m_builtDsCommittee;
 
  public:
-  BlockLink GetFromPersistentStorage(const uint64_t& index);
+  static BlockLink GetFromPersistentStorage(const uint64_t& index);
   void Reset();
 
   BlockLinkChain();

--- a/src/libDirectoryService/DSComposition.cpp
+++ b/src/libDirectoryService/DSComposition.cpp
@@ -29,8 +29,11 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
 void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
                                       DequeOfNode& dsComm,
                                       const DSBlock& dsblock,
-                                      MinerInfoDSComm& minerInfo) {
-  LOG_MARKER();
+                                      MinerInfoDSComm& minerInfo,
+                                      const bool showLogs) {
+  if (showLogs) {
+    LOG_MARKER();
+  }
 
   // Get the map of all pow winners from the DS Block
   const auto& NewDSMembers = dsblock.GetHeader().GetDSPoWWinners();
@@ -56,10 +59,12 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
       continue;
     }
 
-    LOG_GENERAL(
-        INFO,
-        "Shuffling non-performant node to the back of the DS Composition: "
-            << RemovedNode);
+    if (showLogs) {
+      LOG_GENERAL(
+          INFO,
+          "Shuffling non-performant node to the back of the DS Composition: "
+              << RemovedNode);
+    }
 
     // Move the candidate to the back of the committee and continue processing
     // other candidates. Only reorders the Committee. The size is not changed.
@@ -103,9 +108,11 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
   // Print some statistics.
   unsigned int NumLosers = removeDSNodePubkeys.size();
   unsigned int NumExpiring = NumWinners - NumLosers;
-  LOG_GENERAL(INFO, "Total winners inserted: " << NumWinners);
-  LOG_GENERAL(INFO, "Total non-performant nodes re-shuffled: " << NumLosers);
-  LOG_GENERAL(INFO, "Nodes expiring due to old age: " << NumExpiring);
+  if (showLogs) {
+    LOG_GENERAL(INFO, "Total winners inserted: " << NumWinners);
+    LOG_GENERAL(INFO, "Total non-performant nodes re-shuffled: " << NumLosers);
+    LOG_GENERAL(INFO, "Nodes expiring due to old age: " << NumExpiring);
+  }
 
   const bool bStoreDSCommittee =
       (dsblock.GetHeader().GetBlockNum() % STORE_DS_COMMITTEE_INTERVAL) == 0;
@@ -118,8 +125,10 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
   for (uint32_t i = 0; i < NumWinners; ++i) {
     // One item is always removed every winner, with removal priority given to
     // 'loser' candidates before expiring nodes.
-    LOG_GENERAL(INFO,
-                "Node dropped from DS Committee: " << dsComm.back().first);
+    if (showLogs) {
+      LOG_GENERAL(INFO,
+                  "Node dropped from DS Committee: " << dsComm.back().first);
+    }
 
     if (LOOKUP_NODE_MODE && !bStoreDSCommittee) {
       minerInfo.m_dsNodesEjected.emplace_back(dsComm.back().first);

--- a/src/libDirectoryService/DSComposition.h
+++ b/src/libDirectoryService/DSComposition.h
@@ -32,6 +32,7 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
 void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
                                       DequeOfNode& dsComm,
                                       const DSBlock& dsblock,
-                                      MinerInfoDSComm& minerInfo);
+                                      MinerInfoDSComm& minerInfo,
+                                      const bool showLogs = true);
 
 #endif  // ZILLIQA_SRC_LIBDIRECTORYSERVICE_DSCOMPOSITION_H_

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -48,7 +48,8 @@ Mediator::Mediator(const PairOfKey& key, const Peer& peer)
       m_isRetrievedHistory(false),
       m_isVacuousEpoch(false),
       m_curSWInfo(),
-      m_disablePoW(false) {
+      m_disablePoW(false),
+      m_validateState(ValidateState::IDLE) {
   SetupLogLevel();
 }
 

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -100,6 +100,9 @@ class Mediator {
   /// Prevent transactions from being created, forwarded, and dispatched
   static std::atomic<bool> m_disableTxns;
 
+  /// ValidateDB state, used by StatusServer
+  std::atomic<ValidateState> m_validateState;
+
   /// Constructor.
   Mediator(const PairOfKey& key, const Peer& peer);
 

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -99,23 +99,24 @@ void Node::StoreDSBlockToDisk(const DSBlock& dsblock) {
 }
 
 void Node::UpdateDSCommitteeComposition(DequeOfNode& dsComm,
-                                        const DSBlock& dsblock) {
-  // Update the DS committee composition.
-  LOG_MARKER();
+                                        const DSBlock& dsblock,
+                                        const bool showLogs) {
+  if (showLogs) {
+    LOG_MARKER();
+  }
 
   MinerInfoDSComm dummy;
   UpdateDSCommitteeCompositionCore(m_mediator.m_selfKey.second, dsComm, dsblock,
-                                   dummy);
+                                   dummy, showLogs);
 }
 
 void Node::UpdateDSCommitteeComposition(DequeOfNode& dsComm,
                                         const DSBlock& dsblock,
                                         MinerInfoDSComm& minerInfo) {
-  // Update the DS committee composition.
   LOG_MARKER();
 
   UpdateDSCommitteeCompositionCore(m_mediator.m_selfKey.second, dsComm, dsblock,
-                                   minerInfo);
+                                   minerInfo, true);
 }
 
 bool Node::VerifyDSBlockCoSignature(const DSBlock& dsblock) {

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -558,7 +558,7 @@ class Node : public Executable {
   bool StartRetrieveHistory(const SyncType syncType,
                             bool rejoiningAfterRecover = false);
 
-  bool CheckIntegrity(bool fromIsolatedBinary = false);
+  bool CheckIntegrity(const bool fromValidateDBBinary = false);
   void PutProcessedInUnconfirmedTxns();
 
   bool SendPendingTxnToLookup();
@@ -575,8 +575,8 @@ class Node : public Executable {
   /// Add new block into tx blockchain
   void AddBlock(const TxBlock& block);
 
-  void UpdateDSCommitteeComposition(DequeOfNode& dsComm,
-                                    const DSBlock& dsblock);
+  void UpdateDSCommitteeComposition(DequeOfNode& dsComm, const DSBlock& dsblock,
+                                    const bool showLogs = true);
   void UpdateDSCommitteeComposition(DequeOfNode& dsComm, const DSBlock& dsblock,
                                     MinerInfoDSComm& minerInfo);
 
@@ -683,7 +683,8 @@ class Node : public Executable {
   void UpdateDSCommitteeCompositionAfterVC(const VCBlock& vcblock,
                                            DequeOfNode& dsComm);
   void UpdateRetrieveDSCommitteeCompositionAfterVC(const VCBlock& vcblock,
-                                                   DequeOfNode& dsComm);
+                                                   DequeOfNode& dsComm,
+                                                   const bool showLogs = true);
 
   void UpdateProcessedTransactions();
 

--- a/src/libNode/ViewChangeBlockProcessing.cpp
+++ b/src/libNode/ViewChangeBlockProcessing.cpp
@@ -306,9 +306,13 @@ void Node::UpdateDSCommitteeCompositionAfterVC(const VCBlock& vcblock,
 
 // Only compares the pubkeys to kickout
 void Node::UpdateRetrieveDSCommitteeCompositionAfterVC(const VCBlock& vcblock,
-                                                       DequeOfNode& dsComm) {
+                                                       DequeOfNode& dsComm,
+                                                       const bool showLogs) {
   if (GUARD_MODE) {
-    LOG_GENERAL(INFO, "In guard mode. No updating of DS composition requried");
+    if (showLogs) {
+      LOG_GENERAL(INFO,
+                  "In guard mode. No updating of DS composition requried");
+    }
     return;
   }
   for (const auto& faultyLeader : vcblock.GetHeader().GetFaultyLeaders()) {

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -183,7 +183,7 @@ bool BlockStorage::GetHistoricalMicroBlock(const BlockHash& blockhash,
 
 bool BlockStorage::GetMicroBlock(const BlockHash& blockHash,
                                  MicroBlockSharedPtr& microblock) {
-  LOG_MARKER();
+  // LOG_MARKER();
 
   string blockString;
 

--- a/src/libServer/StatusServer.h
+++ b/src/libServer/StatusServer.h
@@ -98,6 +98,16 @@ class StatusServer : public Server,
     (void)request;
     response = this->ToggleDisableTxns();
   }
+  inline virtual void SetValidateDBI(const Json::Value& request,
+                                     Json::Value& response) {
+    (void)request;
+    response = this->SetValidateDB();
+  }
+  inline virtual void GetValidateDBI(const Json::Value& request,
+                                     Json::Value& response) {
+    (void)request;
+    response = this->GetValidateDB();
+  }
 
   Json::Value IsTxnInMemPool(const std::string& tranID);
   bool AddToBlacklistExclusion(const std::string& ipAddr);
@@ -115,6 +125,8 @@ class StatusServer : public Server,
   bool GetSendSCCallsToDS();
   bool DisablePoW();
   bool ToggleDisableTxns();
+  std::string SetValidateDB();
+  std::string GetValidateDB();
 };
 
 #endif  // ZILLIQA_SRC_LIBSERVER_STATUSSERVER_H_

--- a/src/libValidator/Validator.h
+++ b/src/libValidator/Validator.h
@@ -47,9 +47,16 @@ class Validator {
 
   template <class Container, class DirectoryBlock>
   bool CheckBlockCosignature(const DirectoryBlock& block,
-                             const Container& commKeys);
+                             const Container& commKeys,
+                             const bool showLogs = true);
 
   bool CheckDirBlocks(
+      const std::vector<boost::variant<
+          DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
+      const DequeOfNode& initDsComm, const uint64_t& index_num,
+      DequeOfNode& newDSComm);
+
+  bool CheckDirBlocksNoUpdate(
       const std::vector<boost::variant<
           DSBlock, VCBlock, FallbackBlockWShardingStructure>>& dirBlocks,
       const DequeOfNode& initDsComm, const uint64_t& index_num,


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR allows lookup and seed nodes to perform persistence validation on demand by sending `SetValidateDB` message through the `StatusServer` API server.

The validation shares the same `Node::CheckIntegrity` function used by `src/cmd/validateDB.cpp`, with some adjustments:
1. Some log messages are disabled to prevent flooding the zilliqa log (look for `showLogs` in the changes).
1. New function `CheckDirBlocksNoUpdate` is used instead of `CheckDirBlocks` (to avoid modifying the run-time variables and just load blocks from persistence)
1. Lambda `validateOneTxBlock` is called sequentially to keep the entire validation sequence single-threaded

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
