### PR TITLE
[master] Updates to external state fetch in ContractStorage2 

### DIFF
--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -66,6 +66,9 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   /// the current sender address for each hop of invoking
   Address m_curSenderAddr;
 
+  /// the address of transaction sender
+  Address m_originAddr;
+
   /// the transfer amount while executing each txn
   uint128_t m_curAmount{0};
 

--- a/src/libPersistence/ContractStorage2.h
+++ b/src/libPersistence/ContractStorage2.h
@@ -33,7 +33,7 @@
 
 #include "depends/libTrie/TrieDB.h"
 
-class ProtoScillaVal;
+class ProtoScillaQuery;
 
 namespace Contract {
 
@@ -133,6 +133,11 @@ class ContractStorage2 : public Singleton<ContractStorage2> {
   bool FetchStateValue(const dev::h160& addr, const bytes& src,
                        unsigned int s_offset, bytes& dst, unsigned int d_offset,
                        bool& foundVal, bool getType = false,
+                       std::string& type = type_placeholder);
+
+  bool FetchStateValue(const dev::h160& addr, const ProtoScillaQuery& query,
+                       bytes& dst, unsigned int d_offset, bool& foundVal,
+                       bool getType = false,
                        std::string& type = type_placeholder);
 
   bool FetchExternalStateValue(

--- a/tests/Data/CMakeLists.txt
+++ b/tests/Data/CMakeLists.txt
@@ -29,7 +29,7 @@ add_test(NAME Test_TxnOrder COMMAND Test_TxnOrder)
 
 add_executable(Test_Contract Test_Contract.cpp ScillaTestUtil.cpp)
 target_include_directories(Test_Contract PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(Test_Contract PUBLIC AccountData Trie Utils Persistence)
+target_link_libraries(Test_Contract PUBLIC AccountData Trie Utils Persistence Message)
 add_test(NAME Test_Contract COMMAND Test_Contract)
 
 add_executable(Test_EIP Test_EIP.cpp)
@@ -39,7 +39,7 @@ add_test(NAME Test_EIP COMMAND Test_EIP)
 
 add_executable(Test_DSPowSolution Test_DSPowSolution.cpp)
 target_include_directories(Test_DSPowSolution PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
-target_link_libraries(Test_DSPowSolution PUBLIC TestUtils MiningData)
+target_link_libraries(Test_DSPowSolution PUBLIC TestUtils AccountData MiningData)
 add_test(NAME Test_DSPowSolution COMMAND Test_DSPowSolution)
 
 #add_executable(Test_ContractInvoke Test_ContractInvoke.cpp)

--- a/tests/Data/ScillaTestUtil.cpp
+++ b/tests/Data/ScillaTestUtil.cpp
@@ -120,7 +120,7 @@ uint64_t ScillaTestUtil::GetBlockNumberFromJson(Json::Value &blockchain) {
   return bnum;
 }
 
-// Return the _amount in message.json. Remove that and _sender.
+// Return the _amount in message.json. Remove _amount, _sender and _origin.
 uint64_t ScillaTestUtil::PrepareMessageData(Json::Value &message, bytes &data) {
   LOG_GENERAL(INFO, JSONUtils::GetInstance().convertJsontoStr(message));
   uint64_t amount;
@@ -129,9 +129,10 @@ uint64_t ScillaTestUtil::PrepareMessageData(Json::Value &message, bytes &data) {
   } catch (...) {
     amount = boost::lexical_cast<uint64_t>(message["_amount"].asString());
   }
-  // Remove _amount and _sender as they will be automatically inserted.
+  // Remove _amount, _sender and _origin as they will be automatically inserted.
   message.removeMember("_amount");
   message.removeMember("_sender");
+  message.removeMember("_origin");
 
   std::string msgStr = JSONUtils::GetInstance().convertJsontoStr(message);
   data = bytes(msgStr.begin(), msgStr.end());

--- a/tests/Directory/CMakeLists.txt
+++ b/tests/Directory/CMakeLists.txt
@@ -10,7 +10,7 @@ link_directories(${CMAKE_BINARY_DIR}/lib)
 
 add_executable(Test_UpdateDSComposition Test_UpdateDSComposition.cpp)
 target_include_directories(Test_UpdateDSComposition PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(Test_UpdateDSComposition LINK_PUBLIC Network Block DirectoryService TestUtils)
+target_link_libraries(Test_UpdateDSComposition LINK_PUBLIC Network Block AccountData DirectoryService TestUtils Server Message)
 add_test(NAME Test_UpdateDSComposition COMMAND Test_UpdateDSComposition)
 
 add_executable(Test_DetermineByzantineNodes Test_DetermineByzantineNodes.cpp)

--- a/tests/POW/CMakeLists.txt
+++ b/tests/POW/CMakeLists.txt
@@ -14,5 +14,5 @@ add_test(NAME Test_POW COMMAND Test_POW)
 
 link_directories(${CMAKE_BINARY_DIR}/lib)
 add_executable (Test_RemoteMine test_RemoteMine.cpp)
-target_link_libraries(Test_RemoteMine PUBLIC CryptoUtils POW DirectoryService Lookup Node Server Utils TestUtils Boost::unit_test_framework Boost::filesystem)
+target_link_libraries(Test_RemoteMine PUBLIC CryptoUtils POW DirectoryService Lookup Node AccountData Server Utils TestUtils Boost::unit_test_framework Boost::filesystem)
 target_include_directories (Test_RemoteMine PUBLIC ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/tests)

--- a/tests/Server/CMakeLists.txt
+++ b/tests/Server/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 
 add_executable(Test_ScillaIPCServer Test_ScillaIPCServer.cpp)
 target_include_directories(Test_ScillaIPCServer PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(Test_ScillaIPCServer PUBLIC Server jsonrpc::client)
+target_link_libraries(Test_ScillaIPCServer PUBLIC AccountData BlockChainData Server Message jsonrpc::client)
 add_test(NAME Test_ScillaIPCServer COMMAND Test_ScillaIPCServer)
 
 # To be tested with a live network


### PR DESCRIPTION
## Description
1. `query.mapdepth` may be set to -1 by Scilla (in case of external states, Scilla cannot know this value). The blockchain needs to fetch the value from its database and use it for the lookup.
2. `query.ignoreval` may be set for nonmap fields too. In such a case, the blockchain only needs to return the type of the field and not the value.
3. Field not found should no more be an error. `foundVal` needs to be set to `false` and that's it. This will enable Scilla to check for presence of a field in a contract without it becoming an error.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
