### PR TITLE
Fix race condition where GetWorkServer will put difficulty solution for ds_difficulty mining

### DIFF
--- a/src/libServer/GetWorkServer.h
+++ b/src/libServer/GetWorkServer.h
@@ -121,6 +121,9 @@ class GetWorkServer : public AbstractStubServer {
   std::mutex m_mutexResult;
   std::condition_variable m_cvGotResult;
 
+  // an indicator for current mining target difficulty
+  std::atomic<uint8_t> m_currentTargetDifficulty{};
+
  public:
   // Returns the singleton instance.
   static GetWorkServer &GetInstance();
@@ -146,7 +149,8 @@ class GetWorkServer : public AbstractStubServer {
   // Protocol for GetResult
   ethash_mining_result_t GetResult(int waitTime);
 
-  bool UpdateCurrentResult(const ethash_mining_result_t &newResult);
+  bool UpdateCurrentResult(const ethash_mining_result_t &newResult,
+                           const uint8_t difficulty);
 
   // RPC methods
   virtual Json::Value getWork();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
It's possible for `GetWorkServer::submitWork` to receive another solution in the time between `StopMining` for difficulty and `StartMining` for ds_difficulty.

When this happens, `GetWorkServer::UpdateCurrentResult` will trigger `m_cvGotResult` prematurely, causing `Node::StartPoW` to stop mining for DS difficulty and submitting this second solution (which may not satisfy ds_difficulty) to DS committee.

The fix is to keep track of current difficulty inside `GetWorkServer` using a new `m_currentTargetDifficulty` member variable.
1. Set value to difficulty level during `GetWorkServer::StartMining`
1. Pass this value as a parameter into `GetWorkServer::UpdateCurrentResult`
1. Just before accepting PoW result inside `GetWorkServer::UpdateCurrentResult`, double-check that the passed parameter value still matches the current value of `m_currentTargetDifficulty`
1. Set value to zero during `GetWorkServer::StopMining`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
