### PR TITLE
[master] Remove GasIndex entry for smaller gas price

### DIFF
--- a/src/libData/AccountData/TxnPool.h
+++ b/src/libData/AccountData/TxnPool.h
@@ -84,12 +84,16 @@ struct TxnPool {
           HashIndex.erase(searchHash);
         }
         // erase from GasIdxTxns
+        auto smallerGasPrice = searchNonce->second.GetGasPrice();
         auto searchGas = GasIndex.find(searchNonce->second.GetGasPrice());
         if (searchGas != GasIndex.end()) {
           auto searchGasHash =
               searchGas->second.find(searchNonce->second.GetTranID());
           if (searchGasHash != searchGas->second.end()) {
             searchGas->second.erase(searchGasHash);
+          }
+          if (GasIndex[smallerGasPrice].empty()) {
+            GasIndex.erase(smallerGasPrice);
           }
         }
         HashIndex[t.GetTranID()] = t;


### PR DESCRIPTION
## Description
Fix the issue where in entry from GasIndex for smaller gas price is not removed when one with higher price is added.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
