### PR TITLE
Improve accuracy of GetWorkServer::GetSecondsToNextPoW

### DIFF
--- a/scripts/miner_info.py
+++ b/scripts/miner_info.py
@@ -123,6 +123,7 @@ def make_options_dictionary(options_dict):
 	options_dict["get_remotestorage"] = "GetRemoteStorage"
 	options_dict["set_remotestorage"] = "ToggleRemoteStorage"
 	options_dict["init_remotestorage"] = "InitRemoteStorage"
+	options_dict["blocktime"] = "GetAverageBlockTime"
 
 def ProcessResponseCore(resp, param):
 	if param:

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2946,7 +2946,7 @@ bool Lookup::ProcessSetTxBlockFromSeed(const bytes& message,
     num_block = num_block % NUM_FINAL_BLOCK_PER_POW;
     auto now = std::chrono::system_clock::now();
     auto wait_seconds = chrono::seconds(
-        ((TX_DISTRIBUTE_TIME_IN_MS + ANNOUNCEMENT_DELAY_IN_MS) / 1000) *
+        static_cast<unsigned int>(m_mediator.m_aveBlockTimeInSeconds) *
         num_block);
 
     GetWorkServer::GetInstance().SetNextPoWTime(now + wait_seconds);

--- a/src/libMediator/Mediator.cpp
+++ b/src/libMediator/Mediator.cpp
@@ -49,7 +49,11 @@ Mediator::Mediator(const PairOfKey& key, const Peer& peer)
       m_isVacuousEpoch(false),
       m_curSWInfo(),
       m_disablePoW(false),
-      m_validateState(ValidateState::IDLE) {
+      m_validateState(ValidateState::IDLE),
+      m_aveBlockTimeInSeconds(
+          static_cast<double>(TX_DISTRIBUTE_TIME_IN_MS +
+                              (ANNOUNCEMENT_DELAY_IN_MS * 2)) /
+          1000) {
   SetupLogLevel();
 }
 
@@ -143,9 +147,10 @@ void Mediator::IncreaseEpochNum() {
 
     num_block = num_block % NUM_FINAL_BLOCK_PER_POW;
     auto now = std::chrono::system_clock::now();
+
+    // block time = average over last
     auto wait_seconds = chrono::seconds(
-        ((TX_DISTRIBUTE_TIME_IN_MS + ANNOUNCEMENT_DELAY_IN_MS) / 1000) *
-        num_block);
+        static_cast<unsigned int>(m_aveBlockTimeInSeconds) * num_block);
 
     GetWorkServer::GetInstance().SetNextPoWTime(now + wait_seconds);
   }

--- a/src/libMediator/Mediator.h
+++ b/src/libMediator/Mediator.h
@@ -103,6 +103,9 @@ class Mediator {
   /// ValidateDB state, used by StatusServer
   std::atomic<ValidateState> m_validateState;
 
+  /// Average TxBlock time in seconds, used by GetWorkServer
+  std::atomic<double> m_aveBlockTimeInSeconds;
+
   /// Constructor.
   Mediator(const PairOfKey& key, const Peer& peer);
 

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -77,6 +77,24 @@ bool Node::StoreFinalBlock(const TxBlock& txBlock) {
     return false;
   }
 
+  // Update average block time except when txblock is first block for the epoch
+  if ((txBlock.GetHeader().GetBlockNum() % NUM_FINAL_BLOCK_PER_POW) > 0) {
+    const uint64_t& timestampBef =
+        m_mediator.m_txBlockChain
+            .GetBlock(txBlock.GetHeader().GetBlockNum() - 1)
+            .GetTimestamp();
+    const uint64_t& timestampNow = txBlock.GetTimestamp();
+    const double lastBlockTimeInSeconds =
+        static_cast<double>(timestampNow - timestampBef) / 1000000;
+    double tmpAveBlockTimeInSeconds = m_mediator.m_aveBlockTimeInSeconds;
+    tmpAveBlockTimeInSeconds -=
+        tmpAveBlockTimeInSeconds / NUM_FINAL_BLOCK_PER_POW;
+    tmpAveBlockTimeInSeconds +=
+        lastBlockTimeInSeconds / NUM_FINAL_BLOCK_PER_POW;
+    m_mediator.m_aveBlockTimeInSeconds =
+        (tmpAveBlockTimeInSeconds < 1) ? 1 : tmpAveBlockTimeInSeconds;
+  }
+
   m_mediator.IncreaseEpochNum();
 
   LOG_STATE(

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -147,6 +147,10 @@ StatusServer::StatusServer(Mediator& mediator,
       jsonrpc::Procedure("InitRemoteStorage", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_OBJECT, NULL),
       &StatusServer::InitRemoteStorageI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("GetAverageBlockTime", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_STRING, NULL),
+      &StatusServer::GetAverageBlockTimeI);
 }
 
 string StatusServer::GetLatestEpochStatesUpdated() {
@@ -565,4 +569,9 @@ bool StatusServer::InitRemoteStorage() {
   }
 
   return true;
+}
+
+string StatusServer::AverageBlockTime() {
+  return to_string(
+      static_cast<unsigned int>(m_mediator.m_aveBlockTimeInSeconds));
 }

--- a/src/libServer/StatusServer.h
+++ b/src/libServer/StatusServer.h
@@ -130,6 +130,11 @@ class StatusServer : public Server,
     (void)request;
     response = this->InitRemoteStorage();
   }
+  inline virtual void GetAverageBlockTimeI(const Json::Value& request,
+                                           Json::Value& response) {
+    (void)request;
+    response = this->AverageBlockTime();
+  }
 
   Json::Value IsTxnInMemPool(const std::string& tranID);
   bool AddToBlacklistExclusion(const std::string& ipAddr);
@@ -156,6 +161,7 @@ class StatusServer : public Server,
   bool ToggleRemoteStorage();
   bool GetRemoteStorage();
   bool InitRemoteStorage();
+  std::string AverageBlockTime();
 };
 
 #endif  // ZILLIQA_SRC_LIBSERVER_STATUSSERVER_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
For mining proxy server, `GetWorkServer::SetNextPoWTime` is called in two places (after receiving new Tx block):
1. `Lookup::ProcessSetTxBlockFromSeed`
1. `Mediator::IncreaseEpochNum`

Proxy miners then use `GetSecondsToNextPoW` to estimate when the next PoW window will begin.

Currently, next PoW time is estimated using fixed value `TX_DISTRIBUTE_TIME_IN_MS + ANNOUNCEMENT_DELAY_IN_MS` multiplied by the remaining Tx blocks before the end of the current DS epoch.

This block duration is not an accurate estimate because:
1. Actually `ANNOUNCEMENT_DELAY_IN_MS` is not done just once, but twice: during MB and FB consensus
1. Actual block time varies depending on performance of nodes

This PR adds a new variable `Mediator.m_aveBlockTimeInSeconds`
1. It is initially set to `TX_DISTRIBUTE_TIME_IN_MS + (ANNOUNCEMENT_DELAY_IN_MS * 2)`
1. In `Node::StoreFinalBlock`, it is updated as follows:
   ```
   ave = ave - (ave / N)
   ave = ave + (new value / N)
   ```
1. `N` is the sample size, which is just set to `NUM_FINAL_BLOCK_PER_POW` (using a larger value does not improve accuracy because we change shard composition every DS epoch anyway)
1. This average is then used in the calls to `GetWorkServer::SetNextPoWTime`
1. The accuracy should continue to improve as the node goes through its first full DS epoch, and onwards

The average can also be obtained using `miner_info.py blocktime`.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
