### PR TITLE
[master] Request twice for txblocks when ds node syncing to avoid lagging

### DIFF
--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -88,6 +88,7 @@ void DirectoryService::StartSynchronization(bool clean) {
   }
 
   auto func = [this]() -> void {
+    m_mediator.m_lookup->m_fetchNextTxBlock = true;
     while (m_mediator.m_lookup->GetSyncType() != SyncType::NO_SYNC) {
       m_mediator.m_lookup->ComposeAndSendGetDirectoryBlocksFromSeed(
           m_mediator.m_blocklinkchain.GetLatestIndex() + 1);

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3273,11 +3273,15 @@ void Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
     if (!m_currDSExpired &&
         m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetEpochNum() <
             m_mediator.m_currentEpochNum) {
-      m_isFirstLoop = true;
-      SetSyncType(SyncType::NO_SYNC);
-
-      m_mediator.m_ds->FinishRejoinAsDS(lowBlockNum % NUM_FINAL_BLOCK_PER_POW ==
-                                        0);
+      if (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW == 0 ||
+          !m_fetchNextTxBlock) {
+        m_isFirstLoop = true;
+        SetSyncType(SyncType::NO_SYNC);
+        m_mediator.m_ds->FinishRejoinAsDS(
+            lowBlockNum % NUM_FINAL_BLOCK_PER_POW == 0);
+      } else {
+        m_fetchNextTxBlock = false;
+      }
     }
     m_currDSExpired = false;
   } else if (m_syncType == SyncType::LOOKUP_SYNC ||
@@ -3525,17 +3529,18 @@ bool Lookup::ProcessSetStateDeltasFromSeed(
         return false;
       }
       m_prevStateRootHashTemp = AccountStore::GetInstance().GetStateRootHash();
-    }
 
-    if ((txBlkNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) {
-      if (txBlkNum + NUM_FINAL_BLOCK_PER_POW > highBlockNum) {
-        if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
-          LOG_GENERAL(WARNING, "AccountStore::MoveUpdatesToDisk(false) failed");
-          return false;
+      if ((txBlkNum + 1) % NUM_FINAL_BLOCK_PER_POW == 0) {
+        if (txBlkNum + NUM_FINAL_BLOCK_PER_POW > highBlockNum) {
+          if (!AccountStore::GetInstance().MoveUpdatesToDisk()) {
+            LOG_GENERAL(WARNING,
+                        "AccountStore::MoveUpdatesToDisk(false) failed");
+            return false;
+          }
         }
       }
+      txBlkNum++;
     }
-    txBlkNum++;
   }
 
   cv_setStateDeltasFromSeed.notify_all();

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -516,6 +516,7 @@ class Lookup : public Executable {
   std::condition_variable cv_setStateDeltaFromSeed;
   std::mutex m_mutexSetStateDeltaFromSeed;
   bool m_skipAddStateDeltaToAccountStore = false;
+  std::atomic<bool> m_fetchNextTxBlock{false};
 
   std::mutex m_mutexCVJoined;
   std::condition_variable cv_waitJoined;


### PR DESCRIPTION
## Description
This PR tries remediate issue : https://github.com/Zilliqa/Issues/issues/728

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
