### PR TITLE
[master] Lookup to dispatch txn packet to shard leader as well

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -305,12 +305,10 @@ void DirectoryService::InjectPoWForDSNode(
       LOG_GENERAL(INFO, "Injecting into PoW connections " << rit->second);
     }
 
-    if (m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum() >=
-        UPGRADE_TARGET_DS_NUM) {
-      // Remove this node from blacklist if it exists
-      Peer& p = rit->second;
-      Blacklist::GetInstance().Remove(p.GetIpAddress());
-    }
+    // Remove this node from blacklist if it exists
+    Peer& p = rit->second;
+    Blacklist::GetInstance().Remove(p.GetIpAddress());
+
     ++counter;
   }
 

--- a/src/libDirectoryService/DSComposition.cpp
+++ b/src/libDirectoryService/DSComposition.cpp
@@ -135,11 +135,9 @@ void UpdateDSCommitteeCompositionCore(const PubKey& selfKeyPub,
       minerInfo.m_dsNodesEjected.emplace_back(dsComm.back().first);
     }
 
-    if (dsblock.GetHeader().GetBlockNum() >= UPGRADE_TARGET_DS_NUM) {
-      // Remove this node from blacklist if it exists
-      Peer& p = dsComm.back().second;
-      Blacklist::GetInstance().Remove(p.GetIpAddress());
-    }
+    // Remove this node from blacklist if it exists
+    Peer& p = dsComm.back().second;
+    Blacklist::GetInstance().Remove(p.GetIpAddress());
     dsComm.pop_back();
   }
 

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1442,11 +1442,11 @@ uint32_t Node::CalculateShardLeaderFromDequeOfNode(
 
 uint32_t Node::CalculateShardLeaderFromShard(uint16_t lastBlockHash,
                                              uint32_t sizeOfShard,
-                                             const Shard& shardMembers) {
+                                             const Shard& shardMembers,
+                                             PairOfNode& shardLeader) {
   LOG_MARKER();
+  uint32_t consensusLeaderIndex = lastBlockHash % sizeOfShard;
   if (GUARD_MODE) {
-    uint32_t consensusLeaderIndex = lastBlockHash % sizeOfShard;
-
     unsigned int iterationCount = 0;
     while (!Guard::GetInstance().IsNodeInShardGuardList(
                std::get<SHARD_NODE_PUBKEY>(
@@ -1462,9 +1462,15 @@ uint32_t Node::CalculateShardLeaderFromShard(uint16_t lastBlockHash,
       consensusLeaderIndex = lastBlockHash % sizeOfShard;
       iterationCount++;
     }
+    shardLeader = make_pair(
+        std::get<SHARD_NODE_PUBKEY>(shardMembers.at(consensusLeaderIndex)),
+        std::get<SHARD_NODE_PEER>(shardMembers.at(consensusLeaderIndex)));
     return consensusLeaderIndex;
   } else {
-    return lastBlockHash % sizeOfShard;
+    shardLeader = make_pair(
+        std::get<SHARD_NODE_PUBKEY>(shardMembers.at(consensusLeaderIndex)),
+        std::get<SHARD_NODE_PEER>(shardMembers.at(consensusLeaderIndex)));
+    return consensusLeaderIndex;
   }
 }
 

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -744,7 +744,8 @@ class Node : public Executable {
                                                const DequeOfNode& shardMembers);
   uint32_t CalculateShardLeaderFromShard(uint16_t lastBlockHash,
                                          uint32_t sizeOfShard,
-                                         const Shard& shardMembers);
+                                         const Shard& shardMembers,
+                                         PairOfNode& shardLeader);
 
   static bool GetDSLeader(const BlockLink& lastBlockLink,
                           const DSBlock& latestDSBlock,


### PR DESCRIPTION
## Description
This PR basically does folllowing:
- Include `shardleader` in `NUM_NODES_TO_SEND_LOOKUP`  while dispatching txnpkt.
  Previously, leader is excluded.
- Shard leader is first in the queue to be sent.
- Redundant usage of constant `UPGRADE_TARGET_DS_NUM` is removed.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
