### PR TITLE
[release-7.0] Misleading error msg for AddToSeedsWhitelist

### DIFF
--- a/src/libNetwork/Blacklist.cpp
+++ b/src/libNetwork/Blacklist.cpp
@@ -120,6 +120,8 @@ void Blacklist::Enable(const bool enable) {
   m_enabled = enable;
 }
 
+bool Blacklist::IsEnabled() { return m_enabled; }
+
 bool Blacklist::Whitelist(const uint128_t& ip) {
   if (!m_enabled) {
     return false;

--- a/src/libNetwork/Blacklist.h
+++ b/src/libNetwork/Blacklist.h
@@ -79,6 +79,9 @@ class Blacklist {
   /// Enable / disable blacklist
   void Enable(const bool enable);
 
+  // Check if Blacklisting/Whitelisting is enabled
+  bool IsEnabled();
+
   /// Node to be whitelisted
   bool Whitelist(const uint128_t& ip);
 

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -275,6 +275,12 @@ bool StatusServer::AddToSeedsWhitelist(const string& ipAddr) {
                              "IP Address provided not valid");
     }
 
+    if (!Blacklist::GetInstance().IsEnabled()) {
+      throw JsonRpcException(
+          RPC_INVALID_PARAMETER,
+          "Whitelisting is disabled. Node might not be synced yet!");
+    }
+
     if (!Blacklist::GetInstance().WhitelistSeed(numIP)) {
       throw JsonRpcException(
           RPC_INVALID_PARAMETER,


### PR DESCRIPTION
## Description
AddToSeedsWhitelist gives misleading error msg Could not add IP Address in whitelisted seed list, already present when node is yet to be synced ( i.e. when blacklisting/whitelisting is turned off ).

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
