### PR TITLE
[release-7.1] Add more verbose logging to txn processing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,7 +96,7 @@ RUN git clone ${REPO} ${SOURCE_DIR} \
        /usr/local/bin/isolatedServer \
        /usr/local/bin/getrewardhistory \
     #    /usr/local/bin/zilliqa \
-       /usr/local/bin/data_migrate \
+    #   /usr/local/bin/data_migrate \
        /usr/local/lib/libSchnorr.so \
        /usr/local/lib/libethash.so \
        /usr/local/lib/libNAT.so \

--- a/scripts/make_image_for_test.sh
+++ b/scripts/make_image_for_test.sh
@@ -44,9 +44,10 @@ Test_scenarios=("-DVC_TEST_DS_SUSPEND_3=1 "
                 "-DADDRESS_SANITIZER=ON "
                 "-DTHREAD_SANITIZER=ON "
                 "-DSJ_TEST_SJ_TXNBLKS_PROCESS_SLOW=1 "
-                "-DSJ_TEST_SJ_MISSING_MBTXNS=1 " )
+                "-DSJ_TEST_SJ_MISSING_MBTXNS=1 "
+                "-DPOW_TEST_VERSION_CHECK=1 " )
 
-Test_scenarios_name=( "vc2" "govvc2" "vc4" "vc1vc6" "vc3vc6" "vc7" "vc8" "dm1" "dm2" "dm3" "dm4" "dm5" "dm6" "dm7" "dm8" "dm9" "asan" "tsan" "sj1" "sj2" )
+Test_scenarios_name=( "vc2" "govvc2" "vc4" "vc1vc6" "vc3vc6" "vc7" "vc8" "dm1" "dm2" "dm3" "dm4" "dm5" "dm6" "dm7" "dm8" "dm9" "asan" "tsan" "sj1" "sj2" "powver" )
 
 cmd=$0
 

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -325,11 +325,16 @@ void Node::ProcessTransactionWhenShardLeader(
 
   vector<Transaction> gasLimitExceededTxnBuffer;
   vector<pair<TxnHash, TxnStatus>> droppedTxns;
+  unsigned int count_addrNonceTxnMap = 0;
+  unsigned int count_createdTxns = 0;
 
   AccountStore::GetInstance().CleanStorageRootUpdateBufferTemp();
 
+  LOG_GENERAL(INFO, "microblock_gas_limit = " << microblock_gas_limit);
+
   while (m_gasUsedTotal < microblock_gas_limit) {
     if (txnProcTimeout) {
+      LOG_GENERAL(INFO, "txnProcTimeout is set!");
       break;
     }
 
@@ -339,12 +344,16 @@ void Node::ProcessTransactionWhenShardLeader(
     // check m_addrNonceTxnMap contains any txn meets right nonce,
     // if contains, process it
     if (findOneFromAddrNonceTxnMap(t, t_addrNonceTxnMap)) {
+      count_addrNonceTxnMap++;
       // check whether m_createdTransaction have transaction with same Addr and
       // nonce if has and with larger gasPrice then replace with that one.
       // (*optional step)
       t_createdTxns.findSameNonceButHigherGas(t);
 
       if (m_gasUsedTotal + t.GetGasLimit() > microblock_gas_limit) {
+        LOG_GENERAL(WARNING, "Gas limit exceeded = " << t.GetTranID());
+        LOG_GENERAL(WARNING, "m_gasUsedTotal     = " << m_gasUsedTotal);
+        LOG_GENERAL(WARNING, "t.GetGasLimit      = " << t.GetGasLimit());
         gasLimitExceededTxnBuffer.emplace_back(t);
         continue;
       }
@@ -374,6 +383,7 @@ void Node::ProcessTransactionWhenShardLeader(
     }
     // if no txn in u_map meet right nonce process new come-in transactions
     else if (t_createdTxns.findOne(t)) {
+      count_createdTxns++;
       // LOG_GENERAL(INFO, "findOneFromCreated");
 
       Address senderAddr = t.GetSenderAddr();
@@ -381,12 +391,11 @@ void Node::ProcessTransactionWhenShardLeader(
       // m_addrNonceTxnMap
       if (t.GetNonce() >
           AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
-        // LOG_GENERAL(INFO, "High nonce: "
-        //                     << t.GetNonce() << " cur sender " <<
-        //                     senderAddr.hex()
-        //                     << " nonce: "
-        //                     <<
-        //                     AccountStore::GetInstance().GetNonceTemp(senderAddr));
+        LOG_GENERAL(
+            INFO, "High nonce: "
+                      << t.GetNonce() << " cur sender " << senderAddr.hex()
+                      << " nonce: "
+                      << AccountStore::GetInstance().GetNonceTemp(senderAddr));
         auto it1 = t_addrNonceTxnMap.find(senderAddr);
         if (it1 != t_addrNonceTxnMap.end()) {
           auto it2 = it1->second.find(t.GetNonce());
@@ -405,15 +414,19 @@ void Node::ProcessTransactionWhenShardLeader(
       else if (t.GetNonce() <
                AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
         LOG_GENERAL(
-            INFO, "Nonce too small"
-                      << " Expected "
-                      << AccountStore::GetInstance().GetNonceTemp(senderAddr)
-                      << " Found " << t.GetNonce() << " for " << t.GetTranID());
+            INFO,
+            "Nonce too small"
+                << " Expected "
+                << AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1
+                << " Found " << t.GetNonce() << " for " << t.GetTranID());
         droppedTxns.emplace_back(t.GetTranID(), TxnStatus::NONCE_TOO_LOW);
       }
       // if nonce correct, process it
       else {
         if (m_gasUsedTotal + t.GetGasLimit() > microblock_gas_limit) {
+          LOG_GENERAL(WARNING, "Gas limit exceeded = " << t.GetTranID());
+          LOG_GENERAL(WARNING, "m_gasUsedTotal     = " << m_gasUsedTotal);
+          LOG_GENERAL(WARNING, "t.GetGasLimit      = " << t.GetGasLimit());
           gasLimitExceededTxnBuffer.emplace_back(t);
           continue;
         }
@@ -441,9 +454,14 @@ void Node::ProcessTransactionWhenShardLeader(
         }
       }
     } else {
+      LOG_GENERAL(INFO, "Ending txn processing loop");
       break;
     }
   }
+
+  LOG_GENERAL(INFO, "AddrNonceTxnMap # txns = " << count_addrNonceTxnMap);
+  LOG_GENERAL(INFO, "t_createdTxns   # txns = " << count_createdTxns);
+  LOG_GENERAL(INFO, "m_gasUsedTotal         = " << m_gasUsedTotal);
 
   AccountStore::GetInstance().ProcessStorageRootUpdateBufferTemp();
   AccountStore::GetInstance().CleanNewLibrariesCacheTemp();
@@ -599,11 +617,16 @@ void Node::ProcessTransactionWhenShardBackup(
 
   vector<Transaction> gasLimitExceededTxnBuffer;
   vector<pair<TxnHash, TxnStatus>> droppedTxns;
+  unsigned int count_addrNonceTxnMap = 0;
+  unsigned int count_createdTxns = 0;
 
   AccountStore::GetInstance().CleanStorageRootUpdateBufferTemp();
 
+  LOG_GENERAL(INFO, "microblock_gas_limit = " << microblock_gas_limit);
+
   while (m_gasUsedTotal < microblock_gas_limit) {
     if (txnProcTimeout) {
+      LOG_GENERAL(INFO, "txnProcTimeout is set!");
       break;
     }
 
@@ -613,12 +636,16 @@ void Node::ProcessTransactionWhenShardBackup(
     // check t_addrNonceTxnMap contains any txn meets right nonce,
     // if contains, process it
     if (findOneFromAddrNonceTxnMap(t, t_addrNonceTxnMap)) {
+      count_addrNonceTxnMap++;
       // check whether m_createdTransaction have transaction with same Addr and
       // nonce if has and with larger gasPrice then replace with that one.
       // (*optional step)
       t_createdTxns.findSameNonceButHigherGas(t);
 
       if (m_gasUsedTotal + t.GetGasLimit() > microblock_gas_limit) {
+        LOG_GENERAL(WARNING, "Gas limit exceeded = " << t.GetTranID());
+        LOG_GENERAL(WARNING, "m_gasUsedTotal     = " << m_gasUsedTotal);
+        LOG_GENERAL(WARNING, "t.GetGasLimit      = " << t.GetGasLimit());
         gasLimitExceededTxnBuffer.emplace_back(t);
         continue;
       }
@@ -650,11 +677,17 @@ void Node::ProcessTransactionWhenShardBackup(
     }
     // if no txn in u_map meet right nonce process new come-in transactions
     else if (t_createdTxns.findOne(t)) {
+      count_createdTxns++;
       Address senderAddr = t.GetSenderAddr();
       // check nonce, if nonce larger than expected, put it into
       // t_addrNonceTxnMap
       if (t.GetNonce() >
           AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
+        LOG_GENERAL(
+            INFO, "High nonce: "
+                      << t.GetNonce() << " cur sender " << senderAddr.hex()
+                      << " nonce: "
+                      << AccountStore::GetInstance().GetNonceTemp(senderAddr));
         auto it1 = t_addrNonceTxnMap.find(senderAddr);
         if (it1 != t_addrNonceTxnMap.end()) {
           auto it2 = it1->second.find(t.GetNonce());
@@ -673,15 +706,19 @@ void Node::ProcessTransactionWhenShardBackup(
       else if (t.GetNonce() <
                AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1) {
         LOG_GENERAL(
-            INFO, "Nonce too small"
-                      << " Expected "
-                      << AccountStore::GetInstance().GetNonceTemp(senderAddr)
-                      << " Found " << t.GetNonce() << " for " << t.GetTranID());
+            INFO,
+            "Nonce too small"
+                << " Expected "
+                << AccountStore::GetInstance().GetNonceTemp(senderAddr) + 1
+                << " Found " << t.GetNonce() << " for " << t.GetTranID());
         droppedTxns.emplace_back(t.GetTranID(), TxnStatus::NONCE_TOO_LOW);
       }
       // if nonce correct, process it
       else {
         if (m_gasUsedTotal + t.GetGasLimit() > microblock_gas_limit) {
+          LOG_GENERAL(WARNING, "Gas limit exceeded = " << t.GetTranID());
+          LOG_GENERAL(WARNING, "m_gasUsedTotal     = " << m_gasUsedTotal);
+          LOG_GENERAL(WARNING, "t.GetGasLimit      = " << t.GetGasLimit());
           gasLimitExceededTxnBuffer.emplace_back(t);
           continue;
         }
@@ -709,9 +746,14 @@ void Node::ProcessTransactionWhenShardBackup(
         }
       }
     } else {
+      LOG_GENERAL(INFO, "Ending txn processing loop");
       break;
     }
   }
+
+  LOG_GENERAL(INFO, "AddrNonceTxnMap # txns = " << count_addrNonceTxnMap);
+  LOG_GENERAL(INFO, "t_createdTxns   # txns = " << count_createdTxns);
+  LOG_GENERAL(INFO, "m_gasUsedTotal         = " << m_gasUsedTotal);
 
   AccountStore::GetInstance().ProcessStorageRootUpdateBufferTemp();
   AccountStore::GetInstance().CleanNewLibrariesCacheTemp();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
1. Added missing change for `powver` test
2. Added more tx processing logs (`ProcessTransactionWhenShardLeader` and `ProcessTransactionWhenShardBackup` changes should be identical)
3. Corrected the expected nonce for "nonce too small" message
4. Removed `data_migrate` from Dockerfile

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
