### PR TITLE
[master] Allow shard guards to fill slots when not enough nodes

### DIFF
--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -848,6 +848,24 @@ VectorOfPoWSoln DirectoryService::SortPoWSoln(
         }
       }
 
+      if (FilteredPoWOrderSorter.size() < EXPECTED_SHARD_NODE_NUM) {
+        // If there is not enough shard nodes, need to fill up with shard guards
+        auto leftOverCount =
+            EXPECTED_SHARD_NODE_NUM - FilteredPoWOrderSorter.size();
+        LOG_GENERAL(INFO, "Gap to fill = " << leftOverCount);
+
+        for (auto kv = ShadowPoWOrderSorter.begin();
+             (kv != ShadowPoWOrderSorter.end()) && (count < numNodesAfterTrim);
+             kv++) {
+          if (Guard::GetInstance().IsNodeInShardGuardList(kv->second)) {
+            FilteredPoWOrderSorter.emplace(*kv);
+            --leftOverCount;
+          }
+          count++;
+          if (leftOverCount == 0) break;
+        }
+      }
+
       // Sort "FilteredPoWOrderSorter" and stored it in "sortedPoWSolns"
       for (auto kv : FilteredPoWOrderSorter) {
         sortedPoWSolns.emplace_back(kv);


### PR DESCRIPTION
## Description
A fix for removing the restrictions on maximum shard guards when the total nodes are lesser than the EXPECTED_SHARD_NODE_NUM, else there can be only SHARD_GUARD_TOL amount of total nodes that can be shard guards.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
