### PR TITLE
[master] Fix timing issue with GetVCFinalBlock

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -849,11 +849,11 @@ bool Lookup::GetDSBlockFromL2lDataProvider(uint64_t blockNum) {
                   "GetDSBlockFromL2lDataProvider Timeout... may be ds block "
                   "yet to be mined");
     } else {
-      m_mediator.m_lookup->m_vcDsBlockProcessed = false;
-      return true;
+      break;
     }
   }
-  return false;
+  m_mediator.m_lookup->m_vcDsBlockProcessed = false;
+  return true;
 }
 
 bool Lookup::GetVCFinalBlockFromL2lDataProvider(uint64_t blockNum) {
@@ -875,12 +875,11 @@ bool Lookup::GetVCFinalBlockFromL2lDataProvider(uint64_t blockNum) {
                   "GetVCFinalBlockFromL2lDataProvider Timeout... may be "
                   "vc/final block yet to be mined");
     } else {
-      m_mediator.m_lookup->m_vcFinalBlockProcessed = false;
-      return true;
+      break;
     }
   }
-
-  return false;
+  m_mediator.m_lookup->m_vcFinalBlockProcessed = false;
+  return true;
 }
 
 bool Lookup::GetMBnForwardTxnFromL2lDataProvider(uint64_t blockNum,


### PR DESCRIPTION
## Description

This fixes the timing issue with syncing of `extseed` which uses pubkey whitelisting.

 - Basically flag `m_vcFinalBlockProcessed` can remains unset in some corner case with timing issue in `GetVCFinalBlockFromL2lDataProvider`. 
- Same also applies for `GetDSBlockFromL2lDataProvider` 

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
