### PR TITLE
[release-7.0] fix the typo

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -4560,7 +4560,7 @@ void Lookup::RejoinAsNewLookup(bool fromLookup) {
           LOG_GENERAL(INFO,
                       "I am lagging behind by ds epoch! Will rejoin again!");
           m_mediator.m_lookup->SetSyncType(SyncType::NO_SYNC);
-          RejoinAsLookup(false);
+          RejoinAsNewLookup(false);
         }
       };
       DetachedFunction(1, func2);


### PR DESCRIPTION
## Description
This PR fix the typo:
`RejoinAsLookup` -> `RejoinAsNewlookup`. Though functionally its still rejoins successfully in both cases but might miss fetching of MB.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
