### PR TITLE
NewLookup/Level2lookup/Lookup fails to resync if lagging by ds epochs

### DIFF
--- a/scripts/upload_incr_DB.py
+++ b/scripts/upload_incr_DB.py
@@ -391,10 +391,6 @@ def shallStart():
 def main():
 	isVacaous = False
 	lastBlockNum = 0
-	# clear the entire incremental bucket now.
-	CleanS3EntirePersistence()
-	# clear the state-delta bucket now.
-	CleanS3StateDeltas()
 	shallStartFlag = False
 	blockNum = -1
 	global start
@@ -408,6 +404,10 @@ def main():
 					time.sleep(1)
 					continue
 				start = (int)(time.time()) # reset inactive start time since shall start is signaled
+				# clear the entire incremental bucket now.
+				CleanS3EntirePersistence()
+				# clear the state-delta bucket now.
+				CleanS3StateDeltas()
 			else:
 				blockNum = GetCurrentTxBlockNum()
 				if (blockNum == -1):

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2653,8 +2653,9 @@ bool Lookup::ProcessSetDSInfoFromSeed(const bytes& message, unsigned int offset,
     return false;
   }
 
-  // If first epoch and I'm a lookup
-  if ((m_mediator.m_currentEpochNum <= 1) && LOOKUP_NODE_MODE) {
+  // If first epoch and I'm a lookup and I am not syncing right now
+  if ((m_mediator.m_currentEpochNum <= 1) && LOOKUP_NODE_MODE &&
+      (GetSyncType() == SyncType::NO_SYNC)) {
     // Sender must be a DS guard (if in guard mode)
     if (GUARD_MODE && !Guard::GetInstance().IsNodeInDSGuardList(senderPubKey)) {
       LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
@@ -2744,20 +2745,6 @@ bool Lookup::ProcessSetDSInfoFromSeed(const bytes& message, unsigned int offset,
 
   //    Data::GetInstance().SetDSPeers(dsPeers);
   //#endif // IS_LOOKUP_NODE
-
-  /*
-  if ((!LOOKUP_NODE_MODE && m_dsInfoWaitingNotifying &&
-       (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0)) ||
-      (LOOKUP_NODE_MODE &&
-       (m_syncType == SyncType::NEW_LOOKUP_SYNC ||
-        m_syncType == SyncType::LOOKUP_SYNC) &&
-       m_dsInfoWaitingNotifying)) {
-    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-              "Notifying that DSInfo has been received");
-    unique_lock<mutex> lock(m_mutexDSInfoUpdation);
-    m_fetchedDSInfo = true;
-  }
-  */
 
   if (m_dsInfoWaitingNotifying &&
       (m_syncType != NO_SYNC ||
@@ -3022,7 +3009,11 @@ bool Lookup::GetDSInfo() {
   LOG_MARKER();
   m_dsInfoWaitingNotifying = true;
 
-  GetDSInfoFromSeedNodes();
+  if (ARCHIVAL_LOOKUP) {
+    GetDSInfoFromSeedNodes();
+  } else {
+    GetDSInfoFromLookupNodes();
+  }
 
   {
     unique_lock<mutex> lock(m_mutexDSInfoUpdation);
@@ -3558,30 +3549,7 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
   if (!LOOKUP_NODE_MODE) {
     if (m_syncType == SyncType::NEW_SYNC ||
         m_syncType == SyncType::NORMAL_SYNC) {
-      m_dsInfoWaitingNotifying = true;
-
-      GetDSInfoFromSeedNodes();
-
-      {
-        unique_lock<mutex> lock(m_mutexDSInfoUpdation);
-        while (!m_fetchedDSInfo) {
-          LOG_EPOCH(INFO, m_mediator.m_currentEpochNum, "Waiting for DSInfo");
-
-          if (cv_dsInfoUpdate.wait_for(
-                  lock, chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
-              std::cv_status::timeout) {
-            // timed out
-            LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-                      "Timed out waiting for DSInfo");
-            m_dsInfoWaitingNotifying = false;
-            return false;
-          }
-          LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-                    "Get ProcessDsInfo Notified");
-          m_dsInfoWaitingNotifying = false;
-        }
-        m_fetchedDSInfo = false;
-      }
+      GetDSInfo();
 
       LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
                 "DSInfo received -> Ask lookup to let me know when to "
@@ -3641,30 +3609,7 @@ bool Lookup::ProcessSetStateFromSeed(const bytes& message, unsigned int offset,
     }
     m_currDSExpired = false;
   } else if (LOOKUP_NODE_MODE && m_syncType == SyncType::NEW_LOOKUP_SYNC) {
-    m_dsInfoWaitingNotifying = true;
-
-    GetDSInfoFromSeedNodes();
-
-    {
-      unique_lock<mutex> lock(m_mutexDSInfoUpdation);
-      while (!m_fetchedDSInfo) {
-        LOG_EPOCH(INFO, m_mediator.m_currentEpochNum, "Waiting for DSInfo");
-
-        if (cv_dsInfoUpdate.wait_for(lock,
-                                     chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
-            std::cv_status::timeout) {
-          // timed out
-          LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-                    "Timed out waiting for DSInfo");
-          m_dsInfoWaitingNotifying = false;
-          return false;
-        }
-        LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-                  "Get ProcessDsInfo Notified");
-        m_dsInfoWaitingNotifying = false;
-      }
-      m_fetchedDSInfo = false;
-    }
+    GetDSInfo();
 
     if (!m_currDSExpired) {
       SetSyncType(SyncType::NO_SYNC);
@@ -4497,30 +4442,35 @@ void Lookup::StartSynchronization() {
 
   LOG_MARKER();
 
-  if (ARCHIVAL_LOOKUP) {
-    auto func = [this]() -> void {
-      GetDSInfoFromSeedNodes();
-      while (GetSyncType() != SyncType::NO_SYNC) {
-        GetDSBlockFromSeedNodes(m_mediator.m_dsBlockChain.GetBlockCount(), 0,
-                                true);
-        GetTxBlockFromSeedNodes(m_mediator.m_txBlockChain.GetBlockCount(), 0);
-        this_thread::sleep_for(chrono::seconds(NEW_NODE_SYNC_INTERVAL));
-      }
-    };
-    DetachedFunction(1, func);
-  } else {
-    auto func = [this]() -> void {
+  auto func = [this]() -> void {
+    if (!ARCHIVAL_LOOKUP) {
       GetMyLookupOffline();
-      GetDSInfoFromLookupNodes();
-      while (GetSyncType() != SyncType::NO_SYNC) {
-        GetDSBlockFromLookupNodes(m_mediator.m_dsBlockChain.GetBlockCount(), 0,
-                                  true);
+    }
+    while (GetSyncType() != SyncType::NO_SYNC) {
+      ComposeAndSendGetDirectoryBlocksFromSeed(
+          m_mediator.m_blocklinkchain.GetLatestIndex() + 1, ARCHIVAL_LOOKUP,
+          LOOKUP_NODE_MODE);
+      if (ARCHIVAL_LOOKUP) {
+        GetTxBlockFromSeedNodes(m_mediator.m_txBlockChain.GetBlockCount(), 0);
+      } else {
         GetTxBlockFromLookupNodes(m_mediator.m_txBlockChain.GetBlockCount(), 0);
-        this_thread::sleep_for(chrono::seconds(NEW_NODE_SYNC_INTERVAL));
       }
-    };
-    DetachedFunction(1, func);
-  }
+
+      this_thread::sleep_for(chrono::seconds(NEW_NODE_SYNC_INTERVAL));
+    }
+    // Ask for the sharding structure from lookup (may have got new ds block
+    // with new sharding struct)
+    ComposeAndSendGetShardingStructureFromSeed();
+    std::unique_lock<std::mutex> cv_lk(m_mutexShardStruct);
+    if (cv_shardStruct.wait_for(
+            cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
+        std::cv_status::timeout) {
+      LOG_GENERAL(WARNING, "Didn't receive sharding structure!");
+    } else {
+      ProcessEntireShardingStructure();
+    }
+  };
+  DetachedFunction(1, func);
 }
 
 bool Lookup::GetDSInfoLoop() {
@@ -4750,14 +4700,38 @@ void Lookup::RejoinAsNewLookup(bool fromLookup) {
           };
           this_thread::sleep_for(chrono::seconds(RETRY_REJOINING_TIMEOUT));
         }
-        InitSync();
+
+        if (m_seedNodes.empty()) {
+          SetAboveLayer(m_seedNodes,
+                        "node.upper_seed");  // since may have called
+                                             // CleanVariable earlier
+        }
+
+        if (!MULTIPLIER_SYNC_MODE && m_l2lDataProviders.empty()) {
+          SetAboveLayer(m_l2lDataProviders, "node.l2l_data_providers");
+        }
+
+        // Check if next ds epoch was crossed -cornercase after syncing from S3
+        if ((m_mediator.m_txBlockChain.GetBlockCount() %
+                 NUM_FINAL_BLOCK_PER_POW ==
+             0)                // Can fetch dsblock and txblks from new ds epoch
+            || GetDSInfo()) {  // have same ds committee as upper seeds to
+                               // confirm if no new ds epoch started
+          InitSync();
+        } else {
+          // Sync from S3 again
+          LOG_GENERAL(INFO,
+                      "I am lagging behind by ds epoch! Will rejoin again!");
+          m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+          RejoinAsLookup(false);
+        }
       };
       DetachedFunction(1, func2);
     }
   }
 }
 
-void Lookup::RejoinAsLookup() {
+void Lookup::RejoinAsLookup(bool fromLookup) {
   if (!LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "Lookup::RejoinAsLookup not expected to be called from "
@@ -4782,9 +4756,66 @@ void Lookup::RejoinAsLookup() {
 
     DetachedFunction(1, func1);
 
-    auto func2 = [this]() -> void { StartSynchronization(); };
-
-    DetachedFunction(1, func2);
+    if (fromLookup) {  // Lookup syncing from other lookups
+      LOG_GENERAL(INFO, "Syncing from lookup ...");
+      auto func2 = [this]() mutable -> void { StartSynchronization(); };
+      DetachedFunction(1, func2);
+    } else {
+      LOG_GENERAL(INFO, "Syncing from S3 ...");
+      auto func2 = [this]() mutable -> void {
+        while (true) {
+          this->CleanVariables();
+          m_mediator.m_node->CleanUnavailableMicroBlocks();
+          while (!m_mediator.m_node->DownloadPersistenceFromS3()) {
+            LOG_GENERAL(
+                WARNING,
+                "Downloading persistence from S3 has failed. Will try again!");
+            this_thread::sleep_for(chrono::seconds(RETRY_REJOINING_TIMEOUT));
+          }
+          if (!BlockStorage::GetBlockStorage().RefreshAll()) {
+            LOG_GENERAL(WARNING, "BlockStorage::RefreshAll failed");
+            return;
+          }
+          if (!AccountStore::GetInstance().RefreshDB()) {
+            LOG_GENERAL(WARNING, "BlockStorage::RefreshDB failed");
+            return;
+          }
+          if (m_mediator.m_node->Install(SyncType::LOOKUP_SYNC, true)) {
+            break;
+          };
+          this_thread::sleep_for(chrono::seconds(RETRY_REJOINING_TIMEOUT));
+        }
+        if (m_seedNodes.empty()) {
+          SetAboveLayer(m_seedNodes,
+                        "node.upper_seed");  // since may have called
+                                             // CleanVariable earlier
+        }
+        // Check if next ds epoch was crossed - corner case after syncing from
+        // S3
+        if ((m_mediator.m_txBlockChain.GetBlockCount() %
+                 NUM_FINAL_BLOCK_PER_POW ==
+             0)                // Can fetch dsblock and txblks from new ds epoch
+            || GetDSInfo()) {  // have same ds committee as other lookups to
+                               // confirm if no new ds epoch started
+          StartSynchronization();
+        } else {
+          // Sync from S3 again
+          LOG_GENERAL(
+              INFO,
+              "I am lagging behind again by ds epoch! Will rejoin again!");
+          m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+          RejoinAsLookup(false);
+          /* Note: We would like to try to sync the missing txblocks that comes
+             before and after next ds epoch from other lookups. ( instead of
+             complete sync from S3) However, we dont't store the statedeltas
+             from previous ds epoch. So can't fetch the statedeltas for txblocks
+             that comes before next ds epoch. So those txblks would fails the
+             verification.
+          */
+        }
+      };
+      DetachedFunction(1, func2);
+    }
   }
 }
 
@@ -4822,6 +4853,8 @@ bool Lookup::CleanVariables() {
   }
   m_mediator.m_node->CleanWhitelistReqs();
   m_mediator.m_node->ClearAllPendingAndDroppedTxn();
+
+  m_confirmedLatestDSBlock = false;
 
   return true;
 }
@@ -5950,11 +5983,11 @@ void Lookup::FetchMbTxPendingTxMessageFromL2l(uint64_t blockNum) {
 }
 
 void Lookup::CheckAndFetchUnavailableMBs(bool skipLatestTxBlk) {
-  if (!LOOKUP_NODE_MODE && !ARCHIVAL_LOOKUP) {
+  if (!LOOKUP_NODE_MODE) {
     LOG_GENERAL(
         WARNING,
         "Lookup::CheckAndFetchUnavailableMBs not expected to be called from "
-        "other than the ARCHIVAL LOOKUP.");
+        "other than the LOOKUP.");
     return;
   }
   LOG_MARKER();

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -289,7 +289,7 @@ class Lookup : public Executable {
   bool GetMyLookupOnline(bool fromRecovery = false);
 
   // Rejoin the network as a lookup node in case of failure happens in protocol
-  void RejoinAsLookup();
+  void RejoinAsLookup(bool fromLookup = true);
 
   // Rejoin the network as a newlookup node in case of failure happens in
   // protocol
@@ -476,6 +476,7 @@ class Lookup : public Executable {
   bool m_fetchedLatestDSBlock = false;
   std::mutex m_mutexLatestDSBlockUpdation;
   std::condition_variable cv_latestDSBlock;
+  bool m_confirmedLatestDSBlock = false;
 
   std::mutex m_MutexCVSetTxBlockFromSeed;
   std::condition_variable cv_setTxBlockFromSeed;

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -746,9 +746,9 @@ message LookupSetMinerInfoFromSeed
 // From new join lookup node or new join normal node to existing lookup node.
 message LookupGetTxBlockFromSeed
 {
-    uint64 lowblocknum  = 1;
-    uint64 highblocknum = 2;
-    uint32 listenport   = 3;
+    uint64 lowblocknum     = 1;
+    uint64 highblocknum    = 2;
+    uint32 listenport      = 3;
 }
 
 // From lookup nodes to new join lookup node or new join normal node.

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -567,6 +567,8 @@ bool Node::ProcessVCDSBlocksMessage(const bytes& message,
   // Add to block chain and Store the DS block to disk.
   StoreDSBlockToDisk(dsblock);
 
+  m_mediator.m_lookup->m_confirmedLatestDSBlock = false;
+
   if (!BlockStorage::GetBlockStorage().ResetDB(BlockStorage::STATE_DELTA)) {
     LOG_GENERAL(WARNING, "BlockStorage::ResetDB failed");
     return false;

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -705,6 +705,43 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
   if (committeeHash != txBlock.GetHeader().GetCommitteeHash()) {
     LOG_CHECK_FAIL("DS committee hash", txBlock.GetHeader().GetCommitteeHash(),
                    committeeHash);
+    // Lets check if its legitimate hash check failure, if i am lagging behind
+    // in prev ds epoch.
+    if (LOOKUP_NODE_MODE && !m_mediator.m_lookup->m_confirmedLatestDSBlock) {
+      // Check if I have a latest DS Info (but do it only once in current ds
+      // epoch)
+      uint64_t latestDSBlockNum =
+          m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
+      uint64_t recvdDsBlockNum = txBlock.GetHeader().GetDSBlockNum();
+      m_mediator.m_lookup->m_confirmedLatestDSBlock = true;
+
+      if ((recvdDsBlockNum > latestDSBlockNum) ||
+          (m_mediator.m_dsBlockChain.GetBlockCount() <= 1)) {
+        auto func = [this]() -> void {
+          if (ARCHIVAL_LOOKUP) {
+            m_mediator.m_lookup->SetSyncType(SyncType::NEW_LOOKUP_SYNC);
+          } else {
+            m_mediator.m_lookup->SetSyncType(SyncType::LOOKUP_SYNC);
+          }
+          if (!m_mediator.m_lookup->GetDSInfo()) {
+            LOG_GENERAL(INFO,
+                        "I am lagging behind actual ds epoch. Will Rejoin!");
+            m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+            if (ARCHIVAL_LOOKUP) {
+              // Sync from S3
+              m_mediator.m_lookup->RejoinAsNewLookup(false);
+            } else  // Lookup - sync from S3
+            {
+              m_mediator.m_lookup->RejoinAsLookup(false);
+            }
+          } else {
+            m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
+          }
+        };
+        DetachedFunction(1, func);
+      }
+    }
+
     return false;
   }
 
@@ -757,7 +794,8 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
         m_mediator.m_lookup->RejoinAsNewLookup(false);
       } else  // Lookup
       {
-        m_mediator.m_lookup->RejoinAsLookup();
+        // Sync from S3
+        m_mediator.m_lookup->RejoinAsLookup(false);
       }
     }
     // Missed some final block, rejoin
@@ -784,6 +822,7 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
         }
       } else  // Lookup
       {
+        // Sync from lookup
         m_mediator.m_lookup->RejoinAsLookup();
       }
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -841,7 +841,9 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
 
   if ((LOOKUP_NODE_MODE && ARCHIVAL_LOOKUP &&
        SyncType::NEW_LOOKUP_SYNC == syncType) ||
-      (LOOKUP_NODE_MODE && SyncType::RECOVERY_ALL_SYNC == syncType)) {
+      (LOOKUP_NODE_MODE && SyncType::RECOVERY_ALL_SYNC == syncType) ||
+      (LOOKUP_NODE_MODE && !ARCHIVAL_LOOKUP &&
+       SyncType::LOOKUP_SYNC == syncType)) {
     // Additional safe-guard mechanism, find if have not received any MBs from
     // last N txblks in persistence from S3.
     m_mediator.m_lookup->FindMissingMBsForLastNTxBlks(
@@ -902,7 +904,8 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
                                                !bDS) ||
       SyncType::NEW_LOOKUP_SYNC == syncType ||
       (rejoiningAfterRecover &&
-       (SyncType::NORMAL_SYNC == syncType || SyncType::DS_SYNC == syncType))) {
+       (SyncType::NORMAL_SYNC == syncType || SyncType::DS_SYNC == syncType ||
+        SyncType::LOOKUP_SYNC == syncType))) {
     return true;
   }
 

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -55,7 +55,6 @@ bool Node::GetLatestDSBlock() {
     m_synchronizer.FetchLatestDSBlocksSeed(
         m_mediator.m_lookup,
         m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() + 1);
-
     {
       unique_lock<mutex> lock(
           m_mediator.m_lookup->m_mutexLatestDSBlockUpdation);


### PR DESCRIPTION
## Description
Fixes the issue : https://github.com/Zilliqa/Issues/issues/651

With this fix, lookups will be able to automatically resync if its lagging behind by ds epoch after being restarted.
On receiving the txblock from newer ds epoch, lookup identifies that its lagging behind and so it triggers Rejoin from S3.

During RejoinAsLookup or RejoinAsNewLookup, after `Install` is finished ( i.e. processing of S3 dowloaded persistence), it rechecks if ds epoch is crossed. If so, it will re-attempt to rejoin from S3 which will next time not result in corner case ( i.e. another ds epoch will not be crossed) and node will be synced.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
