### PR TITLE
[release-8.1] Fix to avoid delay in switching to POW_SUBMISSION state 

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -285,16 +285,19 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
     m_mediator.m_node->SendPendingTxnToLookup();
   }
   m_mediator.m_node->ClearUnconfirmedTxn();
-  AccountStore::GetInstance().InitTemp();
-  AccountStore::GetInstance().InitRevertibles();
-  m_stateDeltaFromShards.clear();
+
   m_allPoWConns.clear();
   ClearDSPoWSolns();
   ResetPoWSubmissionCounter();
-
   if (isVacuousEpoch) {
     SetState(POW_SUBMISSION);
-  } else {
+  }
+
+  AccountStore::GetInstance().InitTemp();
+  AccountStore::GetInstance().InitRevertibles();
+  m_stateDeltaFromShards.clear();
+
+  if (!isVacuousEpoch) {
     SetState(MICROBLOCK_SUBMISSION);
   }
 


### PR DESCRIPTION
## Description
This PR addresses issue : https://github.com/Zilliqa/Issues/issues/738

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
