### PR TITLE
Improve Daemon to start new process when failed to monitor previous process

### DIFF
--- a/daemon/ZilliqaDaemon.h
+++ b/daemon/ZilliqaDaemon.h
@@ -45,12 +45,14 @@
 class ZilliqaDaemon {
  public:
   ZilliqaDaemon(int argc, const char* argv[], std::ofstream& log);
-  void MonitorProcess(const std::string& name);
+  void MonitorProcess(const std::string& name,
+                      const bool startNewByDaemon = false);
   static void LOG(std::ofstream& log, const std::string& msg);
 
  private:
   std::ofstream& m_log;
   std::unordered_map<std::string, std::vector<pid_t>> m_pids;
+  std::unordered_map<std::string, unsigned int> m_failedMonitorProcessCount;
   std::unordered_map<pid_t, bool> m_died;
   std::string m_privKey, m_pubKey, m_ip, m_logPath, m_nodeType, m_curPath;
   int m_port, m_recovery, m_nodeIndex;
@@ -62,9 +64,9 @@ class ZilliqaDaemon {
   bool DownloadPersistenceFromS3();
 
   std::vector<pid_t> GetProcIdByName(const std::string& procName);
-  void StartNewProcess();
+  void StartNewProcess(bool cleanPersistence = false);
   void StartScripts();
-  void KillProcess();
+  void KillProcess(const std::string& procName);
   int ReadInputs(int argc, const char* argv[]);
 };
 


### PR DESCRIPTION
## Description
Daemon is improved to start the process if it fails to monitor the previous running process.
I also stop the `scilla-server` process if running whenever new `zilliqa` process is started.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
