### PR TITLE
add tini and supervisord to image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,7 +170,9 @@ COPY --from=builder /zilliqa/scripts         /zilliqa/scripts
 # pour in zilliqa binaries and dynnamic libs
 COPY --from=builder ${INSTALL_DIR}/bin/*     ${INSTALL_DIR}/bin/
 COPY --from=builder ${INSTALL_DIR}/lib/*.so* ${INSTALL_DIR}/lib/
-COPY --from=builder ${MONGO_INSTALL_DIR}/lib/*.so* ${INSTALL_DIR}/lib/ 
+COPY --from=builder ${MONGO_INSTALL_DIR}/lib/*.so* ${INSTALL_DIR}/lib/
+
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 
 ENV LD_LIBRARY_PATH=${INSTALL_DIR}/lib:${MONGO_INSTALL_DIR}/lib
 

--- a/docker/requirements3.txt
+++ b/docker/requirements3.txt
@@ -1,8 +1,9 @@
+awscli==1.18.100
+boto3==1.14.23
 clint==0.5.1
 future==0.18.2
-requests==2.24.0
-urllib3==1.25.9
 kubernetes==11.0.0
 netaddr==0.8.0
-boto3==1.14.23
-awscli==1.18.100
+requests==2.24.0
+supervisor==4.2.0
+urllib3==1.25.9


### PR DESCRIPTION
**problem:**
we start a container with bash as the PID1 process
```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root     24989  0.0  0.0  18484  3492 pts/0    Ss   04:29   0:00 bash
root     25015  0.0  0.0  34424  2828 pts/0    R+   04:29   0:00  \_ ps auxf
root         1  0.0  0.0   4404   704 ?        Ss   Oct20   0:00 tail -f /dev/null
root       288  0.0  0.0  26064  2460 ?        Ss   Oct20   0:00 /usr/sbin/cron
root       290  0.0  0.0      0     0 ?        Z    Oct20   0:00 [bash] <defunct>
root       309  0.0  0.0  22300  2656 ?        Ss   Oct20   0:00 zilliqad 33133 --synctype 5 --nodetype
root       310  0.0  0.0  22300  2684 ?        S    Oct20   0:00  \_ zilliqad 33133 --synctype 5 --node
root       312  0.0  0.0   4500   740 ?        S    Oct20   0:00      \_ sh -c cd /run/zilliqa/; ulimit -Sc unlimited; ulimit -Hc unlimited;zilliqa
root       313 19.9 40.2 9912848 1628768 ?     Sl   Oct20 558:16          \_ zilliqa --privk xxx --pubk xxx --address xx.xx.xx.xx --port 33133 --synctype 5
root      1144  0.0  0.5  56024 22848 ?        S    Oct20   0:00 /scilla/0/bin/scilla-server -socket /tmp/scilla-server.sock.0
```
but, bash don't wait its child process nor watch them

if zilliqa or other process crashes, bash won't restart them
and the crashed process may become a zombie process (shows `[defunct]` when run `ps auxf`)

if the container were going to be terminated, the SIGTERM sent to bash won't be passed to other process in the container
by default, after 10s the whole container will be force kill by docker daemon
some sweeping process may fail because of that.

**solution:**
we can use a init process like [tini](https://github.com/krallin/tini) as the PID1, let it hadle the signal passing and zombie reaping.
since tini can only spwan 1 child process, we can use [supervisord](http://supervisord.org/) as the process mannager.
```
tini
 \_ supervisord
     \_ zilliqad
     \_ crond
     \_ exporter
```