### PR TITLE
[release-7.0] Make governance output as part of DS block header instead of separate header

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -139,6 +139,8 @@ const Json::Value JSONConversion::convertDSblocktoJson(const DSBlock& dsblock) {
     ret_header["PoWWinners"].append(static_cast<string>(dswinner.first));
   }
 
+  ret_header["Timestamp"] = to_string(dsblock.GetTimestamp());
+
   for (const auto& govProposal : dshead.GetGovProposalMap()) {
     Json::Value _tempGovProposal;
     Json::Value _dsvotes;
@@ -154,10 +156,8 @@ const Json::Value JSONConversion::convertDSblocktoJson(const DSBlock& dsblock) {
       _shardvotes["VoteCount"] = votes.second;
       _tempGovProposal["ShardVotes"].append(_shardvotes);
     }
-    ret["Governance"].append(_tempGovProposal);
+    ret_header["Governance"].append(_tempGovProposal);
   }
-
-  ret_header["Timestamp"] = to_string(dsblock.GetTimestamp());
   ret["header"] = ret_header;
 
   ret["signature"] = ret_sign;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Previously governance header was part of `result` header.The PR makes governance info as a part of DS block header.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
## Result:
Output of GetDsBlock api.
`{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "header": {
      "BlockNum": "5",
      "Difficulty": 3,
      "DifficultyDS": 13,
      "GasPrice": "1000000000",
      "Governance": [
        {
          "ProposalId": 14,
          "ShardVotes": [
            {
              "VoteCount": 1,
              "VoteValue": 14
            }
          ]
        },
        {
          "ProposalId": 15,
          "ShardVotes": [
            {
              "VoteCount": 1,
              "VoteValue": 15
            }
          ]
        }
      ],
      "LeaderPubKey": "0x022D2FEEB232EB40A72C919840258E9E610A5B77F1A157EEFB9EE307860970D60A",
      "PoWWinners": [
        "0x03E43265761E26FD6AC7CEF2786625730D80D0CE6C7548A659E3964E0FDBBD24CF"
      ],
      "PrevHash": "a70507269a0d7775c5563850f127db0e79c77cb8663ad16128b54ef87da54d3e",
      "Timestamp": "1599644494320586"
    },
    "signature": "01003A73521C5C6E035E06B40A0B5F8C8E545494C0402AE5E68C47FEC6049964198219CD3AA3F6628F1B53F28FF2F92615CE7693A67D41592BBE38AD5190D984"
  }
}`