### PR TITLE
[release-7.0] Index microblocks by epoch number and shard ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,11 @@ if(SJ_TEST_SJ_MISSING_MBTXNS)
     add_definitions(-DSJ_TEST_SJ_MISSING_MBTXNS)
 endif()
 
+if(MIGRATE_MICROBLOCKS)
+    message(STATUS "Migrate MBs enabled")
+    add_definitions(-DMIGRATE_MICROBLOCKS)
+endif()
+
 include(FindProtobuf)
 set(protobuf_MODULE_COMPATIBLE TRUE)
 find_package(Protobuf CONFIG REQUIRED)

--- a/build.sh
+++ b/build.sh
@@ -141,7 +141,11 @@ do
     sj2)
         CMAKE_EXTRA_OPTIONS="-DSJ_TEST_SJ_MISSING_MBTXNS=1 ${CMAKE_EXTRA_OPTIONS}"
         echo "Build with SJ test - New Seed misses the mbtxns message from multiplier"
-    ;;        
+    ;;
+    migrate_mbs)
+        CMAKE_EXTRA_OPTIONS="-DMIGRATE_MICROBLOCKS=1 ${CMAKE_EXTRA_OPTIONS}"
+        echo "Build with microblock persistent migration"
+    ;;
     *)
         echo "Usage $0 [cuda|opencl] [tsan|asan] [style] [heartbeattest] [vc<1-8>] [dm<1-9>] [sj<1-2>]"
         exit 1

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -120,3 +120,10 @@ add_custom_command(TARGET zilliqa
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:websocketsubscriber> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
 target_include_directories(websocketsubscriber PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(websocketsubscriber PUBLIC Utils Server)
+
+add_executable(migrate_mbs migrate_mbs.cpp)
+add_custom_command(TARGET zilliqa
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:migrate_mbs> ${CMAKE_BINARY_DIR}/tests/Zilliqa)
+target_include_directories(migrate_mbs PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(migrate_mbs PUBLIC Utils Server)

--- a/src/cmd/migrate_mbs.cpp
+++ b/src/cmd/migrate_mbs.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "libMediator/Mediator.h"
+#include "libNetwork/Guard.h"
+#include "libPersistence/BlockStorage.h"
+#include "libPersistence/Retriever.h"
+#include "libUtils/UpgradeManager.h"
+
+/// Should be run from a location with constants.xml and persistence folder
+
+using namespace std;
+
+int main() {
+  TxBlockSharedPtr txBlockPtr;
+  if (!BlockStorage::GetBlockStorage().GetLatestTxBlock(txBlockPtr)) {
+    LOG_GENERAL(WARNING, "BlockStorage::GetLatestTxBlock failed");
+    return -1;
+  }
+  const uint64_t lastTxBlockNum = txBlockPtr->GetHeader().GetBlockNum();
+  for (uint64_t txBlockNum = 0; txBlockNum <= lastTxBlockNum; txBlockNum++) {
+    if ((txBlockNum % 1000) == 0) {
+      cout << "At TxBlock " << txBlockNum << endl;
+    }
+    if (!BlockStorage::GetBlockStorage().GetTxBlock(txBlockNum, txBlockPtr)) {
+      LOG_GENERAL(FATAL, "Failed to get TxBlock " << txBlockNum);
+      return -1;
+    }
+    auto microBlockInfos = txBlockPtr->GetMicroBlockInfos();
+    for (auto const& mbInfo : microBlockInfos) {
+      MicroBlockSharedPtr mbptr;
+      if (mbInfo.m_txnRootHash == TxnHash()) {
+        continue;
+      }
+      if (!BlockStorage::GetBlockStorage().GetMicroBlock(
+              mbInfo.m_microBlockHash, mbptr)) {
+        LOG_GENERAL(WARNING, "Missing MB " << mbInfo.m_microBlockHash
+                                           << " for TxBlock " << txBlockNum);
+        continue;
+      }
+      bytes body;
+      mbptr->Serialize(body, 0);
+      if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+              mbInfo.m_microBlockHash, mbptr->GetHeader().GetEpochNum(),
+              mbptr->GetHeader().GetShardId(), body)) {
+        LOG_GENERAL(FATAL, "Failed to write MB " << mbInfo.m_microBlockHash
+                                                 << " for TxBlock "
+                                                 << txBlockNum);
+        return -1;
+      }
+    }
+  }
+
+  return 0;
+}

--- a/src/depends/libDatabase/LevelDB.cpp
+++ b/src/depends/libDatabase/LevelDB.cpp
@@ -152,6 +152,19 @@ string LevelDB::Lookup(const std::string & key) const
     return value;
 }
 
+string LevelDB::Lookup(const vector<unsigned char>& key) const
+{
+    string value;
+    leveldb::Status s = m_db->Get(leveldb::ReadOptions(), leveldb::Slice(vector_ref<const unsigned char>(&key[0], key.size())), &value);
+    if (!s.ok())
+    {
+        // TODO
+        return "";
+    }
+
+    return value;
+}
+
 string LevelDB::Lookup(const boost::multiprecision::uint256_t & blockNum) const
 {
     string value;
@@ -215,6 +228,22 @@ std::shared_ptr<leveldb::DB> LevelDB::GetDB()
 int LevelDB::Insert(const dev::h256 & key, dev::bytesConstRef value)
 {
     return Insert(key, value.toString());
+}
+
+int LevelDB::Insert(const vector<unsigned char>& key, const vector<unsigned char>& body)
+{
+    leveldb::Status s = m_db->Put(leveldb::WriteOptions(),
+                                  leveldb::Slice(vector_ref<const unsigned char>(&key[0], key.size())),
+                                  leveldb::Slice(vector_ref<const unsigned char>(&body[0],
+                                                                                 body.size())));
+
+    if (!s.ok())
+    {
+        LOG_GENERAL(WARNING, "[Insert] Status: " << s.ToString());
+        return -1;
+    }
+
+    return 0;
 }
 
 int LevelDB::Insert(const boost::multiprecision::uint256_t & blockNum,

--- a/src/depends/libDatabase/LevelDB.h
+++ b/src/depends/libDatabase/LevelDB.h
@@ -71,6 +71,9 @@ public:
     std::string Lookup(const std::string & key) const;
 
     /// Returns the value at the specified key.
+    std::string Lookup(const std::vector<unsigned char>& key) const;
+
+    /// Returns the value at the specified key.
     std::string Lookup(const boost::multiprecision::uint256_t & blockNum) const;
 
     /// Returns the value at the specified key and also mark if key was found or not
@@ -84,6 +87,10 @@ public:
 
     /// Sets the value at the specified key.
     int Insert(const dev::h256 & key, dev::bytesConstRef value);
+
+    /// Sets the value at the specified key.
+    int Insert(const std::vector<unsigned char>& key,
+               const std::vector<unsigned char>& body);
 
     /// Sets the value at the specified key.
     int Insert(const boost::multiprecision::uint256_t & blockNum,

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -59,7 +59,9 @@ bool DirectoryService::StoreFinalBlockToDisk() {
     bytes body;
     m_mediator.m_node->m_microblock->Serialize(body, 0);
     if (!BlockStorage::GetBlockStorage().PutMicroBlock(
-            m_mediator.m_node->m_microblock->GetBlockHash(), body)) {
+            m_mediator.m_node->m_microblock->GetBlockHash(),
+            m_mediator.m_node->m_microblock->GetHeader().GetEpochNum(),
+            m_mediator.m_node->m_microblock->GetHeader().GetShardId(), body)) {
       LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
       return false;
     }

--- a/src/libDirectoryService/MicroBlockProcessing.cpp
+++ b/src/libDirectoryService/MicroBlockProcessing.cpp
@@ -310,8 +310,9 @@ bool DirectoryService::ProcessMicroblockSubmissionFromShardCore(
 
   bytes body;
   microBlock.Serialize(body, 0);
-  if (!BlockStorage::GetBlockStorage().PutMicroBlock(microBlock.GetBlockHash(),
-                                                     body)) {
+  if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+          microBlock.GetBlockHash(), microBlock.GetHeader().GetEpochNum(),
+          microBlock.GetHeader().GetShardId(), body)) {
     LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
     return false;
   }
@@ -658,7 +659,9 @@ bool DirectoryService::ProcessMissingMicroblockSubmission(
       bytes body;
       microBlocks[i].Serialize(body, 0);
       if (!BlockStorage::GetBlockStorage().PutMicroBlock(
-              microBlocks[i].GetBlockHash(), body)) {
+              microBlocks[i].GetBlockHash(),
+              microBlocks[i].GetHeader().GetEpochNum(),
+              microBlocks[i].GetHeader().GetShardId(), body)) {
         LOG_GENERAL(WARNING, "Failed to put microblock in persistence");
         return false;
       }

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -2238,8 +2238,9 @@ bool Lookup::AddMicroBlockToStorage(const MicroBlock& microblock) {
 
   bytes body;
   microblock.Serialize(body, 0);
-  if (!BlockStorage::GetBlockStorage().PutMicroBlock(microblock.GetBlockHash(),
-                                                     body)) {
+  if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+          microblock.GetBlockHash(), microblock.GetHeader().GetEpochNum(),
+          microblock.GetHeader().GetShardId(), body)) {
     LOG_GENERAL(WARNING, "Failed to put microblock in body");
     return false;
   }

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -9400,3 +9400,49 @@ bool Messenger::GetMinerInfoShards(const bytes& src, const unsigned int offset,
 
   return true;
 }
+
+bool Messenger::SetMicroBlockKey(bytes& dst, const unsigned int offset,
+                                 const uint64_t& epochNum,
+                                 const uint32_t& shardID) {
+  LOG_MARKER();
+
+  ProtoMicroBlockKey result;
+  result.set_epochnum(epochNum);
+  result.set_shardid(shardID);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoMicroBlockKey initialization failed");
+    return false;
+  }
+
+  return SerializeToArray(result, dst, offset);
+}
+
+bool Messenger::GetMicroBlockKey(const bytes& src, const unsigned int offset,
+                                 uint64_t& epochNum, uint32_t& shardID) {
+  LOG_MARKER();
+
+  if (src.size() == 0) {
+    LOG_GENERAL(INFO, "Empty ProtoMicroBlockKey");
+    return false;
+  }
+
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoMicroBlockKey result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoMicroBlockKey initialization failed");
+    return false;
+  }
+
+  epochNum = result.epochnum();
+  shardID = result.shardid();
+
+  return true;
+}

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -978,5 +978,11 @@ class Messenger {
                                  const MinerInfoShards& minerInfo);
   static bool GetMinerInfoShards(const bytes& src, const unsigned int offset,
                                  MinerInfoShards& minerInfo);
+
+  static bool SetMicroBlockKey(bytes& dst, const unsigned int offset,
+                               const uint64_t& epochNum,
+                               const uint32_t& shardID);
+  static bool GetMicroBlockKey(const bytes& src, const unsigned int offset,
+                               uint64_t& epochNum, uint32_t& shardID);
 };
 #endif  // ZILLIQA_SRC_LIBMESSAGE_MESSENGER_H_

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -276,6 +276,13 @@ message ProtoMinerInfoShards
     // Add new members here
 }
 
+// Used in database "microBlocks"
+message ProtoMicroBlockKey
+{
+    uint64 epochnum = 1;
+    uint32 shardid  = 2;
+}
+
 // ============================================================================
 // Primitives
 // ============================================================================

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -485,7 +485,9 @@ TxBlock IsolatedServer::GenerateTxBlock() {
 
   mb.Serialize(body, 0);
 
-  if (!BlockStorage::GetBlockStorage().PutMicroBlock(mb.GetBlockHash(), body)) {
+  if (!BlockStorage::GetBlockStorage().PutMicroBlock(
+          mb.GetBlockHash(), mb.GetHeader().GetEpochNum(),
+          mb.GetHeader().GetShardId(), body)) {
     LOG_GENERAL(WARNING, "Failed to put microblock in body");
   }
   TxBlock txblock(txblockheader, {mbInfo}, CoSignatures());


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
**MB storage before:**
[microBlocks] hash -> body
**MB storage now:**
[microBlockKeys] hash -> key (epoch+shardid)
[microBlocks] key -> body

Migration to new storage:
1. Validate existing persistence using the `validateDB` from before this PR
1. `./build.sh migrate_mbs` (to enable MIGRATE_MICROBLOCKS flag) on this PR
1. Run `migrate_mbs` on the persistence
1. Replace `microBlocks` levelDB with the newly created `microBlocksNew` levelDB
1. `./build.sh` (to disable MIGRATE_MICROBLOCKS flag) on this PR
1. Run `validateDB` on the migrated persistence

Additional testing:
1. Launch new testnet on migrated persistence
1. Compare output of GetTransactionsForTxBlock between mainnet and testnet for multiple blocks

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
