### PR TITLE
[master] Support pagination for fetching transaction list and transaction bodies

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -172,6 +172,7 @@
             <NUM_TTL_PENDING_TXN>1</NUM_TTL_PENDING_TXN>
             <NUM_TTL_DROPPED_TXN>5</NUM_TTL_DROPPED_TXN>
         </pending_txn>
+        <NUM_TXNS_PER_PAGE>2500</NUM_TXNS_PER_PAGE>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -171,6 +171,7 @@
             <NUM_TTL_PENDING_TXN>1</NUM_TTL_PENDING_TXN>
             <NUM_TTL_DROPPED_TXN>5</NUM_TTL_DROPPED_TXN>
         </pending_txn>
+        <NUM_TXNS_PER_PAGE>2500</NUM_TXNS_PER_PAGE>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -365,6 +365,8 @@ const unsigned int NUM_TTL_PENDING_TXN{
     ReadConstantNumeric("NUM_TTL_PENDING_TXN", "node.jsonrpc.pending_txn.")};
 const unsigned int NUM_TTL_DROPPED_TXN{
     ReadConstantNumeric("NUM_TTL_DROPPED_TXN", "node.jsonrpc.pending_txn.")};
+const unsigned int NUM_TXNS_PER_PAGE{
+    ReadConstantNumeric("NUM_TXNS_PER_PAGE", "node.jsonrpc.")};
 
 // Network composition constants
 const unsigned int COMM_SIZE{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -283,6 +283,7 @@ extern const unsigned int WEBSOCKET_PORT;
 extern const bool ENABLE_GETTXNBODIESFORTXBLOCK;
 extern const unsigned int NUM_TTL_PENDING_TXN;
 extern const unsigned int NUM_TTL_DROPPED_TXN;
+extern const unsigned int NUM_TXNS_PER_PAGE;
 
 // Network composition constants
 extern const unsigned int COMM_SIZE;

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -72,6 +72,8 @@ const Json::Value JSONConversion::convertTxBlocktoJson(const TxBlock& txblock) {
   ret_head["StateRootHash"] = txheader.GetStateRootHash().hex();
   ret_head["StateDeltaHash"] = txheader.GetStateDeltaHash().hex();
   ret_head["NumTxns"] = txheader.GetNumTxs();
+  ret_head["NumPages"] = (txheader.GetNumTxs() / NUM_TXNS_PER_PAGE) +
+                         ((txheader.GetNumTxs() % NUM_TXNS_PER_PAGE) ? 1 : 0);
   ret_head["NumMicroBlocks"] =
       static_cast<uint32_t>(txblock.GetMicroBlockInfos().size());
 

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -46,7 +46,8 @@ class LookupServer : public Server,
     return m_mediator.m_lookup->AddToTxnShardMap(tx, shardId);
   };
 
-  Json::Value GetTransactionsForTxBlock(const std::string& txBlockNum);
+  Json::Value GetTransactionsForTxBlock(const std::string& txBlockNum,
+                                        const std::string& pageNumber);
 
  public:
   LookupServer(Mediator& mediator, jsonrpc::AbstractServerConnector& server);
@@ -197,11 +198,21 @@ class LookupServer : public Server,
   }
   inline virtual void GetTransactionsForTxBlockI(const Json::Value& request,
                                                  Json::Value& response) {
-    response = this->GetTransactionsForTxBlock(request[0u].asString());
+    response = this->GetTransactionsForTxBlock(request[0u].asString(), "");
+  }
+  inline virtual void GetTransactionsForTxBlockExI(const Json::Value& request,
+                                                   Json::Value& response) {
+    response = this->GetTransactionsForTxBlock(request[0u].asString(),
+                                               request[1u].asString());
   }
   inline virtual void GetTxnBodiesForTxBlockI(const Json::Value& request,
                                               Json::Value& response) {
-    response = this->GetTxnBodiesForTxBlock(request[0u].asString());
+    response = this->GetTxnBodiesForTxBlock(request[0u].asString(), "");
+  }
+  inline virtual void GetTxnBodiesForTxBlockExI(const Json::Value& request,
+                                                Json::Value& response) {
+    response = this->GetTxnBodiesForTxBlock(request[0u].asString(),
+                                            request[1u].asString());
   }
   inline virtual void GetShardMembersI(const Json::Value& request,
                                        Json::Value& response) {
@@ -278,10 +289,13 @@ class LookupServer : public Server,
   Json::Value GetSmartContractInit(const std::string& address);
   Json::Value GetSmartContractCode(const std::string& address);
 
-  static Json::Value GetTransactionsForTxBlock(const TxBlock& txBlock);
+  static Json::Value GetTransactionsForTxBlock(
+      const TxBlock& txBlock,
+      const uint32_t pageNumber = std::numeric_limits<uint32_t>::max());
 
   Json::Value GetMinerInfo(const std::string& blockNum);
-  Json::Value GetTxnBodiesForTxBlock(const std::string& txBlockNum);
+  Json::Value GetTxnBodiesForTxBlock(const std::string& txBlockNum,
+                                     const std::string& pageNumber);
   Json::Value GetTransactionStatus(const std::string& txnhash);
 };
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR adds a new field `NumPages` to `GetTxBlock` result:
```
~$ curl -d '{
>     "id": "1",
>     "jsonrpc": "2.0",
>     "method": "GetTxBlock",
>     "params": ["2"]
> }' -H "Content-Type: application/json" -X POST "https://pagination8-api.dev.z7a.xyz/" | jq .
...
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
   ...
    "header": {
      "BlockNum": "2",
      ...
      "NumMicroBlocks": 4,
      "NumPages": 3,
      "NumTxns": 30,
    }
  }
}
```
It also adds 2 new API:
- `GetTransactionsForTxBlockEx`
  - Request format is same as `GetTransactionsForTxBlock` except it has a second parameter (page number)
  - Response format is map{"Transactions":[], "CurrPage": int, "NumPages": int}
- `GetTxnBodiesForTxBlockEx`
  - Request format is same as `GetTxnBodiesForTxBlock` except it has a second parameter (page number)
  - Response format is map{"Transactions":[], "CurrPage": int, "NumPages": int}

Page number is zero-based. `GetTransactionsForTxBlock` and `GetTxnBodiesForTxBlock` behavior are unchanged.

**Sample usage:**

Getting the first page for a 30-transaction block (`NUM_TXNS_PER_PAGE` set to 10)
```
~$ curl -d '{
>     "id": "1",
>     "jsonrpc": "2.0",
>     "method": "GetTransactionsForTxBlockEx",
>     "params": ["2","0"]
> }' -H "Content-Type: application/json" -X POST "https://pagination8-api.dev.z7a.xyz/" | jq .
...
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "CurrPage": 0,
    "NumPages": 3,
    "Transactions": [
      [
        "7a2deb9acfb67b74769ca3310a49fb4e067d7e6363c246e5cf4becbfe1e73225",
        "2cca791240282a6edcb9e6d73ebfaccd4718bfcef28c29835202401bd3f2c7b8",
        "8bff59648ebf6754c976a3366f0ba4b65b092bc86db203fbafd41803badeac19",
        "27f806597d44f3ba2c5903860bcd973db127a08f1da2d002c5a01cb032e00e43",
        "be8b1172b3c5c4a1ac576ff4ec97bb21963b02af50129af6b23f26d37bd67519",
        "deeeec39a72e1bb74942c0bd7e809d2047102335cfffff1ea5883cef88cbec10",
        "42db597acb623b84fa3103c1f2a93f1347822894b684cf6353cdff05e6c1fb93",
        "2d4e8c781d7471de85bb628029bc2043ff8fa2805a245d6f467d83335e88fba5",
        "ee35d9fb66bd0880bb7670cf581c31328502fb87e132ebf16bf6e344d8d6d7f4",
        "ee457d7a54897e61230ac7714881a82950417a614c339a19511be6dd37f4f275"
      ],
      [],
      [],
      []
    ]
  }
}
```

Getting the last page
```
~$ curl -d '{
>     "id": "1",
>     "jsonrpc": "2.0",
>     "method": "GetTransactionsForTxBlockEx",
>     "params": ["2","2"]
> }' -H "Content-Type: application/json" -X POST "https://pagination8-api.dev.z7a.xyz/" | jq .
...
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": {
    "CurrPage": 2,
    "NumPages": 3,
    "Transactions": [
      [],
      [],
      [
        "e6d8b26086ec882f4e54c4f653ed45443ebc236817d5f433969baa33bd6d3464",
        "123e0a9dfa95c6386412a14aaa25a26af3ef8370444821072a3baa9995f77e71",
        "32924770107c13738c7b92b89880e815a5185f646f68c6d1d0db9b71727a05f7",
        "ef6ea7849143036fb9ba9476a8cec7d131d66d30bf1fecaeb3332f99e216653c",
        "4d051f84519dd2005c8341e7843214c1a1541616b1cdc6a01c9d4536ddc430b3"
      ],
      [
        "16b9dffb533141c1a488cfda87ddc67d267223b7fcdd15b62368566549daf881",
        "22159905546c7b083dcd1a7c5a57029b172eca36fbf0d47dbde4980565e55b23",
        "6e59fd6d6061c8fc6ea6182da31e94ee0e5c3d4a932069a8fe9f49b8702a934b",
        "e4322c8a298e03742666a5c25d641a5450d9db4fd6761282556df2de62300590",
        "f87ba2f51a96e4bba9ba454eee45c58e23c291d05e07687470a6e1b085baf3df"
      ]
    ]
  }
}
```

Bad page number
```
~$ curl -d '{
>     "id": "1",
>     "jsonrpc": "2.0",
>     "method": "GetTransactionsForTxBlockEx",
>     "params": ["2","3"]
> }' -H "Content-Type: application/json" -X POST "https://pagination8-api.dev.z7a.xyz/" | jq .
...
{
  "error": {
    "code": -1,
    "data": null,
    "message": "TxBlock has no transactions"
  },
  "id": "1",
  "jsonrpc": "2.0"
}
```

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
