### PR TITLE
[release-8.1] Clean STL cache every tx epoch for normal and ds nodes

### DIFF
--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -228,8 +228,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
     };
     DetachedFunction(1, writeStateToDisk);
 
-    // Clear STL memory cache
-    DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
   } else {
     // Coinbase
     SaveCoinbase(m_finalBlock->GetB1(), m_finalBlock->GetB2(),
@@ -244,6 +242,9 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
       return;
     }
   }
+
+  // Clear STL memory cache
+  DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
 
   m_mediator.UpdateDSBlockRand();
   m_mediator.UpdateTxBlockRand();

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -994,11 +994,6 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
       return false;
     }
 
-    // Clear STL memory cache
-    if (LOOKUP_NODE_MODE) {
-      DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
-    }
-
     // if lookup and loaded microblocks, then skip
     lock_guard<mutex> g(m_mutexUnavailableMicroBlocks);
     if (!(LOOKUP_NODE_MODE &&
@@ -1029,10 +1024,6 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
     if (!StoreFinalBlock(txBlock)) {
       LOG_GENERAL(WARNING, "StoreFinalBlock failed!");
       return false;
-    }
-    // Clear STL memory cache
-    if (!LOOKUP_NODE_MODE) {
-      DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
     }
 
     auto writeStateToDisk = [this]() -> void {
@@ -1098,6 +1089,8 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
                          << "][" << txBlock.GetHeader().GetBlockNum()
                          << "] LAST");
   }
+  // Clear STL memory cache
+  DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
 
   // Assumption: New PoW done after every block committed
   // If I am not a DS committee member (and since I got this FinalBlock message,


### PR DESCRIPTION
## Description
Same as https://github.com/Zilliqa/Zilliqa/pull/2652/  and https://github.com/Zilliqa/Zilliqa/pull/2650

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x]  **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
