### PR TITLE
[master] Remove isBackup flag from auto_backup.py

### DIFF
--- a/scripts/auto_backup.py
+++ b/scripts/auto_backup.py
@@ -179,8 +179,6 @@ def main():
     if 'frequency' in args:
         frequency = int(args['frequency'])
 
-    isBackup = False
-
     while True:
         if os.path.isfile(os.path.dirname(os.path.abspath(__file__)) + "/constants.xml"):
             break
@@ -200,14 +198,10 @@ def main():
             curr_blockNum = GetCurrentTxBlockNum()
             print("Current blockNum = %s" % curr_blockNum)
 
-            if(curr_blockNum % num_final_block_per_pow == 0):
-                isBackup = False
-
-            if((curr_blockNum % num_final_block_per_pow) == target_backup_final_block) and isBackup == False:
+            if((curr_blockNum % num_final_block_per_pow) == target_backup_final_block):
                 logging.info("Starting to back-up persistence at blockNum : %s" % curr_blockNum)
                 backUp(curr_blockNum)
                 logging.info("Backing up persistence successfully.")
-                isBackup = True
 
             time.sleep(frequency)
         except Exception as e:


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
We set `isBackup` to true when backup is completed, and set it back to `false` when epoch 0 is reached.
However, I suspect `isBackup` is not being set back to false in time.
This can happen when `backUp()` takes a long time to run (and it might finish beyond epoch 0).
In any case, I don't see the need to keep `isBackup` flag.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
