### PR TITLE
[master] Add generated test txns to remote storage DB

### DIFF
--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -211,7 +211,7 @@ class Lookup : public Executable {
   bool GenTxnToSend(
       size_t num_txn,
       std::map<uint32_t, std::deque<std::pair<Transaction, uint32_t>>>& mp,
-      uint32_t numShards);
+      uint32_t numShards, const bool updateRemoteStorageDBForGenTxns);
   bool GenTxnToSend(size_t num_txn, std::vector<Transaction>& shardTxn,
                     std::vector<Transaction>& DSTxn);
 
@@ -314,7 +314,8 @@ class Lookup : public Executable {
   void SenderTxnBatchThread(const uint32_t, bool newDSEpoch = false);
 
   void SendTxnPacketPrepare(const uint32_t oldNumShards,
-                            const uint32_t newNumShards);
+                            const uint32_t newNumShards,
+                            const bool updateRemoteStorageDBForGenTxns = true);
   void SendTxnPacketToNodes(const uint32_t oldNumShards,
                             const uint32_t newNumShards);
   void SendTxnPacketToDS(const uint32_t oldNumShards,


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
`Lookup::GenTxnToSend` is used by developer testnets to generate test transactions.
Currently these test transactions are not inserted into the remote db.

Notes:
1. In `SendTxnPacketToNodes`, `SendTxnPacketPrepare` is called twice (`SendTxnPacketPrepare` in turn calls `GenTxnToSend`), so we need to avoid duplicate insertion into the remote db during the second call.
1. I also moved the check for `USE_REMOTE_TXN_CREATOR` from `GenTxnToSend` to `SendTxnPacketPrepare` so that we no longer see pointless "GenTxnToSend failed" messages in mainnet.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
