### PR TITLE
Send Zilliqa application logs to STDOUT

### DIFF
--- a/src/cmd/main.cpp
+++ b/src/cmd/main.cpp
@@ -81,6 +81,7 @@ int main(int argc, const char* argv[]) {
         "loadconfig,l", "Loads configuration if set (deprecated)")(
         "synctype,s", po::value<unsigned int>(&syncType), synctype_descr)(
         "recovery,r", "Runs in recovery mode if set")(
+        "stdoutlog,o", "Send application logs to stdout instead of file")(
         "logpath,g", po::value<string>(&logpath),
         "customized log path, could be relative path (e.g., \"./logs/\"), or "
         "absolute path (e.g., \"/usr/local/test/logs/\")")(
@@ -166,7 +167,11 @@ int main(int argc, const char* argv[]) {
       return ERROR_IN_COMMAND_LINE;
     }
 
-    INIT_FILE_LOGGER("zilliqa", logpath.c_str());
+    if (vm.count("stdoutlog")) {
+      INIT_STDOUT_LOGGER();
+    } else {
+      INIT_FILE_LOGGER("zilliqa", logpath.c_str());
+    }
     INIT_STATE_LOGGER("state", logpath.c_str());
     INIT_EPOCHINFO_LOGGER("epochinfo", logpath.c_str());
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The goal of the PR is to provide option to send zilliqa application logs to `stdout` instead of file.
The change introduces new command line parameter `--stdoutlog` which if provided , will send application logs to standard output instead of files.This is applicable for `zilliqa`, `state` , `epoch` logs.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change


## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
