### PR TITLE
[release-6.4] Redefine recovery process of normal and dsguard nodes

### DIFF
--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -177,6 +177,18 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     LOG_GENERAL(FATAL, "Archvial lookup is true but not lookup ");
   }
 
+  // when individual node is being recovered and persistence is not available
+  // locally, then Rejoin as if new miner node which will download persistence
+  // from S3 incremental db and identify if already part of any
+  // shard/dscommittee and proceed accordingly.
+
+  if (!LOOKUP_NODE_MODE && (SyncType::RECOVERY_ALL_SYNC == syncType)) {
+    if (!boost::filesystem::exists(STORAGE_PATH + PERSISTENCE_PATH)) {
+      syncType = SyncType::NEW_SYNC;
+      m_lookup.SetSyncType(SyncType::NEW_SYNC);
+    }
+  }
+
   if (SyncType::NEW_SYNC == syncType) {
     // Setting it earliest before even p2pcomm is instantiated
     m_n.m_runFromLate = true;
@@ -184,10 +196,6 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
 
   P2PComm::GetInstance().SetSelfPeer(peer);
   P2PComm::GetInstance().SetSelfKey(key);
-
-  // Clear any existing diagnostic data from previous runs
-  BlockStorage::GetBlockStorage().ResetDB(BlockStorage::DIAGNOSTIC_NODES);
-  BlockStorage::GetBlockStorage().ResetDB(BlockStorage::DIAGNOSTIC_COINBASE);
 
   if (GUARD_MODE) {
     // Setting the guard upon process launch
@@ -200,6 +208,10 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
       LOG_GENERAL(INFO, "Current node is a shard guard");
     }
   }
+
+  // Clear any existing diagnostic data from previous runs
+  BlockStorage::GetBlockStorage().ResetDB(BlockStorage::DIAGNOSTIC_NODES);
+  BlockStorage::GetBlockStorage().ResetDB(BlockStorage::DIAGNOSTIC_COINBASE);
 
   if (SyncType::NEW_LOOKUP_SYNC == syncType || SyncType::NEW_SYNC == syncType) {
     while (!m_n.DownloadPersistenceFromS3()) {
@@ -301,7 +313,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
         break;
       case SyncType::DS_SYNC:
         LOG_GENERAL(INFO, "Sync as a ds node");
-        m_ds.StartSynchronization();
+        m_ds.StartSynchronization(false);
         break;
       case SyncType::LOOKUP_SYNC:
         LOG_GENERAL(INFO, "Sync as a lookup node");


### PR DESCRIPTION
## Description
Addresses issue https://github.com/Zilliqa/Issues/issues/670 and also remediate issue https://github.com/Zilliqa/Issues/issues/669

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] small-scale cloud test
 - [x] Recover entire testnet from old testnet
 - [x] Recover one normal node part of any existing shard
 - [x] Recover one normal node not part of any existing shard 
 - [x] Recover one dsguard node part of current dscommittee
 - [x] scale new node (miner node) 