### PR TITLE
Divert naming of rewards field in different epoch

### DIFF
--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -125,7 +125,7 @@ class Mediator {
 
   bool GetIsVacuousEpoch();
 
-  bool GetIsVacuousEpoch(const uint64_t& epochNum);
+  static bool GetIsVacuousEpoch(const uint64_t& epochNum);
 
   uint32_t GetShardSize(const bool& useShardStructure) const;
 

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -27,6 +27,7 @@
 #include "libData/AccountData/Transaction.h"
 #include "libData/AccountData/TransactionReceipt.h"
 #include "libData/BlockData/Block.h"
+#include "libMediator/Mediator.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/Logger.h"
 
@@ -55,10 +56,14 @@ const Json::Value JSONConversion::convertTxBlocktoJson(const TxBlock& txblock) {
 
   const TxBlockHeader& txheader = txblock.GetHeader();
 
+  bool isVacuous =
+      Mediator::GetIsVacuousEpoch(txblock.GetHeader().GetBlockNum());
+
   ret_head["Version"] = txheader.GetVersion();
   ret_head["GasLimit"] = to_string(txheader.GetGasLimit());
   ret_head["GasUsed"] = to_string(txheader.GetGasUsed());
-  ret_head["Rewards"] = txheader.GetRewards().str();
+  ret_head["Rewards"] = isVacuous ? txheader.GetRewards().str() : 0;
+  ret_head["TxnFees"] = isVacuous ? 0 : txheader.GetRewards().str();
   ret_head["PrevBlockHash"] = txheader.GetPrevHash().hex();
   ret_head["BlockNum"] = to_string(txheader.GetBlockNum());
   ret_head["Timestamp"] = to_string(txblock.GetTimestamp());


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Since the `rewards` field in the actual TxBlock can mean for Transaction fees incurred during non-vacuous epoch and also coinbase reward during vacuous epoch. For avoid misunderstanding we decided to explain it into two fields in API level, `TxnFees` and `Rewards` respectively as below:
```
                  | TxnFees | Rewards
Non-vacuous       | fees    | 0
Vacuous           | 0       | coinbase
```
## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
