### PR TITLE
[release-8.0] Make checking for an empty key more optimized

### DIFF
--- a/src/libPersistence/ContractStorage2.h
+++ b/src/libPersistence/ContractStorage2.h
@@ -172,6 +172,8 @@ class ContractStorage2 : public Singleton<ContractStorage2> {
                         unsigned int q_offset, const bytes& v,
                         unsigned int v_offset);
 
+  bool CheckIfKeyIsEmpty(const std::string& key, bool temp);
+
   void UpdateStateDatasAndToDeletes(
       const dev::h160& addr, const std::map<std::string, bytes>& t_states,
       const std::vector<std::string>& toDeleteIndices, dev::h256& stateHash,


### PR DESCRIPTION
## Description
to check if the key was empty, we used to fetch the whole key's value.
Optimize it to just return if it is non-empty
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
