### PR TITLE
[master] Example of how to extract all contract code from persistent storage

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -767,6 +767,10 @@ bool AccountStoreSC<MAP>::ExportCreateContractFiles(
     os << DataConversion::CharArrayToString(contract.GetCode());
     os.close();
 
+    std::ofstream os2("contracts/" + contract.GetAddress().hex() + CONTRACT_FILE_EXTENSION);
+    os2 << DataConversion::CharArrayToString(contract.GetCode());
+    os2.close();
+
     ExportCommonFiles(os, contract, extlibs_exports);
   } catch (const std::exception& e) {
     LOG_GENERAL(WARNING, "Exception caught: " << e.what());


### PR DESCRIPTION
Adding these three lines of code extracts all contract code from persistent storage into the directory `<wd>/contracts/`.

This is just an example of a feature I would like to see. It should not be implemented like this, so do not merge.