### PR TITLE
[master] Scilla disambiguation during state migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - bash ./cmake-3.19.3-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/
   - cmake --version
   - rm cmake-3.19.3-Linux-x86_64.sh
-  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:815465ac cp -r /scilla /root/
+  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:v0.10.0-alpha.0 cp -r /scilla /root/
   - ls /scilla/0/
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ endif()
 
 # installation
 
-set_target_properties(zilliqa sendcmd genaccounts genkeypair getpub getaddr gentxn signmultisig verifymultisig zilliqad gensigninitialds grepperf getnetworkhistory getrewardhistory validateDB restore genTxnBodiesFromS3 isolatedServer
+set_target_properties(zilliqa sendcmd genaccounts genkeypair getpub getaddr gentxn signmultisig verifymultisig zilliqad gensigninitialds grepperf getnetworkhistory getrewardhistory validateDB restore genTxnBodiesFromS3 isolatedServer data_migrate
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set_target_properties(Common Trie CryptoUtils NAT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-ARG BASE=zilliqa/scilla:815465ac
+ARG BASE=zilliqa/scilla:v0.10.0-alpha.0
 FROM ${BASE} AS scilla
 # run a copy -L to unfold the symlinkes, and strip all exes
 RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*
@@ -108,7 +108,7 @@ RUN git clone ${REPO} ${SOURCE_DIR} \
        /usr/local/bin/isolatedServer \
        /usr/local/bin/getrewardhistory \
     #    /usr/local/bin/zilliqa \
-    #   /usr/local/bin/data_migrate \
+       /usr/local/bin/data_migrate \
        /usr/local/lib/libSchnorr.so \
        /usr/local/lib/libCryptoUtils.so \
        /usr/local/lib/libNAT.so \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-FROM zilliqa/scilla:815465ac
+FROM zilliqa/scilla:v0.10.0-alpha.0
 
 COPY requirements3.cuda.txt ./
 

--- a/src/cmd/data_migrate.cpp
+++ b/src/cmd/data_migrate.cpp
@@ -41,8 +41,9 @@ int main(int argc, const char* argv[]) {
   PairOfKey key;  // Dummy to initate mediator
   Peer peer;
   string ignore_checker_str;
-  string contract_address_output_dir;
-  string normal_address_output_dir;
+  string disambiguation_str;
+  string contract_address_output_filename;
+  string normal_address_output_filename;
 
   try {
     po::options_description desc("Options");
@@ -50,11 +51,15 @@ int main(int argc, const char* argv[]) {
     desc.add_options()("help,h", "Print help messages")(
         "ignore_checker,i", po::value<string>(&ignore_checker_str),
         "whether ignore scilla checker result (true to ignore, default false)")(
-        "contract_addresses,c", po::value<string>(&contract_address_output_dir),
-        "indicate the path to output the contract addresses, no output if "
+        "disambiguation,d", po::value<string>(&disambiguation_str),
+        "whether to call the migration tool for disambiguation (default "
+        "false)")(
+        "contract_addresses,c",
+        po::value<string>(&contract_address_output_filename),
+        "indicate the filename to output the contract addresses, no output if "
         "empty")("normal_addresses,n",
-                 po::value<string>(&normal_address_output_dir),
-                 "indicate the path to output non-contract addresses, no "
+                 po::value<string>(&normal_address_output_filename),
+                 "indicate the filename to output non-contract addresses, no "
                  "output if empty");
 
     po::variables_map vm;
@@ -78,7 +83,8 @@ int main(int argc, const char* argv[]) {
       return ERROR_IN_COMMAND_LINE;
     }
 
-    bool ignore_checker = (ignore_checker_str == "true");
+    const bool ignore_checker = (ignore_checker_str == "true");
+    const bool disambiguation = (disambiguation_str == "true");
 
     LOG_GENERAL(INFO, "Begin");
 
@@ -92,14 +98,14 @@ int main(int argc, const char* argv[]) {
       return 0;
     }
 
-    LOG_GENERAL(INFO, "finished RetrieveStates");
+    LOG_GENERAL(INFO, "Finished RetrieveStates");
 
-    if (!retriever.MigrateContractStates(ignore_checker,
-                                         contract_address_output_dir,
-                                         normal_address_output_dir)) {
+    if (!retriever.MigrateContractStates(ignore_checker, disambiguation,
+                                         contract_address_output_filename,
+                                         normal_address_output_filename)) {
       LOG_GENERAL(WARNING, "MigrateContractStates failed");
     } else {
-      LOG_GENERAL(INFO, "Migrate contract data finished");
+      LOG_GENERAL(INFO, "MigrateContractStates finished");
     }
   } catch (std::exception& e) {
     std::cerr << "Unhandled Exception reached the top of main: " << e.what()

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -232,9 +232,10 @@ class AccountStore
 
   std::shared_timed_mutex& GetPrimaryMutex() { return m_mutexPrimary; }
 
-  bool MigrateContractStates2(bool ignoreCheckerFailure,
-                              const std::string& contract_address_output_dir,
-                              const std::string& normal_address_output_dir);
+  bool MigrateContractStates(
+      bool ignoreCheckerFailure, bool disambiguation,
+      const std::string& contract_address_output_filename,
+      const std::string& normal_address_output_filename);
 };
 
 #endif  // ZILLIQA_SRC_LIBDATA_ACCOUNTDATA_ACCOUNTSTORE_H_

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -46,7 +46,7 @@ class AccountStoreAtomic
   GetAddressToAccount();
 };
 
-enum INVOKE_TYPE { CHECKER, RUNNER_CREATE, RUNNER_CALL };
+enum INVOKE_TYPE { CHECKER, RUNNER_CREATE, RUNNER_CALL, DISAMBIGUATE };
 
 template <class MAP>
 class AccountStoreSC : public AccountStoreBase<MAP> {
@@ -193,6 +193,11 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
                          const uint64_t& available_gas,
                          const boost::multiprecision::uint128_t& balance,
                          bool& ret, TransactionReceipt& receipt);
+
+  void InvokeDisambiguation(const uint32_t& version, bool is_library,
+                            const uint64_t& available_gas,
+                            const boost::multiprecision::uint128_t& balance,
+                            bool& ret, TransactionReceipt& receipt);
 
   /// verify the return from scilla_checker for deployment is valid
   /// expose in protected for using by data migration

--- a/src/libData/AccountData/AccountStoreSC.tpp
+++ b/src/libData/AccountData/AccountStoreSC.tpp
@@ -86,6 +86,12 @@ void AccountStoreSC<MAP>::InvokeInterpreter(
                 interprinterPrint)) {
         }
         break;
+      case DISAMBIGUATE:
+        if (!ScillaClient::GetInstance().CallDisambiguate(
+                version, ScillaUtils::GetDisambiguateJson(),
+                interprinterPrint)) {
+        }
+        break;
     }
 
     cv_callContract.notify_all();

--- a/src/libData/AccountData/ScillaClient.cpp
+++ b/src/libData/AccountData/ScillaClient.cpp
@@ -217,3 +217,40 @@ bool ScillaClient::CallRunner(uint32_t version, const Json::Value& _json,
 
   return true;
 }
+
+bool ScillaClient::CallDisambiguate(uint32_t version, const Json::Value& _json,
+                                    std::string& result, uint32_t counter) {
+  if (counter == 0) {
+    return false;
+  }
+
+  if (!ENABLE_SCILLA_MULTI_VERSION) {
+    version = 0;
+  }
+
+  if (!CheckClient(version)) {
+    LOG_GENERAL(WARNING, "CheckClient failed");
+    return false;
+  }
+
+  try {
+    std::lock_guard<std::mutex> g(m_mutexMain);
+    result =
+        m_clients.at(version)->CallMethod("disambiguate", _json).asString();
+  } catch (jsonrpc::JsonRpcException& e) {
+    LOG_GENERAL(WARNING, "CallDisambiguate failed: " << e.what());
+    if (std::string(e.what()).find(SCILLA_SERVER_SOCKET_PATH) !=
+        std::string::npos) {
+      if (!CheckClient(version, true)) {
+        LOG_GENERAL(WARNING, "CheckClient for version " << version << "failed");
+        return CallDisambiguate(version, _json, result, counter - 1);
+      }
+    } else {
+      result = e.what();
+    }
+
+    return false;
+  }
+
+  return true;
+}

--- a/src/libData/AccountData/ScillaClient.h
+++ b/src/libData/AccountData/ScillaClient.h
@@ -52,6 +52,8 @@ class ScillaClient {
                    std::string& result, uint32_t counter = MAXRETRYCONN);
   bool CallRunner(uint32_t version, const Json::Value& _json,
                   std::string& result, uint32_t counter = MAXRETRYCONN);
+  bool CallDisambiguate(uint32_t version, const Json::Value& _json,
+                        std::string& result, uint32_t counter = MAXRETRYCONN);
 };
 
 #endif  // ZILLIQA_SRC_LIBDATA_ACCOUNTDATA_SCILLACLIENT_H_

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -381,8 +381,10 @@ void Retriever::CleanAll() {
 }
 
 bool Retriever::MigrateContractStates(
-    bool ignore_checker, const std::string& contract_address_output_dir,
-    const std::string& normal_address_output_dir) {
-  return AccountStore::GetInstance().MigrateContractStates2(
-      ignore_checker, contract_address_output_dir, normal_address_output_dir);
+    bool ignore_checker, bool disambiguation,
+    const std::string& contract_address_output_filename,
+    const std::string& normal_address_output_filename) {
+  return AccountStore::GetInstance().MigrateContractStates(
+      ignore_checker, disambiguation, contract_address_output_filename,
+      normal_address_output_filename);
 }

--- a/src/libPersistence/Retriever.h
+++ b/src/libPersistence/Retriever.h
@@ -34,9 +34,10 @@ class Retriever {
   bool RetrieveBlockLink();
   bool RetrieveStates();
   bool ValidateStates();
-  bool MigrateContractStates(bool ignore_checker,
-                             const std::string& contract_address_output_dir,
-                             const std::string& normal_address_output_dir);
+  bool MigrateContractStates(
+      bool ignore_checker, bool disambiguation,
+      const std::string& contract_address_output_filename,
+      const std::string& normal_address_output_filename);
   void CleanAll();
 
  private:

--- a/src/libUtils/ScillaUtils.cpp
+++ b/src/libUtils/ScillaUtils.cpp
@@ -141,3 +141,20 @@ Json::Value ScillaUtils::GetCallContractJson(const string& root_w_version,
 
   return ret;
 }
+
+Json::Value ScillaUtils::GetDisambiguateJson() {
+  Json::Value ret;
+  ret["argv"].append("-iinit");
+  ret["argv"].append(boost::filesystem::current_path().string() + '/' +
+                     INIT_JSON);
+  ret["argv"].append("-ipcaddress");
+  ret["argv"].append(SCILLA_IPC_SOCKET_PATH);
+  ret["argv"].append("-oinit");
+  ret["argv"].append(boost::filesystem::current_path().string() + '/' +
+                     OUTPUT_JSON);
+  ret["argv"].append("-i");
+  ret["argv"].append(boost::filesystem::current_path().string() + '/' +
+                     INPUT_CODE + CONTRACT_FILE_EXTENSION);
+
+  return ret;
+}

--- a/src/libUtils/ScillaUtils.h
+++ b/src/libUtils/ScillaUtils.h
@@ -45,6 +45,9 @@ class ScillaUtils {
   static Json::Value GetCallContractJson(
       const std::string& root_w_version, const uint64_t& available_gas,
       const boost::multiprecision::uint128_t& balance);
+
+  /// get the command for invoking disambiguate_state_json while calling
+  static Json::Value GetDisambiguateJson();
 };
 
 #endif  // ZILLIQA_SRC_LIBUTILS_SCILLAUTILS_H_


### PR DESCRIPTION
## Description
This PR updates the state migration code to perform disambiguation (using the Scilla disambiguation tool). This can be enabled under the new `--disambiguation true` flag to the executable.

## Backward Compatibility
N/A
- [ ] This is not a breaking change
- [x] This is a breaking change

### Implementation
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
