### PR TITLE
[release-7.0] Don't skip storing empty mb during migrate_mbs_txns

### DIFF
--- a/src/cmd/migrate_mbs_txns.cpp
+++ b/src/cmd/migrate_mbs_txns.cpp
@@ -161,9 +161,6 @@ int main(int argc, const char* argv[]) {
     auto microBlockInfos = txBlockPtr->GetMicroBlockInfos();
     for (auto const& mbInfo : microBlockInfos) {
       MicroBlockSharedPtr mbptr;
-      if (mbInfo.m_txnRootHash == TxnHash()) {
-        continue;
-      }
       if (!BlockStorage::GetBlockStorage().GetMicroBlock(
               mbInfo.m_microBlockHash, mbptr)) {
         LOG_GENERAL(WARNING, "Missing MB " << mbInfo.m_microBlockHash

--- a/src/libPersistence/BlockStorage.h
+++ b/src/libPersistence/BlockStorage.h
@@ -392,14 +392,14 @@ class BlockStorage : public Singleton<BlockStorage> {
   mutable std::shared_timed_mutex m_mutexMetadata;
   mutable std::shared_timed_mutex m_mutexDsBlockchain;
   mutable std::shared_timed_mutex m_mutexTxBlockchain;
-  mutable std::shared_timed_mutex m_mutexMicroBlock;
+  mutable std::mutex m_mutexMicroBlock;
   mutable std::shared_timed_mutex m_mutexDsCommittee;
   mutable std::shared_timed_mutex m_mutexVCBlock;
   mutable std::shared_timed_mutex m_mutexBlockLink;
   mutable std::shared_timed_mutex m_mutexShardStructure;
   mutable std::shared_timed_mutex m_mutexStateDelta;
   mutable std::shared_timed_mutex m_mutexTempState;
-  mutable std::shared_timed_mutex m_mutexTxBody;
+  mutable std::mutex m_mutexTxBody;
   mutable std::shared_timed_mutex m_mutexStateRoot;
   mutable std::shared_timed_mutex m_mutexProcessTx;
   mutable std::shared_timed_mutex m_mutexMinerInfoDSComm;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`migrate_mbs_txns.cpp` currently skips over microblocks that have 0 txns (root hash = 0).

While non-full nodes (like DS guards) indeed do not store these mbs in their persistence, full nodes (like lookups) actually store these mbs (except if it is for the mb generated by the DS committee). And these mbs are required by dsguards during recovery operation to re-create coinbase for the current DS epoch.

This is why for TxBlocks that have at least one empty mb, dsguards are asking for them from seedpubs.
It's also why seedpubs are failing during `ProcessGetCosigsRewardsFromSeed`, because they themselves also do not have these mbs.

Also changing the mutex type for microBlocks and txBodies since we require exclusive access now.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
