### PR TITLE
Improve DS-Rejoin

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -335,6 +335,7 @@ void DirectoryService::UpdateDSCommitteeComposition() {
 }
 
 void DirectoryService::StartNextTxEpoch() {
+  LOG_MARKER();
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::StartNextTxEpoch not expected to be "
@@ -478,10 +479,13 @@ void DirectoryService::StartNextTxEpoch() {
       }
     };
     DetachedFunction(1, func);
+
+    CommitMBSubmissionMsgBuffer();
   }
 }
 
 void DirectoryService::StartFirstTxEpoch() {
+  LOG_MARKER();
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::StartFirstTxEpoch not expected to be "

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -335,7 +335,6 @@ void DirectoryService::UpdateDSCommitteeComposition() {
 }
 
 void DirectoryService::StartNextTxEpoch() {
-  LOG_MARKER();
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::StartNextTxEpoch not expected to be "
@@ -485,7 +484,6 @@ void DirectoryService::StartNextTxEpoch() {
 }
 
 void DirectoryService::StartFirstTxEpoch() {
-  LOG_MARKER();
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::StartFirstTxEpoch not expected to be "

--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -365,12 +365,12 @@ void DirectoryService::StartNextTxEpoch() {
   ResetPoWSubmissionCounter();
   m_viewChangeCounter = 0;
 
-  {
+  /*{
     std::lock_guard<mutex> lock(m_mutexMicroBlocks);
     m_microBlocks.clear();
     m_missingMicroBlocks.clear();
     m_microBlockStateDeltas.clear();
-  }
+  }*/
 
   // update my shardmembers ( dsCommittee since this is ds node)
   {
@@ -424,7 +424,7 @@ void DirectoryService::StartNextTxEpoch() {
   SetState(MICROBLOCK_SUBMISSION);
 
   auto func1 = [this]() mutable -> void {
-    m_mediator.m_node->CommitTxnPacketBuffer();
+    m_mediator.m_node->CommitTxnPacketBuffer(true);
   };
   DetachedFunction(1, func1);
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -70,6 +70,9 @@ void DirectoryService::StartSynchronization(bool clean) {
 
   if (clean) {
     this->CleanVariables();
+    m_mediator.m_node->CleanVariables();
+  } else {
+    m_mediator.m_node->CleanMBConsensusAndTxnBuffers();
   }
 
   if (!m_mediator.m_node->GetOfflineLookups()) {

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -440,7 +440,6 @@ bool DirectoryService::CleanVariables() {
   }
 
   m_stopRecvNewMBSubmission = false;
-  m_startedRunFinalblockConsensus = false;
 
   {
     std::lock_guard<mutex> lock(m_mutexConsensus);

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -481,7 +481,7 @@ bool DirectoryService::CleanVariables() {
   return true;
 }
 
-void DirectoryService::RejoinAsDS(bool modeCheck) {
+void DirectoryService::RejoinAsDS(bool modeCheck, bool fromUpperSeed) {
   if (LOOKUP_NODE_MODE) {
     LOG_GENERAL(WARNING,
                 "DirectoryService::RejoinAsDS not expected to be called "
@@ -490,8 +490,12 @@ void DirectoryService::RejoinAsDS(bool modeCheck) {
   }
 
   LOG_MARKER();
-  if (m_mediator.m_lookup->GetSyncType() == SyncType::NO_SYNC &&
-      (m_mode == BACKUP_DS || !modeCheck)) {
+  if (fromUpperSeed) {  // syncing via upper_seed
+    LOG_GENERAL(INFO, "Syncing from upper seeds ...");
+    auto func = [this]() mutable -> void { StartSynchronization(); };
+    DetachedFunction(1, func);
+  } else if (m_mediator.m_lookup->GetSyncType() == SyncType::NO_SYNC &&
+             (m_mode == BACKUP_DS || !modeCheck)) {
     auto func = [this]() mutable -> void {
       while (true) {
         m_mediator.m_lookup->SetSyncType(SyncType::DS_SYNC);

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -495,7 +495,7 @@ void DirectoryService::RejoinAsDS(bool modeCheck, bool fromUpperSeed) {
     if (fromUpperSeed) {  // syncing via upper_seed
       LOG_GENERAL(INFO, "Syncing from upper seeds ...");
       m_mediator.m_lookup->SetSyncType(SyncType::DS_SYNC);
-      auto func = [this]() mutable -> void { StartSynchronization(); };
+      auto func = [this]() mutable -> void { StartSynchronization(false); };
       DetachedFunction(1, func);
     } else {
       auto func = [this]() mutable -> void {

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -545,7 +545,6 @@ class DirectoryService : public Executable {
 
   /// Whether ds started finalblock consensus
   std::mutex m_mutexPrepareRunFinalblockConsensus;
-  std::atomic<bool> m_startedRunFinalblockConsensus{};
 
   std::mutex m_mutexMicroBlocks;
   std::unordered_map<uint64_t, std::set<MicroBlock>> m_microBlocks;

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -620,7 +620,7 @@ class DirectoryService : public Executable {
   void ScheduleShardingConsensus(const unsigned int wait_window);
 
   /// Rejoin the network as a DS node in case of failure happens in protocol
-  void RejoinAsDS(bool modeCheck = true);
+  void RejoinAsDS(bool modeCheck = true, bool fromUpperSeed = false);
 
   /// Post processing after the DS node successfully synchronized with the
   /// network

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -450,6 +450,7 @@ bool DirectoryService::ProcessFinalBlockConsensus(
 }
 
 void DirectoryService::CommitFinalBlockConsensusBuffer() {
+  LOG_MARKER();
   lock_guard<mutex> g(m_mutexFinalBlockConsensusBuffer);
 
   for (const auto& i : m_finalBlockConsensusBuffer[m_mediator.m_consensusID]) {

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1191,15 +1191,12 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSBackup() {
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
   uint64_t txCurBlockNum =
       m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
-  static bool testDoneAlready = false;
   // FIXME: Prechecking not working due at epoch 1 due to the way we have low
   // blocknum
-  if (m_consensusMyID == 3 && dsCurBlockNum != 0 && txCurBlockNum > 10 &&
-      !testDoneAlready) {
+  if (m_consensusMyID == 3 && dsCurBlockNum != 0 && txCurBlockNum > 10) {
     LOG_EPOCH(
         WARNING, m_mediator.m_currentEpochNum,
         "I am suspending myself to test viewchange (VC_TEST_VC_PRECHECK_2)");
-    testDoneAlready = true;
     this_thread::sleep_for(chrono::seconds(45));
     return false;
   }

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1191,13 +1191,15 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSBackup() {
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetBlockNum();
   uint64_t txCurBlockNum =
       m_mediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
-
+  static bool testDoneAlready = false;
   // FIXME: Prechecking not working due at epoch 1 due to the way we have low
   // blocknum
-  if (m_consensusMyID == 3 && dsCurBlockNum != 0 && txCurBlockNum > 10) {
+  if (m_consensusMyID == 3 && dsCurBlockNum != 0 && txCurBlockNum > 10 &&
+      !testDoneAlready) {
     LOG_EPOCH(
         WARNING, m_mediator.m_currentEpochNum,
         "I am suspending myself to test viewchange (VC_TEST_VC_PRECHECK_2)");
+    testDoneAlready = true;
     this_thread::sleep_for(chrono::seconds(45));
     return false;
   }

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -1395,11 +1395,11 @@ void DirectoryService::RunConsensusOnFinalBlock() {
       }
     }
 
-    m_startedRunFinalblockConsensus = true;
+    if (ConsensusObjCreation) {
+      auto func1 = [this]() -> void { CommitFinalBlockConsensusBuffer(); };
 
-    auto func1 = [this]() -> void { CommitFinalBlockConsensusBuffer(); };
-
-    DetachedFunction(1, func1);
+      DetachedFunction(1, func1);
+    }
   }
 
   auto func1 = [this]() -> void {

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -274,7 +274,12 @@ void DirectoryService::RunConsensusOnViewChange() {
                   "[RDS]Failed the vc precheck. Node is lagging behind the "
                   "whole network.");
       CleanUpViewChange(true);
-      RejoinAsDS();
+      if (m_vcPreCheckDSBlocks.size() == 0)  // Still in same ds epoch
+      {
+        RejoinAsDS(true, true);  // syncing from upperseed
+      } else {
+        RejoinAsDS();
+      }
       return;
     }
   }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2132,7 +2132,7 @@ bool Node::ProcessProposeGasPrice(
   return true;
 }
 
-void Node::CommitTxnPacketBuffer() {
+void Node::CommitTxnPacketBuffer(bool ignorePktForPrevEpoch) {
   LOG_MARKER();
 
   if (LOOKUP_NODE_MODE) {
@@ -2158,9 +2158,10 @@ void Node::CommitTxnPacketBuffer() {
                 "Messenger::GetNodeForwardTxnBlock failed.");
       return;
     }
-
-    ProcessTxnPacketFromLookupCore(message, epochNumber, dsBlockNum, shardId,
+    if(!ignorePktForPrevEpoch || epochNumber < m_mediator.m_currentEpochNum){
+      ProcessTxnPacketFromLookupCore(message, epochNumber, dsBlockNum, shardId,
                                    lookupPubKey, transactions);
+    }
   }
   m_txnPacketBuffer.clear();
 }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2158,7 +2158,8 @@ void Node::CommitTxnPacketBuffer(bool ignorePktForPrevEpoch) {
                 "Messenger::GetNodeForwardTxnBlock failed.");
       return;
     }
-    if (!ignorePktForPrevEpoch || epochNumber < m_mediator.m_currentEpochNum) {
+    if (!(ignorePktForPrevEpoch &&
+          (epochNumber < m_mediator.m_currentEpochNum))) {
       ProcessTxnPacketFromLookupCore(message, epochNumber, dsBlockNum, shardId,
                                      lookupPubKey, transactions);
     }

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2350,6 +2350,20 @@ void Node::SetMyshardId(uint32_t shardId) {
   m_myshardId = shardId;
 }
 
+void Node::CleanMBConsensusAndTxnBuffers() {
+  LOG_MARKER();
+  {
+    std::lock_guard<mutex> g(m_mutexCreatedTransactions);
+    m_createdTxns.clear();
+    t_createdTxns.clear();
+  }
+  {
+    std::lock_guard<mutex> lock(m_mutexProcessedTransactions);
+    t_processedTransactions.clear();
+  }
+  CleanMicroblockConsensusBuffer();
+}
+
 void Node::CleanCreatedTransaction() {
   LOG_MARKER();
   {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2158,9 +2158,9 @@ void Node::CommitTxnPacketBuffer(bool ignorePktForPrevEpoch) {
                 "Messenger::GetNodeForwardTxnBlock failed.");
       return;
     }
-    if(!ignorePktForPrevEpoch || epochNumber < m_mediator.m_currentEpochNum){
+    if (!ignorePktForPrevEpoch || epochNumber < m_mediator.m_currentEpochNum) {
       ProcessTxnPacketFromLookupCore(message, epochNumber, dsBlockNum, shardId,
-                                   lookupPubKey, transactions);
+                                     lookupPubKey, transactions);
     }
   }
   m_txnPacketBuffer.clear();

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -690,7 +690,7 @@ class Node : public Executable {
   bool RunConsensusOnMicroBlock();
 
   /// Used for commit buffered txn packet
-  void CommitTxnPacketBuffer();
+  void CommitTxnPacketBuffer(bool ignorePktForPrevEpoch = false);
 
   /// Used by oldest DS node to configure sharding variables as a new shard node
   bool LoadShardingStructure(bool callByRetrieve = false);

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -623,6 +623,8 @@ class Node : public Executable {
 
   void CleanCreatedTransaction();
 
+  void CleanMBConsensusAndTxnBuffers();
+
   void AddBalanceToGenesisAccount();
 
   void PopulateAccounts(bool temp = false);


### PR DESCRIPTION
## Description
This PR covers following:

- DS node now rejoin from upper_seed instead of S3 as far as its not lagging by more than a ds epoch.

- Older txn packets are ignored after rejoined ( i.e. txn packets from older epochs )

- Clean `m_createdtxns`, `t_createdtxns` and `t_processedTransactions` before rejoining because they are no more relevant after rejoining.

- Commit MB submission buffer after rejoined so that now we have good chance of moving from `MICROBLOCK_SUBMISSION` to `FINALBLOCK_CONSENSUS_PREP` immediately.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
