### PR TITLE
[master] Fix for libevent deadlock in p2pseed

### DIFF
--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -124,12 +124,11 @@ class P2PComm {
   static void EventCbServerSeed(struct bufferevent* bev, short events,
                                 [[gnu::unused]] void* ctx);
   static void EventCbClientSeed([[gnu::unused]] struct bufferevent* bev,
-                                short events, [[gnu::unused]] void* ctx);
+                                short events, void* ctx);
   static void ReadCallback(struct bufferevent* bev, void* ctx);
   static void ReadCbServerSeed(struct bufferevent* bev,
                                [[gnu::unused]] void* ctx);
-  static void ReadCbClientSeed(struct bufferevent* bev,
-                               [[gnu::unused]] void* ctx);
+  static void ReadCbClientSeed(struct bufferevent* bev, void* ctx);
 
   static void AcceptConnectionCallback(evconnlistener* listener,
                                        evutil_socket_t cli_sock,
@@ -140,7 +139,9 @@ class P2PComm {
                                  struct sockaddr* cli_addr, int socklen,
                                  void* arg);
   static void CloseAndFreeBufferEvent(struct bufferevent* bufev);
-  static void CloseAndFreeBevP2PSeedConn(struct bufferevent* bufev);
+  static void CloseAndFreeBevP2PSeedConnServer(struct bufferevent* bufev);
+  static void CloseAndFreeBevP2PSeedConnClient(struct bufferevent* bufev,
+                                               void* ctx);
 
  public:
   static std::mutex m_mutexBufferEvent;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

In `p2pseed` branch, we observed deadlock situation during testing for testnet termination scenarios or this could probably also happen if all seed nodes are down for long time(say 2-4 mins).Below is explanation.

When the  testnet is terminated, the seedpubs will always send `BEV_EVENT_ERROR`.
On the client side `GetVCFinalBlockFromL2lDataProvider` is run in the infinite loop.The sender application thread calling `SendMsgToSeedNodeOnWire()` keeps waiting always after taking `m_mutexBufferEvent` in function `bufferevent_write`.This happens randomly if one of the libevent callbacks is received out of order.
The `CloseAndFreeBevP2PSeedConn` function is also waiting to acquire lock.This cause deadlock.

Solution:
We should perform `bufferevent_write()` only if the socket is connected.This way, it will not go to perform `bufferevent_write` in the `BEV_EVENT_ERROR`(i.e when the server is down) scenarios.

Note : We won't have face this problem if `bufferevent_socket_connect()` had returned immediately on failure.But it does not happen. Libevent provides socket connection error only in event callback for non blocking operation.


 

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
