### PR TITLE
[master] Adding _origin field in input message

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -66,6 +66,9 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   /// the current sender address for each hop of invoking
   Address m_curSenderAddr;
 
+  /// the address of transaction sender
+  Address m_originAddr;
+
   /// the transfer amount while executing each txn
   uint128_t m_curAmount{0};
 

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -449,6 +449,8 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       // reset the storageroot update buffer atomic per transaction
       m_storageRootUpdateBufferAtomic.clear();
 
+      m_originAddr = fromAddr;
+
       Account* fromAccount = this->GetAccount(fromAddr);
       if (fromAccount == nullptr) {
         LOG_GENERAL(WARNING, "Sender has no balance, reject");
@@ -882,6 +884,7 @@ bool AccountStoreSC<MAP>::ExportCallContractFiles(
     msgObj["_sender"] =
         prepend +
         Account::GetAddressFromPublicKey(transaction.GetSenderPubKey()).hex();
+    msgObj["_origin"] = prepend + m_originAddr.hex();
     msgObj["_amount"] = transaction.GetAmount().convert_to<std::string>();
 
     JSONUtils::GetInstance().writeJsontoFile(INPUT_MESSAGE_JSON, msgObj);
@@ -1378,6 +1381,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
 
       Json::Value input_message;
       input_message["_sender"] = "0x" + curContractAddr.hex();
+      input_message["_origin"] = "0x" + m_originAddr.hex();
       input_message["_amount"] = msg["_amount"];
       input_message["_tag"] = msg["_tag"];
       input_message["params"] = msg["params"];


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
A new field `_origin` implying the address of contract sender will be appended to the scilla input message

Related PR in scilla repo:
https://github.com/Zilliqa/scilla/pull/921

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
