### PR TITLE
[master] Exclude shard guards from PoW reputation

### DIFF
--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -123,11 +123,15 @@ const std::string DS_BACKUP_MSG = "DS BACKUP NOW";
 
 const std::string dsNodeFile = "dsnodes.xml";
 
-const char SCILLA_INDEX_SEPARATOR = 0x16;
+constexpr char SCILLA_INDEX_SEPARATOR = 0x16;
 
-const float ONE_HUNDRED_PERCENT = 100.f;
+constexpr float ONE_HUNDRED_PERCENT = 100.f;
 
-const unsigned int GENESIS_DSBLOCK_VERSION = 1;
+constexpr unsigned int GENESIS_DSBLOCK_VERSION = 1;
+
+constexpr uint16_t MAX_REPUTATION =
+    4096;  // This means the max priority is 12. A node need to continually
+           // run for 5 days to achieve this reputation.
 
 // General constants
 extern const unsigned int DEBUG_LEVEL;

--- a/src/libDirectoryService/Coinbase.cpp
+++ b/src/libDirectoryService/Coinbase.cpp
@@ -63,9 +63,6 @@ bool DirectoryService::SaveCoinbaseCore(const vector<bool>& b1,
   }
 
   unsigned int i = 0;
-  constexpr uint16_t MAX_REPUTATION =
-      4096;  // This means the max priority is 12. A node need to continually
-             // run for 5 days to achieve this reputation.
 
   for (const auto& kv : shard) {
     const auto& pubKey = std::get<SHARD_NODE_PUBKEY>(kv);

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -842,8 +842,10 @@ VectorOfPoWSoln DirectoryService::SortPoWSoln(
       for (auto kv = ShadowPoWOrderSorter.begin();
            (kv != ShadowPoWOrderSorter.end()) && (count < numNodesAfterTrim);
            kv++) {
-        FilteredPoWOrderSorter.emplace(*kv);
-        count++;
+        if (!Guard::GetInstance().IsNodeInShardGuardList(kv->second)) {
+          FilteredPoWOrderSorter.emplace(*kv);
+          count++;
+        }
       }
 
       // Sort "FilteredPoWOrderSorter" and stored it in "sortedPoWSolns"


### PR DESCRIPTION
## Description
To prevent shard guards from being affected by the reputation, priority is being set to the highest for SHARD_GUARD_TOL percent of nodes.

This will be further trimmed in the SortPoWSoln to fit the shard structure.

There will only be a maximum of SHARD_GUARD_TOL percent of shard guards in the shards.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
