### PR TITLE
[release-7.0] Rolling leveldb for microBlocks and txBodies

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -12,6 +12,7 @@
         <UPGRADE_TARGET_DS_NUM>1</UPGRADE_TARGET_DS_NUM>
         <!-- Do not add a trailing "/" in the path-->
         <STORAGE_PATH>.</STORAGE_PATH>
+        <NUM_EPOCHS_PER_PERSISTENT_DB>1000000</NUM_EPOCHS_PER_PERSISTENT_DB>
     </general>
     <version>
         <MSG_VERSION>1</MSG_VERSION>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -11,6 +11,7 @@
         <UPGRADE_TARGET_DS_NUM>1</UPGRADE_TARGET_DS_NUM>
         <!-- Do not add a trailing "/" in the path-->
         <STORAGE_PATH>.</STORAGE_PATH>
+        <NUM_EPOCHS_PER_PERSISTENT_DB>1000000</NUM_EPOCHS_PER_PERSISTENT_DB>
     </general>
     <version>
         <MSG_VERSION>1</MSG_VERSION>

--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -138,7 +138,7 @@ def GetAllObjectsFromS3(url, folderName=""):
 		lastkey = ''
 		for key in tree[startInd:]:
 			key_url = key[0].text
-			if (not (Exclude_txnBodies and "txBodies" in key_url) and not (Exclude_microBlocks and "microBlocks" in key_url) and not (Exclude_minerInfo and (("minerInfoDSComm" in key_url) or ("minerInfoShards" in key_url))) and not ("diff_persistence" in key_url)):
+			if (not (Exclude_txnBodies and "txEpochs" in key_url) and not (Exclude_txnBodies and "txBodies" in key_url) and not (Exclude_microBlocks and "microBlock" in key_url) and not (Exclude_minerInfo and "minerInfo" in key_url) and not ("diff_persistence" in key_url)):
 				list_of_keyurls.append(url+"/"+key_url)
 				print(key_url)
 			lastkey = key_url

--- a/scripts/upload_incr_DB.py
+++ b/scripts/upload_incr_DB.py
@@ -142,7 +142,7 @@ def SyncLocalToS3Persistence(blockNum,lastBlockNum):
 			CleanS3PersistenceDiffs()
 	elif (result == 0):
 		# we still need to sync persistence except for state, stateroot, contractCode, contractStateData, contractStateIndex so that next time for next blocknum we can get statedelta diff and persistence diff correctly
-		bashCommand = "aws s3 sync --delete temp/persistence "+getBucketString(PERSISTENCE_SNAPSHOT_NAME)+"/persistence --exclude '*' --include 'microBlocks/*' --include 'dsBlocks/*' --include 'minerInfoDSComm/*' --include 'minerInfoShards/*' --include 'dsCommittee/*' --include 'shardStructure/*' --include 'txBlocks/*' --include 'VCBlocks/*' --include 'blockLinks/*' --include 'metaData/*' --include 'stateDelta/*' --include 'txBodies/*' --include 'extSeedPubKeys/*' "
+		bashCommand = "aws s3 sync --delete temp/persistence "+getBucketString(PERSISTENCE_SNAPSHOT_NAME)+"/persistence --exclude '*' --include 'microBlockKeys/*' --include 'microBlocks*' --include 'dsBlocks/*' --include 'minerInfoDSComm/*' --include 'minerInfoShards/*' --include 'dsCommittee/*' --include 'shardStructure/*' --include 'txBlocks/*' --include 'VCBlocks/*' --include 'blockLinks/*' --include 'metaData/*' --include 'stateDelta/*' --include 'txEpochs/*' --include 'txBodies*' --include 'extSeedPubKeys/*' "
 		process = subprocess.Popen(bashCommand, universal_newlines=True, shell=True,stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 		str_diff_output, error = process.communicate()
 		logging.info("Remote S3 bucket: "+getBucketString(PERSISTENCE_SNAPSHOT_NAME)+"/persistence is Synced without state/stateRoot/contractCode/contractStateData/contractStateIndex")

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -90,6 +90,8 @@ const string GENESIS_PUBKEY{
 const unsigned int UPGRADE_TARGET_DS_NUM{
     ReadConstantNumeric("UPGRADE_TARGET_DS_NUM")};
 const string STORAGE_PATH{ReadConstantString("STORAGE_PATH", "node.general.")};
+const unsigned int NUM_EPOCHS_PER_PERSISTENT_DB{
+    ReadConstantNumeric("NUM_EPOCHS_PER_PERSISTENT_DB")};
 
 // Version constants
 const unsigned int MSG_VERSION{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -134,6 +134,7 @@ extern const uint16_t CHAIN_ID;
 extern const std::string GENESIS_PUBKEY;
 extern const unsigned int UPGRADE_TARGET_DS_NUM;
 extern const std::string STORAGE_PATH;
+extern const unsigned int NUM_EPOCHS_PER_PERSISTENT_DB;
 
 // Version constants
 extern const unsigned int MSG_VERSION;

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -80,12 +80,12 @@ class BlockStorage : public Singleton<BlockStorage> {
   std::shared_ptr<LevelDB> m_metadataDB;
   std::shared_ptr<LevelDB> m_dsBlockchainDB;
   std::shared_ptr<LevelDB> m_txBlockchainDB;
-  std::shared_ptr<LevelDB> m_txBodyDB;
+  std::vector<std::shared_ptr<LevelDB>> m_txBodyDBs;
 #ifdef MIGRATE_MBS_TXNS
   std::shared_ptr<LevelDB> m_txBodyOrigDB;
 #endif  // MIGRATE_MBS_TXNS
   std::shared_ptr<LevelDB> m_txEpochDB;
-  std::shared_ptr<LevelDB> m_microBlockDB;
+  std::vector<std::shared_ptr<LevelDB>> m_microBlockDBs;
 #ifdef MIGRATE_MBS_TXNS
   std::shared_ptr<LevelDB> m_microBlockOrigDB;
 #endif  // MIGRATE_MBS_TXNS
@@ -117,8 +117,6 @@ class BlockStorage : public Singleton<BlockStorage> {
 #ifdef MIGRATE_MBS_TXNS
         m_microBlockDB(std::make_shared<LevelDB>("microBlocksNew")),
         m_microBlockOrigDB(std::make_shared<LevelDB>("microBlocks")),
-#else   // MIGRATE_MBS_TXNS
-        m_microBlockDB(std::make_shared<LevelDB>("microBlocks")),
 #endif  // MIGRATE_MBS_TXNS
         m_microBlockKeyDB(std::make_shared<LevelDB>("microBlockKeys")),
         m_dsCommitteeDB(std::make_shared<LevelDB>("dsCommittee")),
@@ -140,13 +138,14 @@ class BlockStorage : public Singleton<BlockStorage> {
       m_txBodyDB = std::make_shared<LevelDB>("txBodiesNew");
       m_txBodyOrigDB = std::make_shared<LevelDB>("txBodies");
 #else   // MIGRATE_MBS_TXNS
-      m_txBodyDB = std::make_shared<LevelDB>("txBodies");
+      m_txBodyDBs.emplace_back(std::make_shared<LevelDB>("txBodies"));
 #endif  // MIGRATE_MBS_TXNS
       m_txEpochDB = std::make_shared<LevelDB>("txEpochs");
       m_minerInfoDSCommDB = std::make_shared<LevelDB>("minerInfoDSComm");
       m_minerInfoShardsDB = std::make_shared<LevelDB>("minerInfoShards");
       m_extSeedPubKeysDB = std::make_shared<LevelDB>("extSeedPubKeys");
     }
+    m_microBlockDBs.emplace_back(std::make_shared<LevelDB>("microBlocks"));
   };
   ~BlockStorage() = default;
   bool PutBlock(const uint64_t& blockNum, const bytes& body,
@@ -414,6 +413,9 @@ class BlockStorage : public Singleton<BlockStorage> {
 
   unsigned int m_diagnosticDBNodesCounter;
   unsigned int m_diagnosticDBCoinbaseCounter;
+
+  std::shared_ptr<LevelDB> GetMicroBlockDB(const uint64_t& epochNum);
+  std::shared_ptr<LevelDB> GetTxBodyDB(const uint64_t& epochNum);
 };
 
 #endif  // ZILLIQA_SRC_LIBPERSISTENCE_BLOCKSTORAGE_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
After #2311 and #2316, `microBlocks` and `txBodies` leveldbs can now be indexed by epoch number.
This PR will roll over these leveldbs to new folders after every `NUM_EPOCHS_PER_PERSISTENT_DB`th epoch is crossed.
A pointer is maintained for each folder.

Naming convention (assume rollover after 1M epochs):
`microBlocks` (0 to 1M-1)
`microBlocks_1` (1M to 2M-1)
`microBlocks_2` (2M to 3M-1)
...

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
