### PR TITLE
[master] Clear persistence for dsnode and normal node when relaunched by daemon

### DIFF
--- a/daemon/ZilliqaDaemon.cpp
+++ b/daemon/ZilliqaDaemon.cpp
@@ -133,7 +133,9 @@ void ZilliqaDaemon::MonitorProcess(const string& name,
         m_pids[name].erase(it);
       }
 
-      StartNewProcess();
+      bool toCleanPersistence =
+          (m_nodeType == "dsguard" || m_nodeType == "normal");
+      StartNewProcess(toCleanPersistence);
       m_died.erase(pid);
     }
   }


### PR DESCRIPTION
## Description
Daemon will clear persistence when dsnode or normal node died, in case persistence were corrupted
https://github.com/Zilliqa/Issues/issues/705

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
