### PR TITLE
[release-8.1] Fix for protobuf deserialization issue on lookups during first rejoin attempt

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -4502,6 +4502,7 @@ void Lookup::RejoinAsNewLookup(bool fromLookup) {
       auto func2 = [this]() mutable -> void {
         while (true) {
           this->CleanVariables();
+          AccountStore::GetInstance().Init();
           m_mediator.m_node->CleanUnavailableMicroBlocks();
           while (!m_mediator.m_node->DownloadPersistenceFromS3()) {
             LOG_GENERAL(
@@ -4587,6 +4588,7 @@ void Lookup::RejoinAsLookup(bool fromLookup) {
       auto func2 = [this]() mutable -> void {
         while (true) {
           this->CleanVariables();
+          AccountStore::GetInstance().Init();
           m_mediator.m_node->CleanUnavailableMicroBlocks();
           while (!m_mediator.m_node->DownloadPersistenceFromS3()) {
             LOG_GENERAL(

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -2177,7 +2177,7 @@ bool Node::CleanVariables() {
     return true;
   }
 
-  AccountStore::GetInstance().InitSoft();
+  AccountStore::GetInstance().Init();
   {
     lock_guard<mutex> g(m_mutexShardMember);
     m_myShardMembers.reset(new DequeOfNode);


### PR DESCRIPTION
## Description
This PR does two things:
- Node to do hard Init instead of soft Init for AccountStore.
- Lookup nodes also calls AccountStore initialization before rejoining.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
