### PR TITLE
[master] Avoid fetching BlockChainData(historical MB/TxBodies) for seeds/lookups in case of rejoin from S3

### DIFF
--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -108,11 +108,11 @@ def GetStateDeltaFromS3():
 	ExtractAllGzippedObjects()
 
 def RsyncBlockChainData():
-	bashCommand = "rsync --recursive --inplace blockchaindata_persistence persistence"
+	bashCommand = "rsync --recursive --inplace historical-data/ persistence"
 	logging.info("Command = " + bashCommand)	
 	process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
 	output, error = process.communicate()
-	logging.info("Copied local blockchain-data persistence to main persistence")
+	logging.info("Copied local historical-data persistence to main persistence!")
 
 def Diff(list1, list2):
 	return (list(list(set(list1)-set(list2)) + list(set(list2)-set(list1))))
@@ -344,10 +344,11 @@ def run():
 	print("[" + str(datetime.datetime.now()) + "] Done!")
 
 	if(Exclude_microBlocks == False and Exclude_txnBodies == False):
-		if not os.path.isdir(STORAGE_PATH + "/blockchaindata_persistence"):
+		if not os.path.isdir(STORAGE_PATH + "/historical-data"):
 			# download the static db
 			download_static_DB.start(STORAGE_PATH)
-		RsyncBlockChainData()
+		if os.path.isdir(STORAGE_PATH + "/historical-data"):
+			RsyncBlockChainData()
 	return True
 
 def start():

--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -20,6 +20,7 @@ import re
 import tarfile
 from clint.textui import progress
 import os, sys
+import subprocess
 import shutil
 import time
 import datetime
@@ -107,12 +108,14 @@ def GetStateDeltaFromS3():
 	GetAllObjectsFromS3(getURL(), STATEDELTA_DIFF_NAME)
 	ExtractAllGzippedObjects()
 
-def RsyncBlockChainData():
-	bashCommand = "rsync --recursive --inplace historical-data/ persistence"
-	logging.info("Command = " + bashCommand)	
+def RsyncBlockChainData(source,destination):
+	bashCommand = "rsync --recursive --inplace "
+	bashCommand = bashCommand + source + " "
+	bashCommand = bashCommand + destination
+	print("Command = " + bashCommand)	
 	process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
 	output, error = process.communicate()
-	logging.info("Copied local historical-data persistence to main persistence!")
+	print("Copied local historical-data persistence to main persistence!")
 
 def Diff(list1, list2):
 	return (list(list(set(list1)-set(list2)) + list(set(list2)-set(list1))))
@@ -343,12 +346,28 @@ def run():
 
 	print("[" + str(datetime.datetime.now()) + "] Done!")
 
-	if(Exclude_microBlocks == False and Exclude_txnBodies == False):
-		if not os.path.isdir(STORAGE_PATH + "/historical-data"):
-			# download the static db
-			download_static_DB.start(STORAGE_PATH)
-		if os.path.isdir(STORAGE_PATH + "/historical-data"):
-			RsyncBlockChainData()
+	try:
+		if(Exclude_microBlocks == False and Exclude_txnBodies == False):
+			dir_name = STORAGE_PATH + "/historical-data"
+			main_persistence = STORAGE_PATH + "/persistence"
+			if os.path.exists(dir_name) and os.path.isdir(dir_name):
+				if not os.listdir(dir_name):
+					# download the static db
+					print("Dowloading static historical-data")
+					download_static_DB.start(STORAGE_PATH)
+				else:    
+					print("Already have historical blockchain-data!. Skip downloading again!")
+			else:
+				# download the static db
+				print("Dowloading static historical-data")
+				download_static_DB.start(STORAGE_PATH)
+			if os.path.exists(dir_name):
+				RsyncBlockChainData(dir_name+"/", main_persistence)
+	except Exception as e:
+		print(e)
+		print("Failed to download static historical-data!)
+		pass
+
 	return True
 
 def start():

--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -107,6 +107,13 @@ def GetStateDeltaFromS3():
 	GetAllObjectsFromS3(getURL(), STATEDELTA_DIFF_NAME)
 	ExtractAllGzippedObjects()
 
+def RsyncBlockChainData():
+	bashCommand = "rsync --recursive --inplace blockchaindata_persistence persistence"
+	logging.info("Command = " + bashCommand)	
+	process = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+	output, error = process.communicate()
+	logging.info("Copied local blockchain-data persistence to main persistence")
+
 def Diff(list1, list2):
 	return (list(list(set(list1)-set(list2)) + list(set(list2)-set(list1))))
 
@@ -337,10 +344,12 @@ def run():
 	print("[" + str(datetime.datetime.now()) + "] Done!")
 
 	if(Exclude_microBlocks == False and Exclude_txnBodies == False):
-		# download the static db
-		download_static_DB.start(STORAGE_PATH)
-
+		if not os.path.isdir(STORAGE_PATH + "/blockchaindata_persistence"):
+			# download the static db
+			download_static_DB.start(STORAGE_PATH)
+		RsyncBlockChainData()
 	return True
+
 def start():
 	global Exclude_txnBodies
 	global Exclude_microBlocks

--- a/scripts/download_static_DB.py
+++ b/scripts/download_static_DB.py
@@ -36,7 +36,7 @@ MAX_WORKER_JOBS = 50
 S3_MULTIPART_CHUNK_SIZE_IN_MB = 8
 MAX_FAILED_DOWNLOAD_RETRY = 2
 BASE_PATH = os.path.dirname(os.path.realpath(sys.argv[0]))
-STORAGE_PATH = BASE_PATH+'/persistence'
+STORAGE_PATH = BASE_PATH+'/historical-data'
 mutex = Lock()
 DOWNLOADED_LIST = []
 DOWNLOAD_STARTED_LIST = []
@@ -236,10 +236,10 @@ def start(new_storage_path):
 	global STORAGE_PATH
 	if new_storage_path:
 		if os.path.isabs(new_storage_path):
-			STORAGE_PATH = new_storage_path + "/blockchaindata_persistence"
+			STORAGE_PATH = new_storage_path + "/historical-data"
 		else:
 			# Get absolute path w.r.t to script
-			STORAGE_PATH = os.path.join(BASE_PATH, new_storage_path) + "/blockchaindata_persistence"
+			STORAGE_PATH = os.path.join(BASE_PATH, new_storage_path) + "/historical-data"
 	# Create persistence folder if it does not exist
 	if not os.path.exists(STORAGE_PATH):
 		os.makedirs(STORAGE_PATH)

--- a/scripts/download_static_DB.py
+++ b/scripts/download_static_DB.py
@@ -236,10 +236,10 @@ def start(new_storage_path):
 	global STORAGE_PATH
 	if new_storage_path:
 		if os.path.isabs(new_storage_path):
-			STORAGE_PATH = new_storage_path + "/persistence"
+			STORAGE_PATH = new_storage_path + "/blockchaindata_persistence"
 		else:
 			# Get absolute path w.r.t to script
-			STORAGE_PATH = os.path.join(BASE_PATH, new_storage_path) + "/persistence"
+			STORAGE_PATH = os.path.join(BASE_PATH, new_storage_path) + "/blockchaindata_persistence"
 	# Create persistence folder if it does not exist
 	if not os.path.exists(STORAGE_PATH):
 		os.makedirs(STORAGE_PATH)

--- a/scripts/download_static_DB.py
+++ b/scripts/download_static_DB.py
@@ -36,7 +36,7 @@ MAX_WORKER_JOBS = 50
 S3_MULTIPART_CHUNK_SIZE_IN_MB = 8
 MAX_FAILED_DOWNLOAD_RETRY = 2
 BASE_PATH = os.path.dirname(os.path.realpath(sys.argv[0]))
-STORAGE_PATH = BASE_PATH+'/historical-data'
+STORAGE_PATH1 = BASE_PATH+'/historical-data'
 mutex = Lock()
 DOWNLOADED_LIST = []
 DOWNLOAD_STARTED_LIST = []
@@ -211,7 +211,7 @@ def GetAllObjectsFromS3(url, folderName=""):
 	return True
 
 def GetBlockchainDataFromS3():
-	os.chdir(STORAGE_PATH)
+	os.chdir(STORAGE_PATH1)
 	return GetAllObjectsFromS3(getURL(), PERSISTENCE_SNAPSHOT_NAME)
 
 def run():
@@ -232,17 +232,17 @@ def run():
 	print("[" + str(datetime.datetime.now()) + "] Done!")
 	return True
 
-def start(new_storage_path):
-	global STORAGE_PATH
-	if new_storage_path:
-		if os.path.isabs(new_storage_path):
-			STORAGE_PATH = new_storage_path + "/historical-data"
+def start(new_STORAGE_PATH1):
+	global STORAGE_PATH1
+	if new_STORAGE_PATH1:
+		if os.path.isabs(new_STORAGE_PATH1):
+			STORAGE_PATH1 = new_STORAGE_PATH1 + "/historical-data"
 		else:
 			# Get absolute path w.r.t to script
-			STORAGE_PATH = os.path.join(BASE_PATH, new_storage_path) + "/historical-data"
+			STORAGE_PATH1 = os.path.join(BASE_PATH, new_STORAGE_PATH1) + "/historical-data"
 	# Create persistence folder if it does not exist
-	if not os.path.exists(STORAGE_PATH):
-		os.makedirs(STORAGE_PATH)
+	if not os.path.exists(STORAGE_PATH1):
+		os.makedirs(STORAGE_PATH1)
 	return run()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This PR addresses : https://github.com/Zilliqa/Issues/issues/732

Now, seeds/lookup on Rejoin from S3, will not fetch data from bucket `blockchain-data` instead will reuse the one stored earlier at startup of node.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
