### PR TITLE
[master] Adding DNS query function for seed nodes

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -95,7 +95,7 @@
         <TX_DISTRIBUTE_TIME_IN_MS>30000</TX_DISTRIBUTE_TIME_IN_MS>
         <EXTRA_TX_DISTRIBUTE_TIME_IN_MS>15000</EXTRA_TX_DISTRIBUTE_TIME_IN_MS>
         <DS_TX_PROCESSING_TIMEOUT>55</DS_TX_PROCESSING_TIMEOUT>
-        <NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>300</NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>
+        <NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>10</NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>
         <GETSHARD_TIMEOUT_IN_SECONDS>3</GETSHARD_TIMEOUT_IN_SECONDS>
         <GETSTATEDELTAS_TIMEOUT_IN_SECONDS>5</GETSTATEDELTAS_TIMEOUT_IN_SECONDS>
         <GETCOSIGREWARDS_TIMEOUT_IN_SECONDS>5</GETCOSIGREWARDS_TIMEOUT_IN_SECONDS>
@@ -398,6 +398,14 @@
             <wallet_address>ee06b3c906612cc5bdb087a30e6093c9f0aa04fd</wallet_address>
         </account>
     </ds_accounts>
+    <node_discovery>
+        <QUERY_DNS_FOR_SEED>true</QUERY_DNS_FOR_SEED>
+        <QUERY_DNS_MAX_TRIES>5</QUERY_DNS_MAX_TRIES>
+        <l2l_data_providers_dns/>
+        <upper_seed_dns/>
+        <multiplier_dns/>
+        <default_seed_port>33133</default_seed_port>
+    </node_discovery>
     <!-- The remaining constants below are auto-populated -->
     <lookups>
         <!--IP to be provided after public testnet launch.

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -94,7 +94,7 @@
         <TX_DISTRIBUTE_TIME_IN_MS>15000</TX_DISTRIBUTE_TIME_IN_MS>
         <EXTRA_TX_DISTRIBUTE_TIME_IN_MS>15000</EXTRA_TX_DISTRIBUTE_TIME_IN_MS>
         <DS_TX_PROCESSING_TIMEOUT>55</DS_TX_PROCESSING_TIMEOUT>
-        <NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>300</NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>
+        <NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>10</NEW_LOOKUP_SYNC_DELAY_IN_SECONDS>
         <GETSHARD_TIMEOUT_IN_SECONDS>5</GETSHARD_TIMEOUT_IN_SECONDS>
         <GETSTATEDELTAS_TIMEOUT_IN_SECONDS>5</GETSTATEDELTAS_TIMEOUT_IN_SECONDS>
         <GETCOSIGREWARDS_TIMEOUT_IN_SECONDS>5</GETCOSIGREWARDS_TIMEOUT_IN_SECONDS>
@@ -397,6 +397,14 @@
             <wallet_address>ee06b3c906612cc5bdb087a30e6093c9f0aa04fd</wallet_address>
         </account>
     </ds_accounts>
+    <node_discovery>
+        <QUERY_DNS_FOR_SEED>true</QUERY_DNS_FOR_SEED>
+        <QUERY_DNS_MAX_TRIES>5</QUERY_DNS_MAX_TRIES>
+        <l2l_data_providers_dns/>
+        <upper_seed_dns/>
+        <multiplier_dns/>
+        <default_seed_port>33133</default_seed_port>
+    </node_discovery>
     <!-- For constants.xml, the remaining constants below are auto-populated -->
     <lookups>
         <peer>

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -739,3 +739,22 @@ const bool IGNORE_BLOCKCOSIG_CHECK{
     ReadConstantString("IGNORE_BLOCKCOSIG_CHECK", "node.verifier.") == "true"};
 const vector<pair<uint64_t, uint32_t>> VERIFIER_MICROBLOCK_EXCLUSION_LIST{
     ReadVerifierMicroblockExclusionListFromConstantsFile()};
+
+// DNS
+const bool QUERY_DNS_FOR_SEED{
+    ReadConstantString("QUERY_DNS_FOR_SEED", "node.node_discovery.") == "true"};
+
+const unsigned int QUERY_DNS_MAX_TRIES{
+    ReadConstantNumeric("QUERY_DNS_MAX_TRIES", "node.node_discovery.")};
+
+const string L2L_DATA_PROVIDERS_DNS{
+    ReadConstantString("l2l_data_providers_dns", "node.node_discovery.")};
+
+const string UPPER_SEED_DNS{
+    ReadConstantString("upper_seed_dns", "node.node_discovery.")};
+
+const string MULTIPLIER_DNS{
+    ReadConstantString("multiplier_dns", "node.node_discovery.")};
+
+const unsigned int DEFAULT_SEED_PORT{
+    ReadConstantNumeric("default_seed_port", "node.node_discovery.")};

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -494,4 +494,14 @@ extern const std::vector<std::pair<uint64_t, uint32_t>> VERIFIER_EXCLUSION_LIST;
 extern const bool IGNORE_BLOCKCOSIG_CHECK;
 extern const std::vector<std::pair<uint64_t, uint32_t>>
     VERIFIER_MICROBLOCK_EXCLUSION_LIST;
+
+// DNS
+extern const bool QUERY_DNS_FOR_SEED;
+extern const unsigned int QUERY_DNS_MAX_TRIES;
+extern const std::string L2L_DATA_PROVIDERS_DNS;
+extern const std::string UPPER_SEED_DNS;
+extern const std::string MULTIPLIER_DNS;
+
+extern const unsigned int DEFAULT_SEED_PORT;
+
 #endif  // ZILLIQA_SRC_COMMON_CONSTANTS_H_

--- a/src/libConsensus/ConsensusBackup.h
+++ b/src/libConsensus/ConsensusBackup.h
@@ -114,8 +114,8 @@ class ConsensusBackup : public ConsensusCommon {
                     // any post activity after validation of preprep
                     // message
       CollectiveSigReadinessFunc collsig_readiness_func =
-          nullptr  // function handler for waits until some cond is met
-  );
+          nullptr,  // function handler for waits until some cond is met
+      bool isDS = false);
 
   /// Destructor.
   ~ConsensusBackup();

--- a/src/libConsensus/ConsensusCommon.cpp
+++ b/src/libConsensus/ConsensusCommon.cpp
@@ -70,7 +70,7 @@ ConsensusCommon::ConsensusCommon(uint32_t consensus_id, uint64_t block_number,
                                  const PrivKey& privkey,
                                  const DequeOfNode& committee,
                                  unsigned char class_byte,
-                                 unsigned char ins_byte)
+                                 unsigned char ins_byte, bool isDS)
     : m_consensusErrorCode(NO_ERROR),
       m_consensusID(consensus_id),
       m_blockNumber(block_number),
@@ -80,7 +80,11 @@ ConsensusCommon::ConsensusCommon(uint32_t consensus_id, uint64_t block_number,
       m_committee(committee),
       m_classByte(class_byte),
       m_insByte(ins_byte),
-      m_responseMap(committee.size(), false) {}
+      m_responseMap(committee.size(), false),
+      m_DS(isDS) {
+  m_numOfSubsets =
+      m_DS ? DS_NUM_CONSENSUS_SUBSETS : SHARD_NUM_CONSENSUS_SUBSETS;
+}
 
 ConsensusCommon::~ConsensusCommon() {}
 

--- a/src/libConsensus/ConsensusCommon.h
+++ b/src/libConsensus/ConsensusCommon.h
@@ -29,6 +29,11 @@
 #include "libNetwork/ShardStruct.h"
 #include "libUtils/TimeLockedFunction.h"
 
+struct CommitInfo {
+  CommitPoint commit;
+  CommitPointHash hash;
+};
+
 struct ChallengeSubsetInfo {
   CommitPoint aggregatedCommit;
   PubKey aggregatedKey;
@@ -158,17 +163,20 @@ class ConsensusCommon {
   /// Co-sig bitmap for second round
   std::vector<bool> m_B2;
 
-  /// Generated commit secret
-  std::shared_ptr<CommitSecret> m_commitSecret;
+  /// Generated commit info - commitpoint + commitpointhash
+  std::vector<CommitInfo> m_commitInfo;
 
-  /// Generated commit point
-  std::shared_ptr<CommitPoint> m_commitPoint;
+  // Generated local commit secrets
+  std::vector<CommitSecret> m_commitSecrets;
+
+  bool m_DS;
+  unsigned int m_numOfSubsets;
 
   /// Constructor.
   ConsensusCommon(uint32_t consensus_id, uint64_t block_number,
                   const bytes& block_hash, uint16_t my_id,
                   const PrivKey& privkey, const DequeOfNode& committee,
-                  unsigned char class_byte, unsigned char ins_byte);
+                  unsigned char class_byte, unsigned char ins_byte, bool isDS);
 
   /// Destructor.
   virtual ~ConsensusCommon();

--- a/src/libConsensus/ConsensusLeader.cpp
+++ b/src/libConsensus/ConsensusLeader.cpp
@@ -138,8 +138,8 @@ void ConsensusLeader::GenerateConsensusSubsets() {
 
     subset.state = m_state;
     // add myself to subset commit map always
-    subset.commitPointMap.at(m_myID) = m_commitPointMap.at(m_myID);
-    subset.commitPoints.emplace_back(m_commitPointMap.at(m_myID));
+    subset.commitPointMap.at(m_myID) = m_commitPointMap.at(m_myID).at(i);
+    subset.commitPoints.emplace_back(m_commitPointMap.at(m_myID).at(i));
     subset.commitMap.at(m_myID) = true;
 
     // If DS consensus, then first subset should be of dsguard commits only.
@@ -149,8 +149,8 @@ void ConsensusLeader::GenerateConsensusSubsets() {
       vector<unsigned int> nondsguardIndexes;
       for (auto index : peersWhoCommitted) {
         if (index < Guard::GetInstance().GetNumOfDSGuard()) {
-          subset.commitPointMap.at(index) = m_commitPointMap.at(index);
-          subset.commitPoints.emplace_back(m_commitPointMap.at(index));
+          subset.commitPointMap.at(index) = m_commitPointMap.at(index).at(i);
+          subset.commitPoints.emplace_back(m_commitPointMap.at(index).at(i));
           subset.commitMap.at(index) = true;
           subsetPeers++;
           if (subsetPeers == m_numForConsensus) {
@@ -173,8 +173,8 @@ void ConsensusLeader::GenerateConsensusSubsets() {
                                            << m_numForConsensus - subsetPeers);
 
         for (auto index : nondsguardIndexes) {
-          subset.commitPointMap.at(index) = m_commitPointMap.at(index);
-          subset.commitPoints.emplace_back(m_commitPointMap.at(index));
+          subset.commitPointMap.at(index) = m_commitPointMap.at(index).at(i);
+          subset.commitPoints.emplace_back(m_commitPointMap.at(index).at(i));
           subset.commitMap.at(index) = true;
           if (++subsetPeers >= m_numForConsensus) {
             break;
@@ -187,8 +187,8 @@ void ConsensusLeader::GenerateConsensusSubsets() {
       unsigned int guardCount = 1;  // myself
       for (unsigned int j = 0; j < m_numForConsensus - 1; j++) {
         unsigned int index = peersWhoCommitted.at(j);
-        subset.commitPointMap.at(index) = m_commitPointMap.at(index);
-        subset.commitPoints.emplace_back(m_commitPointMap.at(index));
+        subset.commitPointMap.at(index) = m_commitPointMap.at(index).at(i);
+        subset.commitPoints.emplace_back(m_commitPointMap.at(index).at(i));
         subset.commitMap.at(index) = true;
         if (GUARD_MODE && m_DS &&
             index < Guard::GetInstance().GetNumOfDSGuard()) {
@@ -252,7 +252,7 @@ bool ConsensusLeader::StartConsensusSubsets() {
     SetStateSubset(index, m_state);
 
     // Add the leader to the responses
-    Response r(*m_commitSecret, subset.challenge, m_myPrivKey);
+    Response r(m_commitSecrets.at(index), subset.challenge, m_myPrivKey);
     subset.responseData.emplace_back(r);
     subset.responseDataMap.at(m_myID) = r;
     subset.responseMap.at(m_myID) = true;
@@ -353,12 +353,11 @@ bool ConsensusLeader::ProcessMessageCommitCore(
 
   uint16_t backupID = 0;
 
-  CommitPoint commitPoint;
-  CommitPointHash commitPointHash;
+  vector<CommitInfo> commitInfo;
 
-  if (!Messenger::GetConsensusCommit(
-          commit, offset, m_consensusID, m_blockNumber, m_blockHash, backupID,
-          commitPoint, commitPointHash, m_committee)) {
+  if (!Messenger::GetConsensusCommit(commit, offset, m_consensusID,
+                                     m_blockNumber, m_blockHash, backupID,
+                                     commitInfo, m_committee)) {
     LOG_GENERAL(WARNING, "Messenger::GetConsensusCommit failed");
     return false;
   }
@@ -371,29 +370,40 @@ bool ConsensusLeader::ProcessMessageCommitCore(
     return false;
   }
 
+  if (commitInfo.size() != m_numOfSubsets) {
+    LOG_GENERAL(WARNING, "Backup ID: " << backupID);
+    LOG_CHECK_FAIL("Num of Commits sent by backup: ", commitInfo.size(),
+                   m_numOfSubsets);
+    return false;
+  }
+
   if (m_commitMap.at(backupID)) {
     LOG_GENERAL(WARNING, "Backup already sent commit");
     return false;
   }
 
-  // Check the commit
-  if (!commitPoint.Initialized()) {
-    LOG_GENERAL(WARNING, "Invalid commit");
-    return false;
-  }
+  vector<CommitPoint> commitPoints;
+  for (auto& ci : commitInfo) {
+    // Check the commit
+    if (!ci.commit.Initialized()) {
+      LOG_GENERAL(WARNING, "Invalid commit");
+      return false;
+    }
 
-  // Check the deserialized commit hash
-  if (!commitPointHash.Initialized()) {
-    LOG_GENERAL(WARNING, "Invalid commit hash");
-    return false;
-  }
+    // Check the deserialized commit hash
+    if (!ci.hash.Initialized()) {
+      LOG_GENERAL(WARNING, "Invalid commit hash");
+      return false;
+    }
 
-  // Check the value of the commit hash
-  CommitPointHash commitPointHashExpected(commitPoint);
-  if (!(commitPointHashExpected == commitPointHash)) {
-    LOG_CHECK_FAIL("Commit hash", string(commitPointHash),
-                   string(commitPointHashExpected));
-    return false;
+    // Check the value of the commit hash
+    CommitPointHash commitPointHashExpected(ci.commit);
+    if (!(commitPointHashExpected == ci.hash)) {
+      LOG_CHECK_FAIL("Commit hash", string(ci.hash),
+                     string(commitPointHashExpected));
+      return false;
+    }
+    commitPoints.emplace_back(ci.commit);
   }
 
   // Update internal state
@@ -404,8 +414,8 @@ bool ConsensusLeader::ProcessMessageCommitCore(
   }
 
   // 33-byte commit
-  m_commitPoints.emplace_back(commitPoint);
-  m_commitPointMap.at(backupID) = commitPoint;
+  m_commitPoints.emplace_back(commitPoints);
+  m_commitPointMap.at(backupID) = commitPoints;
   m_commitMap.at(backupID) = true;
 
   m_commitCounter++;
@@ -413,13 +423,6 @@ bool ConsensusLeader::ProcessMessageCommitCore(
   if (m_commitCounter % 10 == 0) {
     LOG_GENERAL(INFO, "Received commits = " << m_commitCounter << " / "
                                             << m_numForConsensus);
-  }
-
-  // Redundant commits
-  if (m_commitCounter > m_numForConsensus) {
-    m_commitRedundantPointMap.at(backupID) = commitPoint;
-    m_commitRedundantMap.at(backupID) = true;
-    m_commitRedundantCounter++;
   }
 
   if (m_numOfSubsets > 1) {
@@ -721,16 +724,16 @@ bool ConsensusLeader::ProcessMessageResponseCore(
 
         // Add the leader to the commits
         m_commitMap.at(m_myID) = true;
-        m_commitPoints.emplace_back(*m_commitPoint);
-        m_commitPointMap.at(m_myID) = *m_commitPoint;
+        vector<CommitPoint> myCommits;
+        for (const auto& cs : m_commitSecrets) {
+          myCommits.emplace_back(CommitPoint(cs));
+        }
+        m_commitPoints.emplace_back(myCommits);
+        m_commitPointMap.at(m_myID) = myCommits;
         m_commitCounter = 1;
 
         m_commitFailureCounter = 0;
         m_commitFailureMap.clear();
-
-        m_commitRedundantCounter = 0;
-        fill(m_commitRedundantMap.begin(), m_commitRedundantMap.end(), false);
-
       } else {
         // Save the collective sig over the second round
         m_CS2 = subset.collectiveSig;
@@ -898,16 +901,11 @@ ConsensusLeader::ConsensusLeader(
     NodeCommitFailureHandlerFunc nodeCommitFailureHandlerFunc,
     ShardCommitFailureHandlerFunc shardCommitFailureHandlerFunc, bool isDS)
     : ConsensusCommon(consensus_id, block_number, block_hash, node_id, privkey,
-                      committee, class_byte, ins_byte),
-      m_DS(isDS),
+                      committee, class_byte, ins_byte, isDS),
       m_commitMap(committee.size(), false),
-      m_commitPointMap(committee.size(), CommitPoint()),
-      m_commitRedundantMap(committee.size(), false),
-      m_commitRedundantPointMap(committee.size(), CommitPoint()) {
+      m_commitPointMap(committee.size(),
+                       vector<CommitPoint>(m_numOfSubsets, CommitPoint())) {
   LOG_MARKER();
-
-  m_numOfSubsets =
-      m_DS ? DS_NUM_CONSENSUS_SUBSETS : SHARD_NUM_CONSENSUS_SUBSETS;
 
   m_state = INITIAL;
   // m_numForConsensus = (floor(TOLERANCE_FRACTION * (pubkeys.size() - 1)) + 1);
@@ -917,17 +915,22 @@ ConsensusLeader::ConsensusLeader(
   m_nodeCommitFailureHandlerFunc = move(nodeCommitFailureHandlerFunc);
   m_shardCommitFailureHandlerFunc = move(shardCommitFailureHandlerFunc);
 
-  m_commitSecret.reset(new CommitSecret());
-  m_commitPoint.reset(new CommitPoint(*m_commitSecret));
+  m_commitSecrets.clear();
 
   // Add the leader to the commits
   m_commitMap.at(m_myID) = true;
-  m_commitPoints.emplace_back(*m_commitPoint);
-  m_commitPointMap.at(m_myID) = *m_commitPoint;
+  vector<CommitPoint> myCommits;
+  for (unsigned int i = 0; i < m_numOfSubsets; i++) {
+    CommitSecret cs;
+    m_commitSecrets.emplace_back(cs);
+    myCommits.emplace_back(CommitPoint(cs));
+  }
+  m_commitPoints.emplace_back(myCommits);
+
+  m_commitPointMap.at(m_myID) = myCommits;
   m_commitCounter = 1;
 
   m_sufficientCommitsReceived = false;
-  m_commitRedundantCounter = 0;
   m_commitFailureCounter = 0;
   m_numSubsetsRunning = 0;
 
@@ -980,7 +983,6 @@ bool ConsensusLeader::StartConsensus(
   // =====================
 
   m_state = ANNOUNCE_DONE;
-  m_commitRedundantCounter = 0;
   m_commitFailureCounter = 0;
 
   // Multicast to all nodes in the committee

--- a/src/libConsensus/ConsensusLeader.h
+++ b/src/libConsensus/ConsensusLeader.h
@@ -53,8 +53,6 @@ class ConsensusLeader : public ConsensusCommon {
   unsigned int m_numForConsensus;
   unsigned int m_numForConsensusFailure;
 
-  bool m_DS;
-  unsigned int m_numOfSubsets;
   // Received commits
   std::mutex m_mutex;
   std::atomic<unsigned int> m_commitCounter{0};
@@ -65,15 +63,11 @@ class ConsensusLeader : public ConsensusCommon {
   unsigned int m_sufficientCommitsNumForSubsets;
 
   std::vector<bool> m_commitMap;
-  std::vector<CommitPoint>
+  std::vector<std::vector<CommitPoint>>
       m_commitPointMap;  // ordered list of commits of size = committee size
-  std::vector<CommitPoint> m_commitPoints;  // unordered list of commits of size
-                                            // = 2/3 of committee size + 1
-  unsigned int m_commitRedundantCounter;
-  std::vector<bool> m_commitRedundantMap;
-  std::vector<CommitPoint>
-      m_commitRedundantPointMap;  // ordered list of redundant commits of size =
-                                  // 1/3 of committee size
+  std::vector<std::vector<CommitPoint>>
+      m_commitPoints;  // unordered list of commits of size
+                       // = 2/3 of committee size + 1
   // Generated challenge
   Challenge m_challenge;
 

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -853,6 +853,8 @@ void DirectoryService::ProcessDSBlockConsensusWhenDone() {
   // Reached here, so already at new ds epoch now and safe to remove
   // ipMapping.xml
   m_mediator.m_node->RemoveIpMapping();
+
+  m_mediator.m_lookup->UpdateAllSeedsAndMultipliers();
 }
 
 bool DirectoryService::ProcessDSBlockConsensus(

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -1358,7 +1358,8 @@ bool DirectoryService::RunConsensusOnDSBlockWhenDSBackup() {
       consensusID, m_mediator.m_currentEpochNum, m_consensusBlockHash,
       m_consensusMyID, GetConsensusLeaderID(), m_mediator.m_selfKey.first,
       *m_mediator.m_DSCommittee, static_cast<uint8_t>(DIRECTORY),
-      static_cast<uint8_t>(DSBLOCKCONSENSUS), func));
+      static_cast<uint8_t>(DSBLOCKCONSENSUS), func, nullptr, nullptr, nullptr,
+      true));
 
   if (m_consensusObject == nullptr) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1261,7 +1261,7 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSBackup() {
       static_cast<uint8_t>(DIRECTORY),
       static_cast<uint8_t>(FINALBLOCKCONSENSUS), completeFBValidatorFunc,
       preprepFBValidatorFunc, postPreprepValidationFunc,
-      txnProcessingReadinessfunc));
+      txnProcessingReadinessfunc, true));
 
   m_mediator.m_node->m_consensusObject = m_consensusObject;
 

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -708,7 +708,8 @@ bool DirectoryService::RunConsensusOnViewChangeWhenNotCandidateLeader(
       consensusID, m_mediator.m_currentEpochNum, m_consensusBlockHash,
       m_consensusMyID, candidateLeaderIndex, m_mediator.m_selfKey.first,
       *m_mediator.m_DSCommittee, static_cast<uint8_t>(DIRECTORY),
-      static_cast<uint8_t>(VIEWCHANGECONSENSUS), func));
+      static_cast<uint8_t>(VIEWCHANGECONSENSUS), func, nullptr, nullptr,
+      nullptr, true));
 
   if (m_consensusObject == nullptr) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -38,6 +38,7 @@
 #include "libNetwork/P2PComm.h"
 #include "libNetwork/Peer.h"
 #include "libNetwork/ShardStruct.h"
+#include "libUtils/DNSUtils.h"
 #include "libUtils/IPConverter.h"
 #include "libUtils/Logger.h"
 
@@ -66,20 +67,23 @@ class Lookup : public Executable {
   Mediator& m_mediator;
 
   // Info about lookup node
+  mutable std::shared_timed_mutex m_mutexLookupNodes;
   VectorOfNode m_lookupNodes;
   VectorOfNode m_lookupNodesOffline;
-  VectorOfNode m_seedNodes;
-  VectorOfNode m_multipliers;
-  std::mutex mutable m_mutexSeedNodes;
-  VectorOfNode m_l2lDataProviders;
-  std::mutex mutable m_mutexL2lDataProviders;
-  bool m_dsInfoWaitingNotifying = false;
-  bool m_fetchedDSInfo = false;
-
   // m_lookupNodes can change during operation if some lookups go offline.
   // m_lookupNodesStatic is the fixed copy of m_lookupNodes after loading from
   // constants.xml.
   VectorOfNode m_lookupNodesStatic;
+  VectorOfNode m_lookupNodesWithoutMultipliers;
+
+  mutable std::shared_timed_mutex m_mutexSeedNodes;
+  VectorOfNode m_seedNodes;
+
+  mutable std::shared_timed_mutex m_mutexL2lDataProviders;
+  VectorOfNode m_l2lDataProviders;
+
+  bool m_dsInfoWaitingNotifying = false;
+  bool m_fetchedDSInfo = false;
 
   // This is used only for testing with gentxn
   std::vector<Address> m_myGenesisAccounts1;
@@ -93,7 +97,6 @@ class Lookup : public Executable {
   bool m_isFirstLoop = true;
   // tells if server is running or not
   bool m_isServer = false;
-  uint8_t m_level = (uint8_t)-1;
 
   // Sharding committee members
 
@@ -111,7 +114,28 @@ class Lookup : public Executable {
   /// To indicate which type of synchronization is using
   std::atomic<SyncType> m_syncType{};  // = SyncType::NO_SYNC;
 
-  void SetAboveLayer(VectorOfNode& aboveLayer, const std::string& xml_node);
+  bool GetNodesFromDnsCache(VectorOfNode& currentLocalNodes,
+                            DNSUtils::DNSListType listType,
+                            unsigned int nodePort);
+
+  void ObtainNodesFromConfig(VectorOfNode& currentLocalNodes,
+                             const std::string& xmlNodeType,
+                             unsigned int nodePort);
+
+  void UpdateNodes(VectorOfNode& currentLocalNodes, unsigned int nodePort,
+                   DNSUtils::DNSListType listType,
+                   const std::string& fallbackXmlType);
+
+  void SetGenesisWallets();
+
+  void SetUpperSeedsInner();
+  void SetL2lDataProvidersInner();
+
+  // Setting the lookup nodes
+  void SetLookupNodes();
+
+  bool IsUpperSeedEmpty();
+  bool IsL2lDataProvidersEmpty();
 
   /// Post processing after the lookup node successfully synchronized with the
   /// network
@@ -124,7 +148,6 @@ class Lookup : public Executable {
   std::mutex m_mutexSetTxBlockFromSeed;
   std::mutex m_mutexSetTxBodyFromSeed;
   std::mutex m_mutexSetState;
-  std::mutex mutable m_mutexLookupNodes;
   std::mutex m_mutexCheckDirBlocks;
   std::mutex m_mutexMicroBlocksBuffer;
 
@@ -174,22 +197,27 @@ class Lookup : public Executable {
   /// Destructor.
   ~Lookup();
 
+  void UpdateAllSeedsAndMultipliers();
+
   /// Sync new lookup node.
   void InitSync();
 
-  // Setting the lookup nodes
-  // Hardcoded for now -- to be called by constructor
-  void SetLookupNodes();
-
+  // For testing usage
   void SetLookupNodes(const VectorOfNode&);
 
   bool CheckStateRoot();
+
+  // Getter for m_l2lDataProviders
+  VectorOfNode GetL2lDataProviders() const;
 
   // Getter for m_lookupNodes
   VectorOfNode GetLookupNodes() const;
 
   // Getter for m_lookupNodesStatic
   VectorOfNode GetLookupNodesStatic() const;
+
+  // Getter for m_lookupNodesStatic
+  VectorOfNode GetLookupNodesWithoutMultipliers() const;
 
   // Getter for m_seedNodes
   VectorOfNode GetSeedNodes() const;
@@ -577,7 +605,7 @@ class Lookup : public Executable {
 
   std::mutex m_mutexExtSeedWhitelisted;
   std::unordered_set<PubKey> m_extSeedWhitelisted;
-  mutable std::mutex m_mutexFwdTxnExcludedSeeds;
+  mutable std::shared_timed_mutex m_mutexFwdTxnExcludedSeeds;
   std::unordered_set<uint128_t> m_fwdTxnExcludedSeeds;
   bool AddToWhitelistExtSeed(const PubKey& pubKey);
   bool RemoveFromWhitelistExtSeed(const PubKey& pubKey);

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -7876,8 +7876,7 @@ bool Messenger::GetLookupSetDirectoryBlocksFromSeed(
 bool Messenger::SetConsensusCommit(
     bytes& dst, const unsigned int offset, const uint32_t consensusID,
     const uint64_t blockNumber, const bytes& blockHash, const uint16_t backupID,
-    const CommitPoint& commitPoint, const CommitPointHash& commitPointHash,
-    const PairOfKey& backupKey) {
+    const vector<CommitInfo>& commitInfo, const PairOfKey& backupKey) {
   LOG_MARKER();
 
   ConsensusCommit result;
@@ -7888,12 +7887,13 @@ bool Messenger::SetConsensusCommit(
                                                 blockHash.size());
   result.mutable_consensusinfo()->set_backupid(backupID);
 
-  SerializableToProtobufByteArray(
-      commitPoint, *result.mutable_consensusinfo()->mutable_commitpoint());
+  for (const auto& info : commitInfo) {
+    ConsensusCommit::CommitInfo* ci =
+        result.mutable_consensusinfo()->add_commitinfo();
 
-  SerializableToProtobufByteArray(
-      commitPointHash,
-      *result.mutable_consensusinfo()->mutable_commitpointhash());
+    SerializableToProtobufByteArray(info.commit, *ci->mutable_commitpoint());
+    SerializableToProtobufByteArray(info.hash, *ci->mutable_commitpointhash());
+  }
 
   if (!result.consensusinfo().IsInitialized()) {
     LOG_GENERAL(WARNING, "ConsensusCommit.Data initialization failed");
@@ -7925,8 +7925,7 @@ bool Messenger::GetConsensusCommit(const bytes& src, const unsigned int offset,
                                    const uint32_t consensusID,
                                    const uint64_t blockNumber,
                                    const bytes& blockHash, uint16_t& backupID,
-                                   CommitPoint& commitPoint,
-                                   CommitPointHash& commitPointHash,
+                                   vector<CommitInfo>& commitInfo,
                                    const DequeOfNode& committeeKeys) {
   LOG_MARKER();
 
@@ -7993,10 +7992,14 @@ bool Messenger::GetConsensusCommit(const bytes& src, const unsigned int offset,
     return false;
   }
 
-  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.consensusinfo().commitpoint(),
-                                  commitPoint);
-  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.consensusinfo().commitpointhash(),
-                                  commitPointHash);
+  for (const auto& proto_ci : result.consensusinfo().commitinfo()) {
+    CommitInfo ci;
+
+    PROTOBUFBYTEARRAYTOSERIALIZABLE(proto_ci.commitpoint(), ci.commit);
+    PROTOBUFBYTEARRAYTOSERIALIZABLE(proto_ci.commitpointhash(), ci.hash);
+
+    commitInfo.emplace_back(ci);
+  }
 
   bytes tmp(result.consensusinfo().ByteSize());
   result.consensusinfo().SerializeToArray(tmp.data(), tmp.size());

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -810,17 +810,18 @@ class Messenger {
     return true;
   }
 
-  static bool SetConsensusCommit(
-      bytes& dst, const unsigned int offset, const uint32_t consensusID,
-      const uint64_t blockNumber, const bytes& blockHash,
-      const uint16_t backupID, const CommitPoint& commitPoint,
-      const CommitPointHash& commitPointHash, const PairOfKey& backupKey);
+  static bool SetConsensusCommit(bytes& dst, const unsigned int offset,
+                                 const uint32_t consensusID,
+                                 const uint64_t blockNumber,
+                                 const bytes& blockHash,
+                                 const uint16_t backupID,
+                                 const std::vector<CommitInfo>& commitInfo,
+                                 const PairOfKey& backupKey);
   static bool GetConsensusCommit(const bytes& src, const unsigned int offset,
                                  const uint32_t consensusID,
                                  const uint64_t blockNumber,
                                  const bytes& blockHash, uint16_t& backupID,
-                                 CommitPoint& commitPoint,
-                                 CommitPointHash& commitPointHash,
+                                 std::vector<CommitInfo>& commitInfo,
                                  const DequeOfNode& committeeKeys);
 
   static bool SetConsensusChallenge(

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -961,14 +961,18 @@ message ConsensusAnnouncement
 
 message ConsensusCommit
 {
+    message CommitInfo
+    {
+        ByteArray commitpoint     = 1;
+        ByteArray commitpointhash = 2;
+    }
     message ConsensusInfo
     {
         uint32 consensusid        = 1;
         uint64 blocknumber        = 2;
         bytes blockhash           = 3; // 32 bytes
         uint32 backupid           = 4; // only lower 2 bytes used
-        ByteArray commitpoint     = 5;
-        ByteArray commitpointhash = 6;
+        repeated CommitInfo commitinfo       = 5;
     }
     ConsensusInfo consensusinfo   = 1;
     ByteArray pubkey              = 2;

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -838,6 +838,8 @@ bool Node::ProcessVCDSBlocksMessage(
     }
   }
 
+  m_mediator.m_lookup->UpdateAllSeedsAndMultipliers();
+
   return true;
 }
 

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -1387,7 +1387,8 @@ bool Node::RunConsensusOnMicroBlockWhenShardBackup() {
       m_mediator.m_selfKey.first, peerList, static_cast<uint8_t>(NODE),
       static_cast<uint8_t>(MICROBLOCKCONSENSUS), completeMBValidatorFunc,
       preprepMBValidatorFunc, postPreprepValidationFunc,
-      /* postFailedPreprepValidationFunc, */ txnProcessingReadinessfunc));
+      /* postFailedPreprepValidationFunc, */ txnProcessingReadinessfunc,
+      m_mediator.m_ds->m_mode != DirectoryService::IDLE));
 
   if (m_consensusObject == nullptr) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -300,7 +300,6 @@ class LookupServer : public Server,
 
   size_t GetNumTransactions(uint64_t blockNum);
   bool StartCollectorThread();
-  std::string GetNodeState();
 
   static void AddToRecentTransactions(const dev::h256& txhash);
 

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -505,7 +505,8 @@ bool StatusServer::RemoveFromFwdTxnExcludedSeeds(const string& ipAddr) {
 string StatusServer::GetFwdTxnExcludedSeeds() {
   try {
     string result;
-    lock_guard<mutex> g(m_mediator.m_lookup->m_mutexFwdTxnExcludedSeeds);
+    shared_lock<shared_timed_mutex> g(
+        m_mediator.m_lookup->m_mutexFwdTxnExcludedSeeds);
     for (const auto& ip : m_mediator.m_lookup->m_fwdTxnExcludedSeeds) {
       result += IPConverter::ToStrFromNumericalIP(ip);
       result += ", ";

--- a/src/libUtils/CMakeLists.txt
+++ b/src/libUtils/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(Utils AddressConversion.cpp BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp MemoryStats.cpp CommonUtils.cpp)
+add_library(Utils AddressConversion.cpp BitVector.cpp DataConversion.cpp DNSUtils.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp MemoryStats.cpp CommonUtils.cpp)
 target_include_directories(Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Boost)
 target_link_libraries(Utils INTERFACE Threads::Threads curl)
 target_link_libraries(Utils PUBLIC g3logger CryptoUtils Constants MessageSWInfo )
+target_link_libraries(Utils PRIVATE -lresolv)

--- a/src/libUtils/DNSUtils.cpp
+++ b/src/libUtils/DNSUtils.cpp
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2022 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DNSUtils.h"
+#include "DataConversion.h"
+#include "Logger.h"
+
+#include "common/Constants.h"
+#include "libUtils/DetachedFunction.h"
+#include "libUtils/IPConverter.h"
+
+#include <arpa/inet.h>
+#include <arpa/nameser.h>
+#include <netdb.h>
+#include <resolv.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <condition_variable>
+
+using namespace std;
+
+namespace DNSUtils {
+
+atomic<bool> isShuttingDown;
+
+using ListOfIPFromDNS = vector<string>;
+
+struct DNSCacheList {
+  mutex dataAccessMutex;
+
+  ListOfIPFromDNS listOfIPFromDNS;
+  IPPubkeyMap listOfPubKeys;
+};
+
+unordered_map<DNSListType, string> addressesOfDNS;
+
+// End of DS consensus, a separate thread will be spawned to query the DNS list
+// This is to avoid delay on the node's SendMessages when DNS query is a
+// blocking call. At the next DS consensus, we will update our local list to the
+// last updated cache And the above starts over again
+unordered_map<DNSListType, DNSCacheList> cacheDataMapOfDNS;
+
+bool QueryIPStrListFromDNS(DNSListType listType, const string &url) {
+  LOG_MARKER();
+
+  struct addrinfo hints {
+  }, *res, *result;
+  int errcode = 0;
+  char addrstr[100];
+  void *ptr = nullptr;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+  for (unsigned int retry = 0; retry < QUERY_DNS_MAX_TRIES; ++retry) {
+    if (isShuttingDown) break;
+
+    errcode = getaddrinfo(url.c_str(), NULL, &hints, &result);
+    if (errcode != 0) {
+      LOG_GENERAL(WARNING, "Failed to query from "
+                               << url << " Err: " << errcode
+                               << ", Msg: " << gai_strerror(errcode)
+                               << ", retry: " << retry);
+      continue;
+    }
+    break;  // If we are here, means success
+  }
+
+  if (isShuttingDown) return false;
+
+  if (errcode != 0) {
+    LOG_GENERAL(WARNING, "Failed to query from "
+                             << url << ", Err: " << gai_strerror(errcode));
+    return false;
+  }
+
+  res = result;
+
+  auto &listOfIPFromDNS = cacheDataMapOfDNS[listType].listOfIPFromDNS;
+  listOfIPFromDNS.clear();
+
+  while (res) {
+    switch (res->ai_family) {
+      case AF_INET:
+        ptr = &((struct sockaddr_in *)res->ai_addr)->sin_addr;
+        break;
+      case AF_INET6:
+        ptr = &((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
+        break;
+    }
+
+    if (ptr) {
+      inet_ntop(res->ai_family, ptr, addrstr, 100);
+      LOG_GENERAL(DEBUG, "Address: " << addrstr);
+      listOfIPFromDNS.emplace_back(addrstr);
+    }
+    res = res->ai_next;
+    ptr = nullptr;
+  }
+
+  freeaddrinfo(result);
+
+  return true;
+}
+
+// Pub key are stored in the TXT record
+bool QueryPubkeyFromUrl(bytes &output, const string &pubKeyUrl) {
+  LOG_MARKER();
+
+  unsigned char query_buffer[256];
+  int resLen = 0;
+
+  for (unsigned int retry = 0; retry < QUERY_DNS_MAX_TRIES; ++retry) {
+    if (isShuttingDown) return false;
+
+    resLen = res_query(pubKeyUrl.c_str(), C_IN, ns_t_txt, query_buffer,
+                       sizeof(query_buffer));
+    if (resLen < 0) {
+      LOG_GENERAL(WARNING, "Failed to query from pubKey from "
+                               << pubKeyUrl << " Retry: " << retry);
+      continue;
+    }
+    break;  // If we are here, means success
+  }
+
+  if (isShuttingDown) return false;
+
+  if (resLen < 0) {
+    LOG_GENERAL(WARNING, "Failed to query from pubKey from "
+                             << pubKeyUrl << " Res: " << resLen);
+    return false;
+  }
+
+  ns_msg nsMsg;
+  ns_initparse(query_buffer, resLen, &nsMsg);
+
+  if (ns_msg_count(nsMsg, ns_s_an) <= 0) {
+    LOG_GENERAL(WARNING, "No data found from pubKey from " << pubKeyUrl);
+    return false;
+  }
+
+  ns_rr rr;
+  ns_parserr(&nsMsg, ns_s_an, 0, &rr);
+  auto rrData = ns_rr_rdata(rr) + 1;
+
+  string p(rrData, rrData + rr.rdlength - 1);
+
+  if (p.compare("0") == 0 || p.empty()) {
+    LOG_GENERAL(WARNING, "Returned pubKey is 0 or empty: " << pubKeyUrl);
+    return false;
+  }
+
+  if (!DataConversion::HexStrToUint8Vec(p, output)) {
+    LOG_GENERAL(WARNING, "Invalid data obtained from pubKey " << pubKeyUrl);
+    return false;
+  }
+  return true;
+}
+
+void QueryDNSList(DNSListType listType) {
+  LOG_MARKER();
+  if (isShuttingDown) return;
+
+  const auto &url = addressesOfDNS[listType];
+  if (url.empty()) {
+    LOG_GENERAL(INFO, "DNS address is empty for type " << (int)listType);
+    return;
+  }
+
+  auto &dataListCache = cacheDataMapOfDNS[listType];
+
+  if (!dataListCache.dataAccessMutex.try_lock()) {
+    LOG_GENERAL(INFO,
+                "Another thread is querying " << addressesOfDNS[listType]);
+    return;
+  }
+
+  if (!QueryIPStrListFromDNS(listType, url)) {
+    LOG_GENERAL(WARNING, "Failed to obtain IP list from "
+                             << addressesOfDNS[listType]
+                             << ", try again on another DS epoch");
+    dataListCache.dataAccessMutex.unlock();
+    return;
+  }
+
+  vector<uint128_t> currentIPKeys;
+  currentIPKeys.reserve(dataListCache.listOfIPFromDNS.size());
+
+  auto &listOfPubKeys = dataListCache.listOfPubKeys;
+
+  // Adding new pubKeys to our dns cache
+  for (const auto &ipStr : dataListCache.listOfIPFromDNS) {
+    uint128_t ipKey;
+    if (!IPConverter::ToNumericalIPFromStr(ipStr, ipKey)) {
+      LOG_GENERAL(WARNING, "Unable to change IP to ipKey: " << ipKey);
+      continue;
+    }
+
+    currentIPKeys.emplace_back(ipKey);
+
+    if (listOfPubKeys.find(ipKey) != listOfPubKeys.end()) {
+      // Already exists, don't need to query again, unlikely to change pubKey
+      // for an ip
+      continue;
+    }
+
+    auto pubKeyUrl = GetPubKeyUrl(ipStr, url);
+    bytes pubKeyResult;
+    if (QueryPubkeyFromUrl(pubKeyResult, pubKeyUrl)) {
+      listOfPubKeys[ipKey] = pubKeyResult;
+    }
+  }
+
+  // Remove pubKeys that are no longer in the dns list
+  for (auto itr = listOfPubKeys.begin(); itr != listOfPubKeys.end();) {
+    if (find(currentIPKeys.begin(), currentIPKeys.end(), itr->first) ==
+        currentIPKeys.end()) {
+      itr = listOfPubKeys.erase(itr);
+    } else {
+      ++itr;
+    }
+  }
+
+  dataListCache.dataAccessMutex.unlock();
+}
+
+void InitDNSCacheList() {
+  cacheDataMapOfDNS[DNSListType::UPPER_SEED];
+  cacheDataMapOfDNS[DNSListType::L2L_DATA_PROVIDERS];
+  cacheDataMapOfDNS[DNSListType::MULTIPLIERS];
+
+  addressesOfDNS[DNSListType::UPPER_SEED] = UPPER_SEED_DNS;
+  addressesOfDNS[DNSListType::L2L_DATA_PROVIDERS] = L2L_DATA_PROVIDERS_DNS;
+  addressesOfDNS[DNSListType::MULTIPLIERS] = MULTIPLIER_DNS;
+
+  isShuttingDown = false;
+}
+
+void ShutDownDNSCacheList() { isShuttingDown = true; }
+
+void AttemptPopulateLookupsDNSCache() {
+  LOG_MARKER();
+  DetachedFunction(1, QueryDNSList, DNSListType::UPPER_SEED);
+  DetachedFunction(1, QueryDNSList, DNSListType::L2L_DATA_PROVIDERS);
+  DetachedFunction(1, QueryDNSList, DNSListType::MULTIPLIERS);
+}
+
+string GetPubKeyUrl(const std::string &ip, const std::string &url) {
+  /*
+    URL = "zilliqa-seedpubs.dev.z7a.xyz"
+    IP = "54.148.35.87"
+    Pubkey URL= "pub-54-148-35-87.dev.z7a.xyz"
+  */
+
+  auto tmpIp = ip;
+  std::replace(tmpIp.begin(), tmpIp.end(), '.', '-');
+  return "pub-" + tmpIp + url.substr(url.find_first_of('.'));
+}
+
+bool GetDNSCacheList(IPPubkeyMap &mapOfIPPubkeyFromDNS, DNSListType listType) {
+  auto &cacheList = cacheDataMapOfDNS[listType];
+  if (!cacheList.dataAccessMutex.try_lock()) {
+    LOG_GENERAL(INFO, "Unable to obtain data from "
+                          << addressesOfDNS[listType]
+                          << ", data are still being queried");
+    return false;
+  }
+
+  auto isEmptyCache = cacheList.listOfPubKeys.empty();
+
+  if (isEmptyCache) {
+    LOG_GENERAL(INFO, "DNS cache is empty for " << addressesOfDNS[listType]);
+  } else {
+    mapOfIPPubkeyFromDNS = cacheList.listOfPubKeys;
+  }
+
+  cacheList.dataAccessMutex.unlock();
+  return !isEmptyCache;
+}
+}  // namespace DNSUtils

--- a/src/libUtils/DNSUtils.h
+++ b/src/libUtils/DNSUtils.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ZILLIQA_SRC_LIBUTILS_DNSUTILS_H_
+#define ZILLIQA_SRC_LIBUTILS_DNSUTILS_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "common/BaseType.h"
+
+namespace DNSUtils {
+enum class DNSListType : int {
+  UPPER_SEED = 0,
+  L2L_DATA_PROVIDERS,
+  MULTIPLIERS
+};
+
+using IPPubkeyMap = std::unordered_map<uint128_t, bytes>;
+
+void InitDNSCacheList();
+
+void ShutDownDNSCacheList();
+
+void AttemptPopulateLookupsDNSCache();
+
+std::string GetPubKeyUrl(const std::string& ip, const std::string& url);
+
+bool GetDNSCacheList(IPPubkeyMap& mapOfIPPubkeyFromDNS, DNSListType listType);
+
+}  // namespace DNSUtils
+
+#endif  // ZILLIQA_SRC_LIBUTILS_DNSUTILS_H_

--- a/tests/Utils/CMakeLists.txt
+++ b/tests/Utils/CMakeLists.txt
@@ -44,6 +44,11 @@ target_include_directories (Test_DetachedFunction PUBLIC ${CMAKE_SOURCE_DIR}/src
 target_link_libraries (Test_DetachedFunction PUBLIC Utils)
 add_test(NAME Test_DetachedFunction COMMAND Test_DetachedFunction)
 
+add_executable (Test_DNSUtils Test_DNSUtils.cpp)
+target_include_directories (Test_DNSUtils PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries (Test_DNSUtils PUBLIC AccountData Utils)
+add_test(NAME Test_DNSUtils COMMAND Test_DNSUtils)
+
 add_executable (Test_BoostBigNum Test_BoostBigNum.cpp)
 target_include_directories (Test_BoostBigNum PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries (Test_BoostBigNum PUBLIC Utils)

--- a/tests/Utils/Test_DNSUtils.cpp
+++ b/tests/Utils/Test_DNSUtils.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <Schnorr.h>
+#include "libUtils/DNSUtils.h"
+#include "libUtils/Logger.h"
+
+#define BOOST_TEST_MODULE dnsutils
+#define BOOST_TEST_DYN_LINK
+#include <algorithm>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+BOOST_AUTO_TEST_SUITE(dnsutils)
+
+BOOST_AUTO_TEST_CASE(testGetPubKeyUrl) {
+  string url = "zilliqa-seedpubs.dev.z7a.xyz";
+  string ip = "54.148.35.87";
+  string output = DNSUtils::GetPubKeyUrl(ip, url);
+  BOOST_CHECK_MESSAGE(output.compare("pub-54-148-35-87.dev.z7a.xyz") == 0,
+                      "Incorrect output: " << output);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description
To move upper_seeds, l2l_dataprovider and multiplier IPs from constants.xml to getting fetched from DNS

The constants.xml IP still stays, in event where dns is unable to be accessed, we will fall back to the static IPs in there.


**DNS cache**
- This is maintained on a separate thread, to be updated on every DS epoch.
- The `AttemptPopulateLookupsDnsCache` is called at every end of a DS epoch.
- It is separate so that it would not be blocking our nodes function while querying.
- A retry constant `QUERY_DNS_MAX_TRIES` can be use to query again if DNS query failed.

**Local list**
- These are all in the lookup's class. `m_lookupNodes`, `m_seedNodes`, `m_l2lDataProviders`
- These will be updated via looking into the **DNS cache** at every end of DS epoch.
- Because of the DNS querying delay, when the local list look at **DNS cache**, it is looking at the data from last DS epoch.
- This is separate from the **DNS cache** because we want to use it without the delay of blocking calls from DNS querying.
- **DNS cache** will be updated after **Local list** populate from it.

**constants.xml list**
- In the event when **Local list** is empty, this will be used to populate the **Local list**
- This is usually used at the startup, as the DNS needs time to start up, querying to DNS will fail at this point.



## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

Scaling can be done by by
`kubectl scale sts <testnetname>-<nodetype> --replicas=2`

Tests done
- Scaling up and down seedpubs and multipliers to see if other nodes can obtain the ip list
- Check if community seeds and miner nodes can obtain the ip list from dns
- Simulate scenario where DNS is down by setting /etc/resolv.conf namesevers ip to random IP to block dns query.


## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
