### PR TITLE
[master] Reduce log messages during node initialization

### DIFF
--- a/src/libData/BlockChainData/BlockLinkChain.cpp
+++ b/src/libData/BlockChainData/BlockLinkChain.cpp
@@ -54,7 +54,8 @@ BlockLink BlockLinkChain::GetBlockLink(const uint64_t& index) {
 bool BlockLinkChain::AddBlockLink(const uint64_t& index,
                                   const uint64_t& dsindex,
                                   const BlockType blocktype,
-                                  const BlockHash& blockhash) {
+                                  const BlockHash& blockhash,
+                                  const bool showLogs) {
   uint64_t latestIndex = GetLatestIndex();
 
   std::lock_guard<std::mutex> g(m_mutexBlockLinkChain);
@@ -74,10 +75,12 @@ bool BlockLinkChain::AddBlockLink(const uint64_t& index,
 
   bytes dst;
 
-  LOG_GENERAL(INFO, "Index      = " << index);
-  LOG_GENERAL(INFO, "DS Index   = " << dsindex);
-  LOG_GENERAL(INFO, "Block type = " << blocktype);
-  LOG_GENERAL(INFO, "Block hash = " << blockhash);
+  if (showLogs) {
+    LOG_GENERAL(INFO, "Index      = " << index);
+    LOG_GENERAL(INFO, "DS Index   = " << dsindex);
+    LOG_GENERAL(INFO, "Block type = " << blocktype);
+    LOG_GENERAL(INFO, "Block hash = " << blockhash);
+  }
 
   if (!Messenger::SetBlockLink(
           dst, 0,

--- a/src/libData/BlockChainData/BlockLinkChain.h
+++ b/src/libData/BlockChainData/BlockLinkChain.h
@@ -47,7 +47,8 @@ class BlockLinkChain {
   BlockLink GetBlockLink(const uint64_t& index);
 
   bool AddBlockLink(const uint64_t& index, const uint64_t& dsindex,
-                    const BlockType blocktype, const BlockHash& blockhash);
+                    const BlockType blocktype, const BlockHash& blockhash,
+                    const bool showLogs = true);
   uint64_t GetLatestIndex();
 
   const DequeOfNode& GetBuiltDSComm();

--- a/src/libPersistence/BlockStorage.cpp
+++ b/src/libPersistence/BlockStorage.cpp
@@ -477,7 +477,8 @@ bool BlockStorage::GetTxBlock(const uint64_t& blockNum,
 
 bool BlockStorage::GetLatestTxBlock(TxBlockSharedPtr& block) {
   uint64_t latestTxBlockNum = 0;
-  uint64_t count = 0;
+
+  LOG_GENERAL(INFO, "Retrieving latest Tx block...");
 
   {
     shared_lock<shared_timed_mutex> g(m_mutexTxBlockchain);
@@ -485,11 +486,6 @@ bool BlockStorage::GetLatestTxBlock(TxBlockSharedPtr& block) {
         m_txBlockchainDB->GetDB()->NewIterator(leveldb::ReadOptions());
     for (it->SeekToFirst(); it->Valid(); it->Next()) {
       uint64_t blockNum = boost::lexical_cast<uint64_t>(it->key().ToString());
-      count++;
-      if (count % 1000 == 0) {
-        LOG_GENERAL(INFO, "txBlockNum: " << blockNum);
-        count = 0;
-      }
       if (blockNum > latestTxBlockNum) {
         latestTxBlockNum = blockNum;
       }
@@ -497,6 +493,7 @@ bool BlockStorage::GetLatestTxBlock(TxBlockSharedPtr& block) {
     delete it;
   }
 
+  LOG_GENERAL(INFO, "Latest Tx block = " << latestTxBlockNum);
   return GetTxBlock(latestTxBlockNum, block);
 }
 
@@ -824,6 +821,8 @@ bool BlockStorage::GetAllVCBlocks(std::list<VCBlockSharedPtr>& blocks) {
 bool BlockStorage::GetAllBlockLink(std::list<BlockLink>& blocklinks) {
   LOG_MARKER();
 
+  LOG_GENERAL(INFO, "Retrieving blocklinks...");
+
   shared_lock<shared_timed_mutex> g(m_mutexBlockLink);
 
   leveldb::Iterator* it =
@@ -850,13 +849,13 @@ bool BlockStorage::GetAllBlockLink(std::list<BlockLink>& blocklinks) {
       return false;
     }
     blocklinks.emplace_back(blcklink);
-    LOG_GENERAL(INFO, "Retrievd BlockLink Num:" << bns);
   }
   delete it;
   if (blocklinks.empty()) {
     LOG_GENERAL(INFO, "Disk has no blocklink");
     return false;
   }
+  LOG_GENERAL(INFO, "Retrieving blocklinks done");
   return true;
 }
 

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -285,6 +285,10 @@ bool Retriever::RetrieveBlockLink() {
     lastDsIndex--;
   }
 
+  LOG_GENERAL(INFO,
+              "Reconstructing DS committee from blocklinks (this may take some "
+              "time)...");
+
   std::list<BlockLink>::iterator blocklinkItr;
   for (blocklinkItr = blocklinks.begin(); blocklinkItr != blocklinks.end();
        ++blocklinkItr) {
@@ -300,7 +304,7 @@ bool Retriever::RetrieveBlockLink() {
         return false;
       }
 
-      m_mediator.m_node->UpdateDSCommitteeComposition(dsComm, *dsblock);
+      m_mediator.m_node->UpdateDSCommitteeComposition(dsComm, *dsblock, false);
       m_mediator.m_dsBlockChain.AddBlock(*dsblock);
 
     } else if (std::get<BlockLinkIndex::BLOCKTYPE>(blocklink) ==
@@ -314,8 +318,8 @@ bool Retriever::RetrieveBlockLink() {
                         << std::get<BlockLinkIndex::BLOCKHASH>(blocklink));
         return false;
       }
-      m_mediator.m_node->UpdateRetrieveDSCommitteeCompositionAfterVC(*vcblock,
-                                                                     dsComm);
+      m_mediator.m_node->UpdateRetrieveDSCommitteeCompositionAfterVC(
+          *vcblock, dsComm, false);
     }
 
     m_mediator.m_blocklinkchain.SetBuiltDSComm(dsComm);
@@ -324,8 +328,10 @@ bool Retriever::RetrieveBlockLink() {
         std::get<BlockLinkIndex::INDEX>(blocklink),
         std::get<BlockLinkIndex::DSINDEX>(blocklink),
         std::get<BlockLinkIndex::BLOCKTYPE>(blocklink),
-        std::get<BlockLinkIndex::BLOCKHASH>(blocklink));
+        std::get<BlockLinkIndex::BLOCKHASH>(blocklink), false);
   }
+
+  LOG_GENERAL(INFO, "Reconstructing DS committee done");
 
   return true;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
During node launch, `Retriever::RetrieveBlockLink` pollutes the logs with too many messages for:
1. Retrieving entire blocklinks leveldb (each blocklink number is displayed)
2. Reconstruction of DS committee from the blocklinks (member insertion/removal details are displayed)
3. Addition of each processed blocklink into `m_blocklinkchain`

Another such excessive logging happens in `BlockStorage::GetLatestTxBlock` (each 1000th block number retrieved is displayed).

After this PR, we will only display a single message such as:
1. `Retrieving blocklinks...`
2. `Retrieving latest Tx block...`
3. `Reconstructing DS committee from blocklinks (this may take some time)...`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
