### PR TITLE
[master] Fix memory increase issue of lookups/seed nodes

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -32,6 +32,7 @@
 #include "libNetwork/Blacklist.h"
 #include "libNetwork/Guard.h"
 #include "libPersistence/ContractStorage2.h"
+#include "libUtils/CommonUtils.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/DetachedFunction.h"
 #include "libUtils/Logger.h"
@@ -96,7 +97,6 @@ bool DirectoryService::StoreFinalBlockToDisk() {
     LOG_GENERAL(WARNING, "Failed to put statedelta in persistence");
     return false;
   }
-
   return true;
 }
 
@@ -217,6 +217,9 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       }
     };
     DetachedFunction(1, writeStateToDisk);
+
+    // Clear STL memory cache
+    DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
   } else {
     // Coinbase
     SaveCoinbase(m_finalBlock->GetB1(), m_finalBlock->GetB2(),

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -45,6 +45,7 @@
 #include "libServer/LookupServer.h"
 #include "libServer/WebsocketServer.h"
 #include "libUtils/BitVector.h"
+#include "libUtils/CommonUtils.h"
 #include "libUtils/DataConversion.h"
 #include "libUtils/DetachedFunction.h"
 #include "libUtils/HashUtils.h"
@@ -968,6 +969,11 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
       return false;
     }
 
+    // Clear STL memory cache
+    if (LOOKUP_NODE_MODE) {
+      DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
+    }
+
     // if lookup and loaded microblocks, then skip
     lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
     if (!(LOOKUP_NODE_MODE &&
@@ -995,6 +1001,11 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
       LOG_GENERAL(WARNING, "StoreFinalBlock failed!");
       return false;
     }
+    // Clear STL memory cache
+    if (!LOOKUP_NODE_MODE) {
+      DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
+    }
+
     auto writeStateToDisk = [this]() -> void {
       if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
         LOG_GENERAL(WARNING, "MoveUpdatesToDisk failed, what to do?");

--- a/src/libUtils/CMakeLists.txt
+++ b/src/libUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(Utils AddressConversion.cpp BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp)
+add_library(Utils AddressConversion.cpp BitVector.cpp DataConversion.cpp Logger.cpp SanityChecks.cpp Scheduler.cpp ShardSizeCalculator.cpp TimeUtils.cpp RandomGenerator.cpp RootComputation.cpp IPConverter.cpp UpgradeManager.cpp SWInfo.cpp FileSystem.cpp ScillaUtils.cpp CommonUtils.cpp)
 target_include_directories(Utils PUBLIC ${PROJECT_SOURCE_DIR}/src Boost)
 target_link_libraries(Utils INTERFACE Threads::Threads curl)
 target_link_libraries(Utils PUBLIC g3logger CryptoUtils Constants MessageSWInfo )

--- a/src/libUtils/CommonUtils.cpp
+++ b/src/libUtils/CommonUtils.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <malloc.h>
+#include <chrono>
+
+#include "libUtils/CommonUtils.h"
+#include "libUtils/Logger.h"
+
+using namespace std;
+
+void CommonUtils ::ReleaseSTLMemoryCache() {
+  LOG_MARKER();
+  malloc_trim(0);
+}

--- a/src/libUtils/CommonUtils.h
+++ b/src/libUtils/CommonUtils.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 Zilliqa
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef ZILLIQA_SRC_LIBUTILS_COMMONUTILS_H_
+#define ZILLIQA_SRC_LIBUTILS_COMMONUTILS_H_
+
+namespace CommonUtils {
+void ReleaseSTLMemoryCache();
+}  // namespace CommonUtils
+
+#endif  // ZILLIQA_SRC_LIBUTILS_COMMONUTILS_H_


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
To fix the continuous increase of memory, clean up the memory cache for STL containers for `seeds` , `lookup`, `ds` and `normal` node.

Lookup, seed = Clear every Tx epoch
DS, Miner node = Clear every vacuous epoch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
