### PR TITLE
Miner node is not able to do pow submission

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3014,7 +3014,7 @@ bool Lookup::GetDSInfo() {
   LOG_MARKER();
   m_dsInfoWaitingNotifying = true;
 
-  if (ARCHIVAL_LOOKUP) {
+  if (!LOOKUP_NODE_MODE || ARCHIVAL_LOOKUP) {
     GetDSInfoFromSeedNodes();
   } else {
     GetDSInfoFromLookupNodes();


### PR DESCRIPTION
## Description
It is observed that in master branch, miner node pow submission is breaking because of bug in the code where node goes to fetch `DSInfo` from lookup nodes instead of l2l nodes(seed nodes)
Below is the reference:
https://github.com/Zilliqa/Zilliqa/pull/2283#discussion_r512692382

Note: Once PR is reviewed, will port the fix to `release-7.0` branch
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
