### PR TITLE
[master] Add bech32 utilities and initial migration to bech32 address

### DIFF
--- a/src/libUtils/AddressConversion.cpp
+++ b/src/libUtils/AddressConversion.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "AddressConversion.h"
+#include "DataConversion.h"
+#include "depends/cryptoutils/include/Bech32/segwit_addr.h"
+
+using namespace std;
+
+inline bool HasZilHrp(const string& input) {
+  return input.substr(0, 4) == string("zil1");
+}
+
+AddressConversionCode ToAddressStructure(const string& addr, Address& retAddr) {
+  if (addr.size() != HEX_ADDR_SIZE) {
+    return AddressConversionCode::WRONG_ADDR_SIZE;
+  }
+
+  bytes tmpaddr;
+  if (!DataConversion::HexStrToUint8Vec(addr, tmpaddr)) {
+    return AddressConversionCode::INVALID_ADDR;
+  }
+
+  retAddr = Address{tmpaddr};
+  return AddressConversionCode::OK;
+}
+
+AddressConversionCode ToBase16Addr(const string& addr, Address& retAddr) {
+  // Accept both bech32 or base16 string, and convert to our structure
+  if (HasZilHrp(addr)) {
+    bytes tmpaddr(ACC_ADDR_SIZE);
+    size_t tmpaddrSize = 0;
+
+    if (bech32_addr_decode(tmpaddr.data(), &tmpaddrSize, "zil", addr.c_str()) ==
+        0) {
+      return AddressConversionCode::INVALID_BECH32_ADDR;
+    }
+
+    retAddr = Address{tmpaddr};
+    return AddressConversionCode::OK;
+  }
+
+  return ToAddressStructure(addr, retAddr);
+}

--- a/src/libUtils/AddressConversion.h
+++ b/src/libUtils/AddressConversion.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ZILLIQA_SRC_LIBUTILS_ADDRESSCONVERSION_H_
+#define ZILLIQA_SRC_LIBUTILS_ADDRESSCONVERSION_H_
+
+#include "libData/AccountData/Address.h"
+
+enum class AddressConversionCode {
+  OK = 0,
+  INVALID_ADDR,
+  INVALID_BECH32_ADDR,
+  WRONG_ADDR_SIZE,
+};
+
+const unsigned int HEX_ADDR_SIZE = ACC_ADDR_SIZE * 2;
+
+inline bool HasZilHrp(const std::string& input);
+AddressConversionCode ToAddressStructure(const std::string& addr,
+                                         Address& retAddr);
+AddressConversionCode ToBase16Addr(const std::string& addr, Address& retAddr);
+
+#endif  // ZILLIQA_SRC_LIBUTILS_ADDRESSCONVERSION_H_

--- a/src/libUtils/CMakeLists.txt
+++ b/src/libUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Utils BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp)
+add_library(Utils AddressConversion.cpp BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp)
 target_include_directories(Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Boost)
 target_link_libraries(Utils INTERFACE Threads::Threads curl)
-target_link_libraries(Utils PUBLIC g3logger Constants MessageSWInfo)
+target_link_libraries(Utils PUBLIC g3logger CryptoUtils Constants MessageSWInfo )

--- a/tests/Utils/CMakeLists.txt
+++ b/tests/Utils/CMakeLists.txt
@@ -8,6 +8,12 @@ endif(CMAKE_CONFIGURATION_TYPES)
 
 link_directories(${CMAKE_BINARY_DIR}/lib)
 
+
+add_executable (Test_AddressConversion Test_AddressConversion.cpp)
+target_include_directories (Test_AddressConversion PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries (Test_AddressConversion PUBLIC Utils)
+add_test(NAME Test_AddressConversion COMMAND Test_AddressConversion)
+
 add_executable (Test_TimeLockedFunction Test_TimeLockedFunction.cpp)
 target_include_directories (Test_TimeLockedFunction PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_TimeLockedFunction PUBLIC Utils)

--- a/tests/Utils/Test_AddressConversion.cpp
+++ b/tests/Utils/Test_AddressConversion.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2021 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+#include "libUtils/AddressConversion.h"
+#include "libUtils/DataConversion.h"
+
+#define BOOST_TEST_MODULE address_conversion
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(address_conversion)
+
+using namespace std;
+
+BOOST_AUTO_TEST_CASE(testAddrBech32Decode) {
+  INIT_STDOUT_LOGGER();
+
+  using strPairs = std::pair<std::string, std::string>;
+
+  std::vector<strPairs> testPairs;
+  testPairs.push_back(
+      std::make_pair("zil1fwh4ltdguhde9s7nysnp33d5wye6uqpugufkz7",
+                     "4baf5fada8e5db92c3d3242618c5b47133ae003c"));
+
+  testPairs.push_back(
+      std::make_pair("zil1gjpxry26srx7n008c7nez6zjqrf6p06wur4x3m",
+                     "448261915A80CDE9BDE7C7A791685200D3A0BF4E"));
+
+  testPairs.push_back(
+      std::make_pair("zil1mmgzlktelsh9tspy80f02t0sytzq4ks79zdnkk",
+                     "DED02FD979FC2E55C0243BD2F52DF022C40ADA1E"));
+
+  testPairs.push_back(
+      std::make_pair("zil1z0cxucpf004x50zq9ahkf3qk56e3ukrwaty4g8",
+                     "13F06E60297BEA6A3C402F6F64C416A6B31E586E"));
+
+  testPairs.push_back(
+      std::make_pair("zil1r2gvy5c8c0x8r9v2s0azzw3rvtv9nnenynd33g",
+                     "1A90C25307C3CC71958A83FA213A2362D859CF33"));
+
+  testPairs.push_back(
+      std::make_pair("zil1vfdt467c0khf4vfg7we6axtg3qfan3wlf9yc6y",
+                     "625ABAEBD87DAE9AB128F3B3AE99688813D9C5DF"));
+  testPairs.push_back(
+      std::make_pair("zil1x6argztlscger3yvswwfkx5ttyf0tq703v7fre",
+                     "36BA34097F861191C48C839C9B1A8B5912F583CF"));
+  testPairs.push_back(
+      std::make_pair("zil16fzn4emvn2r24e2yljnfnk7ut3tk4me6qx08ed",
+                     "D2453AE76C9A86AAE544FCA699DBDC5C576AEF3A"));
+  testPairs.push_back(
+      std::make_pair("zil1wg3qapy50smprrxmckqy2n065wu33nvh35dn0v",
+                     "72220E84947C36118CDBC580454DFAA3B918CD97"));
+  testPairs.push_back(
+      std::make_pair("zil12rujxpxgjtv55wzu5m8xe454pn56x6pedpl554",
+                     "50F92304C892D94A385CA6CE6CD6950CE9A36839"));
+  testPairs.push_back(
+      std::make_pair("zil1r5verznnwvrzrz6uhveyrlxuhkvccwnju4aehf",
+                     "1d19918a737306218b5cbb3241fcdcbd998c3a72"));
+  testPairs.push_back(
+      std::make_pair("zil1ej8wy3mnux6t9zeuc4vkhww0csctfpznzt4s76",
+                     "cc8ee24773e1b4b28b3cc5596bb9cfc430b48453"));
+  testPairs.push_back(
+      std::make_pair("zil1u9zhd9zyg056ajn0z269f9qcsj4py2fc89ru3d",
+                     "e14576944443e9aeca6f12b454941884aa122938"));
+  testPairs.push_back(
+      std::make_pair("zil1z7fkzy2vhl2nhexng50dlq2gehjvlem5w7kx8z",
+                     "179361114cbfd53be4d3451edf8148cde4cfe774"));
+  testPairs.push_back(
+      std::make_pair("zil1tg4kvl77kc6kt9mgr5y0dntxx6hdj3uy95ash8",
+                     "5a2b667fdeb6356597681d08f6cd6636aed94784"));
+  testPairs.push_back(
+      std::make_pair("zil12de59e0q566q9u5pu26rqxufzgawxyghq0vdk9",
+                     "537342e5e0a6b402f281e2b4301b89123ae31117"));
+  testPairs.push_back(
+      std::make_pair("zil1tesag25495klra89e0kh7lgjjn5hgjjj0qmu8l",
+                     "5e61d42a952d2df1f4e5cbed7f7d1294e9744a52"));
+  testPairs.push_back(
+      std::make_pair("zil1tawmrsvvehn8u5fm0aawsg89dy25ja46ndsrhq",
+                     "5f5db1c18ccde67e513b7f7ae820e569154976ba"));
+
+  for (auto& pair : testPairs) {
+    Address retAddr;
+    auto retCode = ToBase16Addr(pair.first, retAddr);
+    BOOST_CHECK_MESSAGE(retCode == AddressConversionCode::OK,
+                        "Bech32 unable to decode");
+
+    bytes tmpAddr;
+    DataConversion::HexStrToUint8Vec(pair.second, tmpAddr);
+
+    Address correctAddr{tmpAddr};
+    BOOST_CHECK_MESSAGE(retAddr == correctAddr, "Bech32 decode incorrectly");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testAddrDecodeNegativeCase1) {
+  INIT_STDOUT_LOGGER();
+
+  std::vector<string> testStrings{
+      "zil", "z", "asdc", "1234567890abcdef1234567890abcdef1234567890abcdef"};
+
+  for (const auto& input : testStrings) {
+    Address retAddr;
+    auto retCode = ToBase16Addr(input, retAddr);
+    BOOST_CHECK_MESSAGE(retCode == AddressConversionCode::WRONG_ADDR_SIZE,
+                        "Address decode did not detect invalid size");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testAddrDecodeNegativeCase2) {
+  INIT_STDOUT_LOGGER();
+
+  std::vector<string> testStrings{
+      "zil1", "zil1abc", "zil1T413131515AWMRSVVEHN8U5FM0AAWSG89DY25JA46NDSRHQ"};
+
+  for (const auto& input : testStrings) {
+    Address retAddr;
+    auto retCode = ToBase16Addr(input, retAddr);
+    BOOST_CHECK_MESSAGE(retCode == AddressConversionCode::INVALID_BECH32_ADDR,
+                        "Bech32 decode did not detect invalid address");
+  }
+}
+
+BOOST_AUTO_TEST_CASE(testAddrDecodeNegativeCase3) {
+  INIT_STDOUT_LOGGER();
+
+  std::vector<string> testStrings{"xxx8055ea3bc78d759d10663da40d171dec992aa"};
+
+  for (const auto& input : testStrings) {
+    Address retAddr;
+    auto retCode = ToBase16Addr(input, retAddr);
+    BOOST_CHECK_MESSAGE(retCode == AddressConversionCode::INVALID_ADDR,
+                        "Address decode did not detect invalid address");
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
To add Bech32 utilities and allow the following API to accept both base16 and bech32 for now.

GetBalance
GetSmartContractCode
GetSmartContractInit
GetSmartContracts
GetSmartContractState
GetSmartContractSubState

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
Was tested with a local isolated server, testing with the bech32 and base16 address

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
