### PR TITLE
[master] De-blacklist ejected dscommittee members

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -30,6 +30,7 @@
 #include "libCrypto/Sha2.h"
 #include "libMediator/Mediator.h"
 #include "libMessage/Messenger.h"
+#include "libNetwork/Blacklist.h"
 #include "libNetwork/Guard.h"
 #include "libNetwork/P2PComm.h"
 #include "libPOW/pow.h"
@@ -304,6 +305,12 @@ void DirectoryService::InjectPoWForDSNode(
       LOG_GENERAL(INFO, "Injecting into PoW connections " << rit->second);
     }
 
+    if (m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() >=
+        UPGRADE_TARGET_DS_NUM) {
+      // Remove this node from blacklist if it exists
+      Peer& p = rit->second;
+      Blacklist::GetInstance().Remove(p.GetIpAddress());
+    }
     ++counter;
   }
 

--- a/src/libDirectoryService/DSComposition.cpp
+++ b/src/libDirectoryService/DSComposition.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "DSComposition.h"
+#include "libNetwork/Blacklist.h"
 
 using namespace std;
 
@@ -134,6 +135,11 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
       minerInfo.m_dsNodesEjected.emplace_back(dsComm.back().first);
     }
 
+    if (dsblock.GetHeader().GetBlockNum() >= UPGRADE_TARGET_DS_NUM) {
+      // Remove this node from blacklist if it exists
+      Peer& p = dsComm.back().second;
+      Blacklist::GetInstance().Remove(p.GetIpAddress());
+    }
     dsComm.pop_back();
   }
 


### PR DESCRIPTION
This PR makes sure that `ejected dscommittee members` which are now `shard-members` are removed from blacklist of existing 
ds-committee members.

This change should take effect only at `UPGRADE_TARGET_DS_NUM`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
