### PR TITLE
Add missing property to constants config to make isolatedServer start successfully

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -284,6 +284,7 @@
         <LOG_SC>false</LOG_SC>
         <DISABLE_SCILLA_LIB>false</DISABLE_SCILLA_LIB>
         <SCILLA_SERVER_PENDING_IN_MS>1500</SCILLA_SERVER_PENDING_IN_MS>
+        <disambiguate_exclusion_list></disambiguate_exclusion_list>
     </smart_contract>
     <tests>
         <ENABLE_CHECK_PERFORMANCE_LOG>false</ENABLE_CHECK_PERFORMANCE_LOG>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -283,6 +283,7 @@
         <LOG_SC>true</LOG_SC>
         <DISABLE_SCILLA_LIB>false</DISABLE_SCILLA_LIB>
         <SCILLA_SERVER_PENDING_IN_MS>1500</SCILLA_SERVER_PENDING_IN_MS>
+        <disambiguate_exclusion_list></disambiguate_exclusion_list>
     </smart_contract>
     <tests>
         <ENABLE_CHECK_PERFORMANCE_LOG>false</ENABLE_CHECK_PERFORMANCE_LOG>


### PR DESCRIPTION
CC: @KaustubhShamshery 

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR is to make `/usr/local/bin/isolatedServer` start successfully in https://github.com/Zilliqa/Zilliqa/blob/master/docker/Dockerfile.

Currently, running it causes the following error: 

```# /usr/local/bin/isolatedServer -f isolated-server-accounts.json
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::property_tree::ptree_bad_path> >'
  what():  No such node (node.smart_contract.disambiguate_exclusion_list)
Aborted
```

It points out that `disambiguate_exclusion_list` property inside the `constants.xml` is missing. This PR fills it in with the default empty value. After this change, I was able to run it successfully inside the Docker image.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test (commit: 1b340c04) 

- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
