### PR TITLE
[master] P2pseed: close connection from server if the key is not whitelisted.

### DIFF
--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -553,7 +553,8 @@ class Lookup : public Executable {
   std::unordered_set<PubKey> m_extSeedWhitelisted;
   bool AddToWhitelistExtSeed(const PubKey& pubKey);
   bool RemoveFromWhitelistExtSeed(const PubKey& pubKey);
-  bool IsWhitelistedExtSeed(const PubKey& pubKey);
+  bool IsWhitelistedExtSeed(const PubKey& pubKey, const Peer& from,
+                            const unsigned char& startByte);
 
   // VCDSblock processed variables - used by seed nodes using PULL P1 option
   std::mutex m_mutexVCDSBlockProcessed;

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -1029,6 +1029,53 @@ void P2PComm::RemoveBevFromMap(const Peer& peer) {
   }
 }
 
+void P2PComm::RemoveBevAndCloseP2PConnServer(const Peer& peer,
+                                             const unsigned& startByteType) {
+  LOG_MARKER();
+  if (startByteType == START_BYTE_SEED_TO_SEED_REQUEST) {
+    lock(m_mutexPeerConnectionCount, m_mutexBufferEvent);
+    unique_lock<mutex> lock(m_mutexPeerConnectionCount, adopt_lock);
+    lock_guard<mutex> g(m_mutexBufferEvent, adopt_lock);
+    string bufKey = peer.GetPrintableIPAddress() + ":" +
+                    boost::lexical_cast<string>(peer.GetListenPortHost());
+    LOG_GENERAL(DEBUG,
+                "P2PSeed RemoveBufferEvent=" << peer << " bufKey =" << bufKey);
+    auto it = m_bufferEventMap.find(bufKey);
+    if (it != m_bufferEventMap.end()) {
+      // TODO Remove this log
+      if (DEBUG_LEVEL == 4) {
+        LOG_GENERAL(DEBUG, "P2PSeed clearing bufferevent for bufKey="
+                               << it->first << " bev=" << it->second);
+        for (const auto& it : m_bufferEventMap) {
+          LOG_GENERAL(DEBUG, " P2PSeed m_bufferEventMap key = "
+                                 << it.first << " bev = " << it.second);
+        }
+      }
+      bufferevent* bufev = it->second;
+      int fd = bufferevent_getfd(bufev);
+      struct sockaddr_in cli_addr {};
+      socklen_t addr_size = sizeof(struct sockaddr_in);
+      getpeername(fd, (struct sockaddr*)&cli_addr, &addr_size);
+      char* strAdd = inet_ntoa(cli_addr.sin_addr);
+      int port = cli_addr.sin_port;
+      // TODO Remove log
+      LOG_GENERAL(DEBUG, "P2PSeed RemoveBevAndCloseP2PConnServer ip="
+                             << strAdd << " port=" << port << " bev=" << bufev);
+      uint128_t ipAddr = cli_addr.sin_addr.s_addr;
+      if (m_peerConnectionCount[ipAddr] > 0) {
+        m_peerConnectionCount[ipAddr]--;
+        // TODO Remove log
+        LOG_GENERAL(DEBUG, "P2PSeed decrementing connection count for ipaddr="
+                               << ipAddr << " m_peerConnectionCount="
+                               << m_peerConnectionCount[ipAddr]);
+      }
+      bufferevent_setcb(bufev, NULL, NULL, NULL, NULL);
+      bufferevent_free(bufev);
+      m_bufferEventMap.erase(it);
+    }
+  }
+}
+
 void P2PComm ::EventCbClientSeed([[gnu::unused]] struct bufferevent* bev,
                                  short events, void* ctx) {
   int fd = bufferevent_getfd(bev);
@@ -1065,15 +1112,11 @@ void P2PComm ::EventCbClientSeed([[gnu::unused]] struct bufferevent* bev,
     if (destBytes != NULL) {
       if (bufferevent_write(bev, &(destBytes->at(0)), destBytes->size()) < 0) {
         LOG_GENERAL(WARNING, "Error: P2PSeed bufferevent_write failed !!!");
-        return;
       }
+      struct timeval tv = {SEED_SYNC_LARGE_PULL_INTERVAL, 0};
+      bufferevent_set_timeouts(bev, &tv, NULL);
     }
-  }
-  if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {
-    bufferevent_set_timeouts(bev, NULL, NULL);
-    CloseAndFreeBevP2PSeedConnClient(bev, ctx);
-  }
-  if (events & BEV_EVENT_TIMEOUT) {
+  } else if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR | BEV_EVENT_TIMEOUT)) {
     CloseAndFreeBevP2PSeedConnClient(bev, ctx);
   }
 }
@@ -1410,9 +1453,6 @@ void P2PComm::SendMsgToSeedNodeOnWire(const Peer& peer, const Peer& fromPeer,
       bufferevent_setcb(bev, ReadCbClientSeed, NULL, EventCbClientSeed,
                         (void*)destBytes);
       bufferevent_enable(bev, EV_READ | EV_WRITE);
-
-      struct timeval tv = {SEED_SYNC_LARGE_PULL_INTERVAL, 0};
-      bufferevent_set_timeouts(bev, &tv, NULL);
 
       struct sockaddr_in serv_addr {};
       serv_addr.sin_family = AF_INET;

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -164,6 +164,8 @@ class P2PComm {
   inline static bool IsNodeNotRunning();
   static void ClearPeerConnectionCount();
   static void RemoveBevFromMap(const Peer& peer);
+  static void RemoveBevAndCloseP2PConnServer(const Peer& peer,
+                                             const unsigned& startByteType);
 
  private:
   using SocketCloser = std::unique_ptr<int, void (*)(int*)>;

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -122,11 +122,6 @@ void Zilliqa::ProcessMessage(
 
       if (!result) {
         // To-do: Error recovery
-        if (message->second.second == START_BYTE_SEED_TO_SEED_REQUEST) {
-          Peer requestorPeer(message->second.first.GetIpAddress(),
-                             message->second.first.GetListenPortHost());
-          P2PComm::GetInstance().RemoveBevFromMap(requestorPeer);
-        }
       }
     } else {
       LOG_GENERAL(WARNING, "Unknown message type " << std::hex


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
In p2pseed code, client seed is always responsible for closing socket connection on successful response message or no response message.server seed will close upon receipt of `BEV_EVENT_EOF` from client.

However if the key is not whitelisted in our seedpubs, it is better to close connection from server side immediately.In this scenario, client will receive `BEV_EVENT_EOF` from server and terminate socket connection on it's end.

In the same PR, added some optimization in client seed code.
1) To set timeout on bufferevent only if socket connect is successful.
2) Remove `RemoveBevFromMap` from `Zillqa.cpp` for clearing entry from map.Anyway this would be cleared in another call to `RemoveBevFromMap` in `EventCbServerSeed`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
