### PR TITLE
Bring transaction distribution earlier for shard

### DIFF
--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -127,6 +127,7 @@ class Lookup : public Executable {
   std::mutex m_mutexMicroBlocksBuffer;
 
   TxnShardMap m_txnShardMap;
+  TxnShardMap m_txnShardMapGenerated;
 
   // Get StateDeltas from seed
   std::mutex m_mutexSetStateDeltasFromSeed;
@@ -192,6 +193,7 @@ class Lookup : public Executable {
   VectorOfNode GetSeedNodes() const;
 
   std::mutex m_txnShardMapMutex;
+  std::mutex m_txnShardMapGeneratedMutex;
 
   const std::vector<Transaction>& GetTxnFromShardMap(
       uint32_t index);  // Use m_txnShardMapMutex with this function
@@ -307,9 +309,16 @@ class Lookup : public Executable {
 
   bool GetIsServer();
 
-  void SenderTxnBatchThread(const uint32_t);
+  void SenderTxnBatchThread(const uint32_t, bool newDSEpoch = false);
 
-  void SendTxnPacketToNodes(const uint32_t, const uint32_t);
+  void SendTxnPacketPrepare(const uint32_t oldNumShards,
+                            const uint32_t newNumShards);
+  void SendTxnPacketToNodes(const uint32_t oldNumShards,
+                            const uint32_t newNumShards);
+  void SendTxnPacketToDS(const uint32_t oldNumShards,
+                         const uint32_t newNumShards);
+  void SendTxnPacketToShard(const uint32_t shardId, bool toDS);
+
   bool ProcessEntireShardingStructure();
   bool ProcessGetDSInfoFromSeed(const bytes& message, unsigned int offset,
                                 const Peer& from);

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -348,7 +348,7 @@ void Node::StartFirstTxEpoch(bool fbWaitState) {
     P2PComm::GetInstance().InitializeRumorManager(peers, pubKeys);
   }
 
-  CommitTxnPacketBuffer();
+  // CommitTxnPacketBuffer();
 
   if (fbWaitState) {
     SetState(WAITING_FINALBLOCK);
@@ -731,7 +731,7 @@ bool Node::ProcessVCDSBlocksMessage(const bytes& message,
     }
 
     if (m_mediator.m_lookup->GetIsServer() && !ARCHIVAL_LOOKUP) {
-      m_mediator.m_lookup->SenderTxnBatchThread(oldNumShards);
+      m_mediator.m_lookup->SenderTxnBatchThread(oldNumShards, true);
     }
 
     FallbackTimerLaunch();

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -325,6 +325,9 @@ bool Node::ProcessMicroBlockConsensusCore(const bytes& message,
                      m_consensusObject->GetCS2(), m_consensusObject->GetB2());
 
     SetState(WAITING_FINALBLOCK);
+    m_txn_distribute_window_open = true;
+
+    CommitTxnPacketBuffer();
 
     lock_guard<mutex> cv_lk(m_MutexCVFBWaitMB);
     cv_FBWaitMB.notify_all();
@@ -368,9 +371,12 @@ bool Node::ProcessMicroBlockConsensusCore(const bytes& message,
     LOG_GENERAL(WARNING, "ConsensusCommon::State::ERROR here, but we move on.");
 
     SetState(WAITING_FINALBLOCK);  // Move on to next Epoch.
+    m_txn_distribute_window_open = true;
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
               "If I received a new Finalblock from DS committee. I will "
               "still process it");
+
+    CommitTxnPacketBuffer();
 
     lock_guard<mutex> cv_lk(m_MutexCVFBWaitMB);
     cv_FBWaitMB.notify_all();

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -1088,7 +1088,7 @@ bool Node::RunConsensusOnMicroBlock() {
   LOG_MARKER();
 
   SetState(MICROBLOCK_CONSENSUS_PREP);
-  m_txn_distribute_window_open = true;
+  cv_txnPacket.notify_all();
 
   if (m_mediator.GetIsVacuousEpoch()) {
     LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -924,6 +924,9 @@ bool Node::RunConsensusOnMicroBlockWhenShardLeader() {
       !m_mediator.GetIsVacuousEpoch()) {
     std::this_thread::sleep_for(chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS +
                                                      ANNOUNCEMENT_DELAY_IN_MS));
+    while (m_txnPacketThreadOnHold > 0) {
+      std::this_thread::sleep_for(chrono::milliseconds(100));
+    }
   }
 
   m_txn_distribute_window_open = false;
@@ -1027,6 +1030,9 @@ bool Node::RunConsensusOnMicroBlockWhenShardBackup() {
        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() >=
            TXN_DS_TARGET_NUM)) {
     std::this_thread::sleep_for(chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS));
+    while (m_txnPacketThreadOnHold > 0) {
+      std::this_thread::sleep_for(chrono::milliseconds(100));
+    }
     ProcessTransactionWhenShardBackup(SHARD_MICROBLOCK_GAS_LIMIT);
   }
 

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -126,6 +126,10 @@ class Node : public Executable {
   std::mutex m_mutexCVWaitDSBlock;
   std::condition_variable cv_waitDSBlock;
 
+  /// TxnPacket Timer Vars
+  std::mutex m_mutexCVTxnPacket;
+  std::condition_variable cv_txnPacket;
+
   // Final Block Buffer for seed node
   std::vector<bytes> m_seedTxnBlksBuffer;
   std::mutex m_mutexSeedTxnBlksBuffer;

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -129,6 +129,7 @@ class Node : public Executable {
   /// TxnPacket Timer Vars
   std::mutex m_mutexCVTxnPacket;
   std::condition_variable cv_txnPacket;
+  std::atomic<uint32_t> m_txnPacketThreadOnHold{0};
 
   // Final Block Buffer for seed node
   std::vector<bytes> m_seedTxnBlksBuffer;


### PR DESCRIPTION
Two major changes:
- Lookup dispatch transaction upon receiving of soft confirmation with microblock.
- Shard node distribute gossip for transaction upon receiving of packet from lookup, hold and commit into txn pool upon new epoch. 

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
