### PR TITLE
Move auto_backup to lookup-1 and skip upload_incr_DB backup

### DIFF
--- a/daemon/ZilliqaDaemon.cpp
+++ b/daemon/ZilliqaDaemon.cpp
@@ -327,8 +327,10 @@ void ZilliqaDaemon::StartScripts() {
       ZilliqaDaemon::LOG(m_log, "\" " + Execute(cmdToRun + " 2>&1") + " \"");
       exit(0);
     }
+  }
 
-    pid_parent = fork();
+  if (m_nodeType == "lookup" && 1 == m_nodeIndex) {
+    pid_t pid_parent = fork();
 
     if (pid_parent < 0) {
       ZilliqaDaemon::LOG(m_log, "Failed to fork.");
@@ -342,27 +344,6 @@ void ZilliqaDaemon::StartScripts() {
       ZilliqaDaemon::LOG(m_log, "Start to run command: \"" + cmdToRun + "\"");
       ZilliqaDaemon::LOG(m_log, "\" " + Execute(cmdToRun + " 2>&1") + " \"");
       cmdToRun = "python3 " + m_curPath + auto_backup_script + " -f 10 &";
-      ZilliqaDaemon::LOG(m_log, "Start to run command: \"" + cmdToRun + "\"");
-      ZilliqaDaemon::LOG(m_log, "\" " + Execute(cmdToRun + " 2>&1") + " \"");
-      exit(0);
-    }
-  }
-
-  if (m_nodeType == "lookup" && 1 == m_nodeIndex) {
-    pid_t pid_parent = fork();
-
-    if (pid_parent < 0) {
-      ZilliqaDaemon::LOG(m_log, "Failed to fork.");
-      exit(EXIT_FAILURE);
-    }
-
-    if (pid_parent == 0) {
-      string cmdToRun =
-          "ps axf | grep " + upload_incr_DB_script +
-          " | grep -v grep  | awk '{print \"kill -9 \" $1}'| sh &";
-      ZilliqaDaemon::LOG(m_log, "Start to run command: \"" + cmdToRun + "\"");
-      ZilliqaDaemon::LOG(m_log, "\" " + Execute(cmdToRun + " 2>&1") + " \"");
-      cmdToRun = "python3 " + m_curPath + upload_incr_DB_script + " --backup &";
       ZilliqaDaemon::LOG(m_log, "Start to run command: \"" + cmdToRun + "\"");
       ZilliqaDaemon::LOG(m_log, "\" " + Execute(cmdToRun + " 2>&1") + " \"");
       exit(0);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`upload_incr_DB` in backup mode (different S3 location) is not used for anything right now.
Better to omit it and relieve `lookup-0` of having to do both persistence backup and incremental DB updating.

Before:
`lookup-0`: `auto_backup` and `upload_incr_DB`
`lookup-1`: `upload_incr_DB (backup S3 location)`

After:
`lookup-0`: `upload_incr_DB`
`lookup-1`: `auto_backup`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
