### PR TITLE
Add NONCE_TOO_LOW error to dropped txns

### DIFF
--- a/src/common/TxnStatus.h
+++ b/src/common/TxnStatus.h
@@ -52,6 +52,7 @@ enum TxnStatus : uint8_t {
   //
   INVALID_TO_ACCOUNT = 25,
   FAIL_CONTRACT_ACCOUNT_CREATION = 26,
+  NONCE_TOO_LOW = 27,
   ERROR = 255  // MISC_ERROR
 };
 

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -408,12 +408,12 @@ void Node::ProcessTransactionWhenShardLeader(
       // if nonce too small, ignore it
       else if (t.GetNonce() <
                AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
-        // LOG_GENERAL(INFO,
-        //             "Nonce too small"
-        //                 << " Expected "
-        //                 <<
-        //                 AccountStore::GetInstance().GetNonceTemp(senderAddr)
-        //                 << " Found " << t.GetNonce());
+        LOG_GENERAL(
+            INFO, "Nonce too small"
+                      << " Expected "
+                      << AccountStore::GetInstance().GetNonceTemp(senderAddr)
+                      << " Found " << t.GetNonce() << " for " << t.GetTranID());
+        droppedTxns.emplace_back(t.GetTranID(), TxnStatus::NONCE_TOO_LOW);
       }
       // if nonce correct, process it
       else {
@@ -676,6 +676,12 @@ void Node::ProcessTransactionWhenShardBackup(
       // if nonce too small, ignore it
       else if (t.GetNonce() <
                AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
+        LOG_GENERAL(
+            INFO, "Nonce too small"
+                      << " Expected "
+                      << AccountStore::GetInstance().GetNonceTemp(senderAddr)
+                      << " Found " << t.GetNonce() << " for " << t.GetTranID());
+        droppedTxns.emplace_back(t.GetTranID(), TxnStatus::NONCE_TOO_LOW);
       }
       // if nonce correct, process it
       else {


### PR DESCRIPTION
## Description
When a txn reaches the lookup at the stage when a the lookup did not update the  account nonce in its own local memory
but when the same was recv by DS it was already too late (the txn with same nonce was already processed). It results in rejection of the txn as the nonce does not match.
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
