### PR TITLE
[master] Fix docker build failure in master branch code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,5 @@
 	branch = releases/stable
 [submodule "src/depends/cryptoutils"]
 	path = src/depends/cryptoutils
-	url = https://github.com/Zilliqa/cryptoutils
+	url = https://github.com/Zilliqa/cryptoutils.git
+	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ endif()
 include(InstallG3log)
 find_package(g3logger CONFIG REQUIRED)
 
+include(InstallCryptoUtils)
+
 include(InstallMongo)
 find_package(mongocxx CONFIG REQUIRED)
  

--- a/cmake/InstallCryptoUtils.cmake
+++ b/cmake/InstallCryptoUtils.cmake
@@ -1,0 +1,19 @@
+set(CRYPTOUTILS_INSTALL_LOG ${CMAKE_BINARY_DIR}/install_cryptoutils.log)
+set(CRYPTOUTILS_INSTALL_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
+
+message(STATUS "Building and installing cryptoutils")
+
+# update submodule to the latest commit
+execute_process(
+    COMMAND git submodule update --init --recursive src/depends/cryptoutils
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE CRYPTOUTILS_INSTALL_RET
+    OUTPUT_FILE ${CRYPTOUTILS_INSTALL_LOG}
+    ERROR_FILE ${CRYPTOUTILS_INSTALL_LOG}
+)
+
+if(NOT "${CRYPTOUTILS_INSTALL_RET}" STREQUAL "0")
+    message(FATAL_ERROR "Error when building and installing cryptoutils (1), see more in log ${CRYPTOUTILS_INSTALL_LOG}")
+endif()
+
+file(MAKE_DIRECTORY ${CRYPTOUTILS_INSTALL_INCLUDE_DIR})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     build-essential \
     ca-certificates \
     cmake \
+    wget \
     # curl is not a build dependency
     curl \
     git \
@@ -58,6 +59,17 @@ RUN apt-get update \
     python3-setuptools \
     libsecp256k1-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Install cmake 3.19
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh \
+    && mkdir -p "${HOME}"/.local \
+    && bash ./cmake-3.19.3-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/
+
+# Include path to refer to latest version of cmake
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN cmake --version \
+    && rm cmake-3.19.3-Linux-x86_64.sh
 
 # Manually input tag or commit, can be overwritten by docker build-args
 ARG COMMIT_OR_TAG=v7.0.0-alpha.0


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

There is change in zilliqa repo to use inbuild `cryptoutils` library instead of etash.This requires changes in the `Dockerfile` and fetching of modules. please refer to [https://github.com/Zilliqa/Zilliqa/commit/86263ba52dfd629fcac9830a6a1a548c45076e81](url) for more details.

The PR address the build failure with docker.

Following are the changes.
1)  Update cmake version from 3.10 to 3.19 from the steps specified by @vaivaswatha  in the `cryptoutils` PR merge.
2) Fetch `cryptoutils` repo.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
