### PR TITLE
[master] Optimize deserialization

### DIFF
--- a/src/common/Serializable.h
+++ b/src/common/Serializable.h
@@ -80,6 +80,10 @@ class SerializableDataBlock {
   /// Deserializes source byte stream into internal state.
   virtual bool Deserialize(const bytes& src, unsigned int offset) = 0;
 
+  /// Deserializes source string stream into internal state (used by
+  /// libMessage).
+  virtual bool Deserialize(const std::string& src, unsigned int offset) = 0;
+
   /// Virtual destructor.
   virtual ~SerializableDataBlock() {}
 

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -67,6 +67,17 @@ bool AccountBase::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool AccountBase::Deserialize(const string& src, unsigned int offset) {
+  // LOG_MARKER();
+
+  if (!Messenger::GetAccountBase(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetAccount failed.");
+    return false;
+  }
+
+  return true;
+}
+
 void AccountBase::SetVersion(const uint32_t& version) { m_version = version; }
 
 const uint32_t& AccountBase::GetVersion() const { return m_version; }

--- a/src/libData/AccountData/Account.h
+++ b/src/libData/AccountData/Account.h
@@ -60,6 +60,9 @@ class AccountBase : public SerializableDataBlock {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   void SetVersion(const uint32_t& version);
 
   const uint32_t& GetVersion() const;

--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -144,6 +144,21 @@ bool AccountStore::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool AccountStore::Deserialize(const string& src, unsigned int offset) {
+  LOG_MARKER();
+
+  this->Init();
+
+  unique_lock<shared_timed_mutex> g(m_mutexPrimary);
+
+  if (!Messenger::GetAccountStore(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetAccountStore failed.");
+    return false;
+  }
+
+  return true;
+}
+
 bool AccountStore::SerializeDelta() {
   LOG_MARKER();
 

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -107,6 +107,8 @@ class AccountStore
 
   bool Deserialize(const bytes& src, unsigned int offset) override;
 
+  bool Deserialize(const std::string& src, unsigned int offset) override;
+
   /// generate serialized raw bytes for StateDelta
   bool SerializeDelta();
 

--- a/src/libData/AccountData/AccountStoreBase.h
+++ b/src/libData/AccountData/AccountStoreBase.h
@@ -50,6 +50,9 @@ class AccountStoreBase : public SerializableDataBlock {
   /// Implements the Deserialize function inherited from Serializable.
   virtual bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  virtual bool Deserialize(const std::string& src, unsigned int offset);
+
   virtual Account* GetAccount(const Address& address);
 
   /// Verifies existence of Account in the list.

--- a/src/libData/AccountData/AccountStoreBase.tpp
+++ b/src/libData/AccountData/AccountStoreBase.tpp
@@ -54,6 +54,18 @@ bool AccountStoreBase<MAP>::Deserialize(const bytes& src, unsigned int offset) {
 }
 
 template <class MAP>
+bool AccountStoreBase<MAP>::Deserialize(const std::string& src,
+                                        unsigned int offset) {
+  if (!MessengerAccountStoreBase::GetAccountStore(src, offset,
+                                                  *m_addressToAccount)) {
+    LOG_GENERAL(WARNING, "Messenger::GetAccountStore failed.");
+    return false;
+  }
+
+  return true;
+}
+
+template <class MAP>
 bool AccountStoreBase<MAP>::UpdateAccounts(const Transaction& transaction,
                                            TransactionReceipt& receipt,
                                            TxnStatus& error_code) {

--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -128,6 +128,15 @@ bool Transaction::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool Transaction::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetTransaction(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTransaction failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const TxnHash& Transaction::GetTranID() const { return m_tranID; }
 
 const TransactionCoreInfo& Transaction::GetCoreInfo() const {

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -104,6 +104,9 @@ class Transaction : public SerializableDataBlock {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset) override;
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset) override;
+
   /// Returns the transaction ID.
   const TxnHash& GetTranID() const;
 

--- a/src/libData/AccountData/TransactionReceipt.cpp
+++ b/src/libData/AccountData/TransactionReceipt.cpp
@@ -58,6 +58,28 @@ bool TransactionReceipt::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool TransactionReceipt::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetTransactionReceipt(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTransactionReceipt failed.");
+    return false;
+  }
+
+  if (!JSONUtils::GetInstance().convertStrtoJson(m_tranReceiptStr,
+                                                 m_tranReceiptObj)) {
+    LOG_GENERAL(WARNING, "Error with convert receipt string to json object");
+    return false;
+  }
+
+  try {
+    update();
+  } catch (const std::exception& e) {
+    LOG_GENERAL(WARNING, "Error with TransactionReceipt::Deserialize."
+                             << ' ' << e.what());
+    return false;
+  }
+  return true;
+}
+
 void TransactionReceipt::SetResult(const bool& result) {
   if (result) {
     m_tranReceiptObj["success"] = true;
@@ -181,6 +203,16 @@ bool TransactionWithReceipt::Serialize(bytes& dst, unsigned int offset) const {
 
 /// Implements the Deserialize function inherited from Serializable.
 bool TransactionWithReceipt::Deserialize(const bytes& src,
+                                         unsigned int offset) {
+  if (!Messenger::GetTransactionWithReceipt(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTransactionWithReceipt failed.");
+    return false;
+  }
+  return true;
+}
+
+/// Implements the Deserialize function inherited from Serializable.
+bool TransactionWithReceipt::Deserialize(const string& src,
                                          unsigned int offset) {
   if (!Messenger::GetTransactionWithReceipt(src, offset, *this)) {
     LOG_GENERAL(WARNING, "Messenger::GetTransactionWithReceipt failed.");

--- a/src/libData/AccountData/TransactionReceipt.h
+++ b/src/libData/AccountData/TransactionReceipt.h
@@ -69,6 +69,7 @@ class TransactionReceipt : public SerializableDataBlock {
   TransactionReceipt();
   bool Serialize(bytes& dst, unsigned int offset) const override;
   bool Deserialize(const bytes& src, unsigned int offset) override;
+  bool Deserialize(const std::string& src, unsigned int offset) override;
   void SetResult(const bool& result);
   void AddError(const unsigned int& errCode);
   void AddException(const Json::Value& jsonException);
@@ -109,6 +110,9 @@ class TransactionWithReceipt : public SerializableDataBlock {
 
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset) override;
+
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset) override;
 
   const Transaction& GetTransaction() const { return m_transaction; }
   const TransactionReceipt& GetTransactionReceipt() const {

--- a/src/libData/BlockData/Block/BlockBase.cpp
+++ b/src/libData/BlockData/Block/BlockBase.cpp
@@ -36,6 +36,11 @@ bool BlockBase::Deserialize([[gnu::unused]] const bytes& src,
   return true;
 }
 
+bool BlockBase::Deserialize([[gnu::unused]] const string& src,
+                            [[gnu::unused]] unsigned int offset) {
+  return true;
+}
+
 const uint64_t& BlockBase::GetTimestamp() const { return m_timestamp; }
 
 void BlockBase::SetTimestamp(const uint64_t& timestamp) {

--- a/src/libData/BlockData/Block/BlockBase.h
+++ b/src/libData/BlockData/Block/BlockBase.h
@@ -58,6 +58,9 @@ class BlockBase : public SerializableDataBlock {
   /// Implements the Deserialize function inherited from Serializable.
   virtual bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  virtual bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the block hash
   const BlockHash& GetBlockHash() const;
 

--- a/src/libData/BlockData/Block/DSBlock.cpp
+++ b/src/libData/BlockData/Block/DSBlock.cpp
@@ -59,6 +59,15 @@ bool DSBlock::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool DSBlock::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetDSBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetDSBlock failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const DSBlockHeader& DSBlock::GetHeader() const { return m_header; }
 
 bool DSBlock::operator==(const DSBlock& block) const {

--- a/src/libData/BlockData/Block/DSBlock.h
+++ b/src/libData/BlockData/Block/DSBlock.h
@@ -48,6 +48,9 @@ class DSBlock : public BlockBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the reference to the DSBlockHeader part of the DS block.
   const DSBlockHeader& GetHeader() const;
 

--- a/src/libData/BlockData/Block/MicroBlock.cpp
+++ b/src/libData/BlockData/Block/MicroBlock.cpp
@@ -57,6 +57,22 @@ bool MicroBlock::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool MicroBlock::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetMicroBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetMicroBlock failed.");
+    return false;
+  }
+
+  if (m_header.GetNumTxs() != m_tranHashes.size()) {
+    LOG_GENERAL(WARNING, "Header txn count (" << m_header.GetNumTxs()
+                                              << ") != txn hash count ("
+                                              << m_tranHashes.size() << ")");
+    return false;
+  }
+
+  return true;
+}
+
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
 MicroBlock::MicroBlock() {}
 

--- a/src/libData/BlockData/Block/MicroBlock.h
+++ b/src/libData/BlockData/Block/MicroBlock.h
@@ -51,6 +51,9 @@ class MicroBlock : public BlockBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the header component of the microblock.
   const MicroBlockHeader& GetHeader() const;
 

--- a/src/libData/BlockData/Block/TxBlock.cpp
+++ b/src/libData/BlockData/Block/TxBlock.cpp
@@ -42,6 +42,15 @@ bool TxBlock::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool TxBlock::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetTxBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTxBlock failed.");
+    return false;
+  }
+
+  return true;
+}
+
 // creates a dummy invalid placeholder block -- blocknum is maxsize of uint256
 TxBlock::TxBlock() {}
 

--- a/src/libData/BlockData/Block/TxBlock.h
+++ b/src/libData/BlockData/Block/TxBlock.h
@@ -80,6 +80,9 @@ class TxBlock : public BlockBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the reference to the TxBlockHeader part of the Tx block.
   const TxBlockHeader& GetHeader() const;
 

--- a/src/libData/BlockData/Block/VCBlock.cpp
+++ b/src/libData/BlockData/Block/VCBlock.cpp
@@ -57,6 +57,15 @@ bool VCBlock::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool VCBlock::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetVCBlock(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetVCBlock failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const VCBlockHeader& VCBlock::GetHeader() const { return m_header; }
 
 bool VCBlock::operator==(const VCBlock& block) const {

--- a/src/libData/BlockData/Block/VCBlock.h
+++ b/src/libData/BlockData/Block/VCBlock.h
@@ -47,6 +47,10 @@ class VCBlock : public BlockBase {
   /// Return 0 if successed, -1 if failed
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  /// Return 0 if successed, -1 if failed
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the reference to the VCBlockHeader part of the VC block.
   const VCBlockHeader& GetHeader() const;
 

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.cpp
@@ -97,6 +97,15 @@ bool DSBlockHeader::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool DSBlockHeader::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetDSBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetDSBlockHeader failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const uint8_t& DSBlockHeader::GetDSDifficulty() const { return m_dsDifficulty; }
 
 const uint8_t& DSBlockHeader::GetDifficulty() const { return m_difficulty; }

--- a/src/libData/BlockData/BlockHeader/DSBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/DSBlockHeader.h
@@ -71,6 +71,9 @@ class DSBlockHeader : public BlockHeaderBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset) override;
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset) override;
+
   /// Implements the GetHash function for serializing based on concrete vars
   /// only, primarily used for generating randomness seed
   BlockHash GetHashForRandom() const;

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.cpp
@@ -75,6 +75,15 @@ bool MicroBlockHeader::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool MicroBlockHeader::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetMicroBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetMicroBlockHeader failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const uint32_t& MicroBlockHeader::GetShardId() const { return m_shardId; }
 
 const uint64_t& MicroBlockHeader::GetGasLimit() const { return m_gasLimit; }

--- a/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/MicroBlockHeader.h
@@ -61,6 +61,9 @@ class MicroBlockHeader : public BlockHeaderBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   // [TODO] These methods are all supposed to be moved into BlockHeaderBase, so
   // no need to add Doxygen tags for now
   const uint32_t& GetShardId() const;

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.cpp
@@ -73,6 +73,15 @@ bool TxBlockHeader::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool TxBlockHeader::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetTxBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTxBlockHeader failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const uint64_t& TxBlockHeader::GetGasLimit() const { return m_gasLimit; }
 
 const uint64_t& TxBlockHeader::GetGasUsed() const { return m_gasUsed; }

--- a/src/libData/BlockData/BlockHeader/TxBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/TxBlockHeader.h
@@ -60,6 +60,9 @@ class TxBlockHeader : public BlockHeaderBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset) override;
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset) override;
+
   /// Returns the current limit for gas expenditure per block.
   const uint64_t& GetGasLimit() const;
 

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.cpp
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.cpp
@@ -70,6 +70,15 @@ bool VCBlockHeader::Deserialize(const bytes& src, unsigned int offset) {
   return true;
 }
 
+bool VCBlockHeader::Deserialize(const string& src, unsigned int offset) {
+  if (!Messenger::GetVCBlockHeader(src, offset, *this)) {
+    LOG_GENERAL(WARNING, "Messenger::GetVCBlockHeader failed.");
+    return false;
+  }
+
+  return true;
+}
+
 const uint64_t& VCBlockHeader::GetViewChangeDSEpochNo() const {
   return m_VieWChangeDSEpochNo;
 }

--- a/src/libData/BlockData/BlockHeader/VCBlockHeader.h
+++ b/src/libData/BlockData/BlockHeader/VCBlockHeader.h
@@ -63,6 +63,9 @@ class VCBlockHeader : public BlockHeaderBase {
   /// Implements the Deserialize function inherited from Serializable.
   bool Deserialize(const bytes& src, unsigned int offset);
 
+  /// Implements the Deserialize function inherited from Serializable.
+  bool Deserialize(const std::string& src, unsigned int offset);
+
   /// Returns the DS Epoch number where view change happen
   const uint64_t& GetViewChangeDSEpochNo() const;
 

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -48,15 +48,15 @@ void SerializableToProtobufByteArray(const T& serializable,
 
 bool ProtobufByteArrayToSerializable(const ByteArray& byteArray,
                                      Serializable& serializable) {
-  bytes tmp;
-  copy(byteArray.data().begin(), byteArray.data().end(), back_inserter(tmp));
+  bytes tmp(byteArray.data().size());
+  copy(byteArray.data().begin(), byteArray.data().end(), tmp.begin());
   return serializable.Deserialize(tmp, 0) == 0;
 }
 
 bool ProtobufByteArrayToSerializable(const ByteArray& byteArray,
                                      SerializableCrypto& serializable) {
-  bytes tmp;
-  copy(byteArray.data().begin(), byteArray.data().end(), back_inserter(tmp));
+  bytes tmp(byteArray.data().size());
+  copy(byteArray.data().begin(), byteArray.data().end(), tmp.begin());
   return serializable.Deserialize(tmp, 0);
 }
 
@@ -71,9 +71,7 @@ void SerializableToProtobufByteArray(const SerializableDataBlock& serializable,
 // Temporary function for use by data blocks
 bool ProtobufByteArrayToSerializable(const ByteArray& byteArray,
                                      SerializableDataBlock& serializable) {
-  bytes tmp;
-  copy(byteArray.data().begin(), byteArray.data().end(), back_inserter(tmp));
-  return serializable.Deserialize(tmp, 0);
+  return serializable.Deserialize(byteArray.data(), 0);
 }
 
 template <class T, size_t S>
@@ -85,8 +83,8 @@ void NumberToProtobufByteArray(const T& number, ByteArray& byteArray) {
 
 template <class T, size_t S>
 void ProtobufByteArrayToNumber(const ByteArray& byteArray, T& number) {
-  bytes tmp;
-  copy(byteArray.data().begin(), byteArray.data().end(), back_inserter(tmp));
+  bytes tmp(byteArray.data().size());
+  copy(byteArray.data().begin(), byteArray.data().end(), tmp.begin());
   number = Serializable::GetNumber<T>(tmp, 0, S);
 }
 
@@ -2364,6 +2362,30 @@ bool Messenger::GetAccountBase(const bytes& src, const unsigned int offset,
   return true;
 }
 
+bool Messenger::GetAccountBase(const string& src, const unsigned int offset,
+                               AccountBase& accountbase) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoAccountBase result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoAccount initialization failed");
+    return false;
+  }
+
+  if (!ProtobufToAccountBase(result, accountbase)) {
+    LOG_GENERAL(WARNING, "ProtobufToAccountBase failed");
+    return false;
+  }
+
+  return true;
+}
+
 bool Messenger::SetAccount(bytes& dst, const unsigned int offset,
                            const Account& account) {
   ProtoAccount result;
@@ -2485,6 +2507,44 @@ bool Messenger::GetAccountStore(const bytes& src, const unsigned int offset,
 }
 
 bool Messenger::GetAccountStore(const bytes& src, const unsigned int offset,
+                                AccountStore& accountStore) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoAccountStore result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoAccountStore initialization failed");
+    return false;
+  }
+
+  LOG_GENERAL(INFO, "Accounts deserialized: " << result.entries().size());
+
+  for (const auto& entry : result.entries()) {
+    Address address;
+    Account account;
+
+    copy(entry.address().begin(),
+         entry.address().begin() + min((unsigned int)entry.address().size(),
+                                       (unsigned int)address.size),
+         address.asArray().begin());
+    if (!ProtobufToAccount(entry.account(), account, address)) {
+      LOG_GENERAL(WARNING, "ProtobufToAccount failed for account at address "
+                               << address.hex());
+      return false;
+    }
+
+    accountStore.AddAccountDuringDeserialization(address, account, Account());
+  }
+
+  return true;
+}
+
+bool Messenger::GetAccountStore(const string& src, const unsigned int offset,
                                 AccountStore& accountStore) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -2769,6 +2829,25 @@ bool Messenger::GetDSBlockHeader(const bytes& src, const unsigned int offset,
   return ProtobufToDSBlockHeader(result, dsBlockHeader);
 }
 
+bool Messenger::GetDSBlockHeader(const string& src, const unsigned int offset,
+                                 DSBlockHeader& dsBlockHeader) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoDSBlock::DSBlockHeader result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoDSBlock::DSBlockHeader initialization failed");
+    return false;
+  }
+
+  return ProtobufToDSBlockHeader(result, dsBlockHeader);
+}
+
 bool Messenger::SetDSBlock(bytes& dst, const unsigned int offset,
                            const DSBlock& dsBlock) {
   ProtoDSBlock result;
@@ -2784,6 +2863,25 @@ bool Messenger::SetDSBlock(bytes& dst, const unsigned int offset,
 }
 
 bool Messenger::GetDSBlock(const bytes& src, const unsigned int offset,
+                           DSBlock& dsBlock) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoDSBlock result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoDSBlock initialization failed");
+    return false;
+  }
+
+  return ProtobufToDSBlock(result, dsBlock);
+}
+
+bool Messenger::GetDSBlock(const string& src, const unsigned int offset,
                            DSBlock& dsBlock) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -2837,6 +2935,27 @@ bool Messenger::GetMicroBlockHeader(const bytes& src, const unsigned int offset,
   return ProtobufToMicroBlockHeader(result, microBlockHeader);
 }
 
+bool Messenger::GetMicroBlockHeader(const string& src,
+                                    const unsigned int offset,
+                                    MicroBlockHeader& microBlockHeader) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoMicroBlock::MicroBlockHeader result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING,
+                "ProtoMicroBlock::MicroBlockHeader initialization failed");
+    return false;
+  }
+
+  return ProtobufToMicroBlockHeader(result, microBlockHeader);
+}
+
 bool Messenger::SetMicroBlock(bytes& dst, const unsigned int offset,
                               const MicroBlock& microBlock) {
   ProtoMicroBlock result;
@@ -2852,6 +2971,25 @@ bool Messenger::SetMicroBlock(bytes& dst, const unsigned int offset,
 }
 
 bool Messenger::GetMicroBlock(const bytes& src, const unsigned int offset,
+                              MicroBlock& microBlock) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoMicroBlock result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoMicroBlock initialization failed");
+    return false;
+  }
+
+  return ProtobufToMicroBlock(result, microBlock);
+}
+
+bool Messenger::GetMicroBlock(const string& src, const unsigned int offset,
                               MicroBlock& microBlock) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -2903,6 +3041,25 @@ bool Messenger::GetTxBlockHeader(const bytes& src, const unsigned int offset,
   return ProtobufToTxBlockHeader(result, txBlockHeader);
 }
 
+bool Messenger::GetTxBlockHeader(const string& src, const unsigned int offset,
+                                 TxBlockHeader& txBlockHeader) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoTxBlock::TxBlockHeader result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTxBlock::TxBlockHeader initialization failed");
+    return false;
+  }
+
+  return ProtobufToTxBlockHeader(result, txBlockHeader);
+}
+
 bool Messenger::SetTxBlock(bytes& dst, const unsigned int offset,
                            const TxBlock& txBlock) {
   ProtoTxBlock result;
@@ -2918,6 +3075,25 @@ bool Messenger::SetTxBlock(bytes& dst, const unsigned int offset,
 }
 
 bool Messenger::GetTxBlock(const bytes& src, const unsigned int offset,
+                           TxBlock& txBlock) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoTxBlock result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTxBlock initialization failed");
+    return false;
+  }
+
+  return ProtobufToTxBlock(result, txBlock);
+}
+
+bool Messenger::GetTxBlock(const string& src, const unsigned int offset,
                            TxBlock& txBlock) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -2969,6 +3145,25 @@ bool Messenger::GetVCBlockHeader(const bytes& src, const unsigned int offset,
   return ProtobufToVCBlockHeader(result, vcBlockHeader);
 }
 
+bool Messenger::GetVCBlockHeader(const string& src, const unsigned int offset,
+                                 VCBlockHeader& vcBlockHeader) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoVCBlock::VCBlockHeader result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoVCBlock::VCBlockHeader initialization failed");
+    return false;
+  }
+
+  return ProtobufToVCBlockHeader(result, vcBlockHeader);
+}
+
 bool Messenger::SetVCBlock(bytes& dst, const unsigned int offset,
                            const VCBlock& vcBlock) {
   ProtoVCBlock result;
@@ -2984,6 +3179,25 @@ bool Messenger::SetVCBlock(bytes& dst, const unsigned int offset,
 }
 
 bool Messenger::GetVCBlock(const bytes& src, const unsigned int offset,
+                           VCBlock& vcBlock) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoVCBlock result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoVCBlock initialization failed");
+    return false;
+  }
+
+  return ProtobufToVCBlock(result, vcBlock);
+}
+
+bool Messenger::GetVCBlock(const string& src, const unsigned int offset,
                            VCBlock& vcBlock) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -3049,6 +3263,25 @@ bool Messenger::SetTransaction(bytes& dst, const unsigned int offset,
 }
 
 bool Messenger::GetTransaction(const bytes& src, const unsigned int offset,
+                               Transaction& transaction) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoTransaction result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTransaction initialization failed");
+    return false;
+  }
+
+  return ProtobufToTransaction(result, transaction);
+}
+
+bool Messenger::GetTransaction(const string& src, const unsigned int offset,
                                Transaction& transaction) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -3164,6 +3397,26 @@ bool Messenger::GetTransactionReceipt(const bytes& src,
   return ProtobufToTransactionReceipt(result, transactionReceipt);
 }
 
+bool Messenger::GetTransactionReceipt(const string& src,
+                                      const unsigned int offset,
+                                      TransactionReceipt& transactionReceipt) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoTransactionReceipt result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTransactionReceipt initialization failed");
+    return false;
+  }
+
+  return ProtobufToTransactionReceipt(result, transactionReceipt);
+}
+
 bool Messenger::SetTransactionWithReceipt(
     bytes& dst, const unsigned int offset,
     const TransactionWithReceipt& transactionWithReceipt) {
@@ -3180,6 +3433,26 @@ bool Messenger::SetTransactionWithReceipt(
 
 bool Messenger::GetTransactionWithReceipt(
     const bytes& src, const unsigned int offset,
+    TransactionWithReceipt& transactionWithReceipt) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  ProtoTransactionWithReceipt result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "ProtoTransactionWithReceipt initialization failed");
+    return false;
+  }
+
+  return ProtobufToTransactionWithReceipt(result, transactionWithReceipt);
+}
+
+bool Messenger::GetTransactionWithReceipt(
+    const string& src, const unsigned int offset,
     TransactionWithReceipt& transactionWithReceipt) {
   if (offset >= src.size()) {
     LOG_GENERAL(WARNING, "Invalid data and offset, data size "
@@ -3893,10 +4166,10 @@ bool Messenger::GetDSMicroBlockSubmission(
     ProtobufToMicroBlock(proto_mb, microBlock);
     microBlocks.emplace_back(move(microBlock));
   }
+
   for (const auto& proto_delta : result.data().statedeltas()) {
-    stateDeltas.emplace_back();
-    copy(proto_delta.begin(), proto_delta.end(),
-         std::back_inserter(stateDeltas.back()));
+    stateDeltas.emplace_back(bytes(proto_delta.size()));
+    copy(proto_delta.begin(), proto_delta.end(), stateDeltas.back().begin());
   }
 
   return true;

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -77,6 +77,8 @@ class Messenger {
                              const AccountBase& accountbase);
   static bool GetAccountBase(const bytes& src, const unsigned int offset,
                              AccountBase& accountbase);
+  static bool GetAccountBase(const std::string& src, const unsigned int offset,
+                             AccountBase& accountbase);
 
   static bool SetAccount(bytes& dst, const unsigned int offset,
                          const Account& account);
@@ -94,6 +96,8 @@ class Messenger {
   static bool GetAccountStore(const bytes& src, const unsigned int offset,
                               MAP& addressToAccount);
   static bool GetAccountStore(const bytes& src, const unsigned int offset,
+                              AccountStore& accountStore);
+  static bool GetAccountStore(const std::string& src, const unsigned int offset,
                               AccountStore& accountStore);
 
   // These are called by AccountStore class
@@ -115,36 +119,56 @@ class Messenger {
                                bool concreteVarsOnly = false);
   static bool GetDSBlockHeader(const bytes& src, const unsigned int offset,
                                DSBlockHeader& dsBlockHeader);
+  static bool GetDSBlockHeader(const std::string& src,
+                               const unsigned int offset,
+                               DSBlockHeader& dsBlockHeader);
   static bool SetDSBlock(bytes& dst, const unsigned int offset,
                          const DSBlock& dsBlock);
   static bool GetDSBlock(const bytes& src, const unsigned int offset,
+                         DSBlock& dsBlock);
+  static bool GetDSBlock(const std::string& src, const unsigned int offset,
                          DSBlock& dsBlock);
 
   static bool SetMicroBlockHeader(bytes& dst, const unsigned int offset,
                                   const MicroBlockHeader& microBlockHeader);
   static bool GetMicroBlockHeader(const bytes& src, const unsigned int offset,
                                   MicroBlockHeader& microBlockHeader);
+  static bool GetMicroBlockHeader(const std::string& src,
+                                  const unsigned int offset,
+                                  MicroBlockHeader& microBlockHeader);
   static bool SetMicroBlock(bytes& dst, const unsigned int offset,
                             const MicroBlock& microBlock);
   static bool GetMicroBlock(const bytes& src, const unsigned int offset,
+                            MicroBlock& microBlock);
+  static bool GetMicroBlock(const std::string& src, const unsigned int offset,
                             MicroBlock& microBlock);
 
   static bool SetTxBlockHeader(bytes& dst, const unsigned int offset,
                                const TxBlockHeader& txBlockHeader);
   static bool GetTxBlockHeader(const bytes& src, const unsigned int offset,
                                TxBlockHeader& txBlockHeader);
+  static bool GetTxBlockHeader(const std::string& src,
+                               const unsigned int offset,
+                               TxBlockHeader& txBlockHeader);
   static bool SetTxBlock(bytes& dst, const unsigned int offset,
                          const TxBlock& txBlock);
   static bool GetTxBlock(const bytes& src, const unsigned int offset,
+                         TxBlock& txBlock);
+  static bool GetTxBlock(const std::string& src, const unsigned int offset,
                          TxBlock& txBlock);
 
   static bool SetVCBlockHeader(bytes& dst, const unsigned int offset,
                                const VCBlockHeader& vcBlockHeader);
   static bool GetVCBlockHeader(const bytes& src, const unsigned int offset,
                                VCBlockHeader& vcBlockHeader);
+  static bool GetVCBlockHeader(const std::string& src,
+                               const unsigned int offset,
+                               VCBlockHeader& vcBlockHeader);
   static bool SetVCBlock(bytes& dst, const unsigned int offset,
                          const VCBlock& vcBlock);
   static bool GetVCBlock(const bytes& src, const unsigned int offset,
+                         VCBlock& vcBlock);
+  static bool GetVCBlock(const std::string& src, const unsigned int offset,
                          VCBlock& vcBlock);
 
   static bool SetTransactionCoreInfo(bytes& dst, const unsigned int offset,
@@ -155,6 +179,8 @@ class Messenger {
   static bool SetTransaction(bytes& dst, const unsigned int offset,
                              const Transaction& transaction);
   static bool GetTransaction(const bytes& src, const unsigned int offset,
+                             Transaction& transaction);
+  static bool GetTransaction(const std::string& src, const unsigned int offset,
                              Transaction& transaction);
   static bool SetTransactionFileOffset(bytes& dst, const unsigned int offset,
                                        const std::vector<uint32_t>& txnOffsets);
@@ -170,12 +196,18 @@ class Messenger {
       const TransactionReceipt& transactionReceipt);
   static bool GetTransactionReceipt(const bytes& src, const unsigned int offset,
                                     TransactionReceipt& transactionReceipt);
+  static bool GetTransactionReceipt(const std::string& src,
+                                    const unsigned int offset,
+                                    TransactionReceipt& transactionReceipt);
 
   static bool SetTransactionWithReceipt(
       bytes& dst, const unsigned int offset,
       const TransactionWithReceipt& transactionWithReceipt);
   static bool GetTransactionWithReceipt(
       const bytes& src, const unsigned int offset,
+      TransactionWithReceipt& transactionWithReceipt);
+  static bool GetTransactionWithReceipt(
+      const std::string& src, const unsigned int offset,
       TransactionWithReceipt& transactionWithReceipt);
 
   static bool SetStateIndex(bytes& dst, const unsigned int offset,

--- a/src/libMessage/MessengerAccountStoreBase.h
+++ b/src/libMessage/MessengerAccountStoreBase.h
@@ -38,6 +38,9 @@ class MessengerAccountStoreBase {
   template <class MAP>
   static bool GetAccountStore(const bytes& src, const unsigned int offset,
                               MAP& addressToAccount);
+  template <class MAP>
+  static bool GetAccountStore(const std::string& src, const unsigned int offset,
+                              MAP& addressToAccount);
 };
 
 #endif  // ZILLIQA_SRC_LIBMESSAGE_MESSENGERACCOUNTSTOREBASE_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Data types that inherit from `SerializableDataBlock` (e.g., transactions, accounts, all block types) are deserialized using `ProtobufByteArrayToSerializable` in Messenger.cpp.

This function first converts the protobuf `bytes` type (which is basically `std::string`) into `vector<uint8>`, before then using each data type's `Deserialize` function on the conversion result.

This makes deserialization quite slow and can affect some protocol timings. For example, Lookup node might take too long to run `Messenger::GetNodeMBnForwardTransaction`, causing soft-confirmation to possibly overlap with final block receipt.

To fix this, we can just bypass string to byte vector conversion, and use string directly in the deserialization.

Additionally, I removed the use of `back_inserter` in Messenger.cpp. This is also inefficient as it translates to `push_back` which could potentially re-allocate new memory each time it is called.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
