### PR TITLE
[release-7.0] Keep one mutex for both reading and deletion of txn shard map

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -5209,8 +5209,6 @@ bool Lookup::DeleteTxnShardMap(uint32_t shardId) {
     return true;
   }
 
-  lock_guard<mutex> g(m_txnShardMapMutex);
-
   m_txnShardMap[shardId].clear();
 
   return true;
@@ -5396,6 +5394,7 @@ void Lookup::SendTxnPacketToNodes(const uint32_t oldNumShards,
 
       P2PComm::GetInstance().SendBroadcastMessage(toSend, msg);
 
+      lock_guard<mutex> g(m_txnShardMapMutex);
       DeleteTxnShardMap(i);
     } else if (i == numShards) {
       // To send DS
@@ -5431,6 +5430,7 @@ void Lookup::SendTxnPacketToNodes(const uint32_t oldNumShards,
       LOG_GENERAL(INFO, "[DSMB]"
                             << " Sent DS the txns");
 
+      lock_guard<mutex> g(m_txnShardMapMutex);
       DeleteTxnShardMap(i);
     }
   }

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -349,14 +349,13 @@ bool LookupServer::StartCollectorThread() {
                     SEND_TYPE::ARCHIVAL_SEND_DS))) {
           continue;
         }
+        for (auto const& i :
+             {SEND_TYPE::ARCHIVAL_SEND_SHARD, SEND_TYPE::ARCHIVAL_SEND_DS}) {
+          m_mediator.m_lookup->DeleteTxnShardMap(i);
+        }
       }
 
       m_mediator.m_lookup->SendMessageToRandomSeedNode(msg);
-
-      for (auto const& i :
-           {SEND_TYPE::ARCHIVAL_SEND_SHARD, SEND_TYPE::ARCHIVAL_SEND_DS}) {
-        m_mediator.m_lookup->DeleteTxnShardMap(i);
-      }
     }
   };
   DetachedFunction(1, collectorThread);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Newly created transactions can be accidentally deleted before being dispatched to upper_seed, because the mutex on the txn-shard map is acquired twice: first for creating FORWARDTXN message, and then for deletion of the map. If a transaction is added to the map in between the two steps, it is deleted before dispatch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
