### PR TITLE
[release-8.0] Skip waiting on txn processing in vacuous epoch

### DIFF
--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -1061,6 +1061,10 @@ void Node::StartTxnProcessingThread() {
 
 bool Node::WaitUntilTxnProcessingDone() {
   LOG_MARKER();
+  if (!m_mediator.ToProcessTransaction()) {
+    LOG_GENERAL(INFO, "Vacuous epoch: Skipping processing transactions");
+    return true;
+  }
   // wait for txn processing being ready by me (backup)
   unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
   int timeout_time =

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2267,6 +2267,7 @@ bool Node::CleanVariables() {
   m_stillMiningPrimary = false;
   m_myshardId = 0;
   m_proposedGasPrice = PRECISION_MIN_VALUE;
+  m_lastMicroBlockCoSig = {0, CoSignatures()};
   CleanCreatedTransaction();
   CleanMicroblockConsensusBuffer();
   P2PComm::GetInstance().InitializeRumorManager({}, {});

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -137,7 +137,7 @@ class Node : public Executable {
   std::shared_ptr<Retriever> m_retriever;
 
   bytes m_consensusBlockHash;
-  std::pair<uint64_t, CoSignatures> m_lastMicroBlockCoSig;
+  std::pair<uint64_t, CoSignatures> m_lastMicroBlockCoSig{0, CoSignatures()};
 
   const static uint32_t RECVTXNDELAY_MILLISECONDS = 3000;
   const static unsigned int GOSSIP_RATE = 48;


### PR DESCRIPTION
## Description
This PR cover:

- Skip waiting on txn processing in vacuous epoch

- Clean all created txns on receiving FB with my shard MB generated but not contributed by me(shard node).

- set `m_txn_distribute_window_open` on rejoin ( No previous  microblock consensus in recovery/rejoin case )

- wait on `cv_FBWaitMB` only if my shard MB generated but not contributed by me and also if node is not in `MICROBLOCK_CONSENSUS_PREP/MICROBLOCK_CONSENSUS` state.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->

- small-scale cloud test
- [x] Skip waiting on txn processing in vacuous epoch
- [x] Clean all created txns on receiving FB with my shard MB generated but not contributed by me(shard node).
- [x] set `m_txn_distribute_window_open` on rejoin ( No previous  microblock consensus in recovery/rejoin case )
- [x] wait on `cv_FBWaitMB` only if my shard MB generated but not contributed by me and also if node is not in `MICROBLOCK_CONSENSUS_PREP/MICROBLOCK_CONSENSUS` state.


