### PR TITLE
Temp fix for port 4501 CLOSE_WAIT stall

### DIFF
--- a/src/depends/safeserver/safehttpserver.cpp
+++ b/src/depends/safeserver/safehttpserver.cpp
@@ -29,11 +29,12 @@ struct mhd_coninfo {
     int code;
 };
 
-SafeHttpServer::SafeHttpServer(int port, const std::string &sslcert, const std::string &sslkey, int threads) :
+SafeHttpServer::SafeHttpServer(int port, bool useEpoll, const std::string &sslcert, const std::string &sslkey, int threads) :
     AbstractServerConnector(),
     port(port),
     threads(threads),
     running(false),
+    useEpoll(useEpoll),
     path_sslcert(sslcert),
     path_sslkey(sslkey),
     daemon(NULL),
@@ -58,33 +59,33 @@ bool SafeHttpServer::StartListening() {
 
     unsigned int mhd_flags = 0;
 
-    if (CONNECTION_IO_USE_EPOLL) {
+    // Temp fix with useEpoll until proper solution for CLOSE_WAIT
+    if (CONNECTION_IO_USE_EPOLL && useEpoll) {
     
       const bool has_epoll =
           (MHD_is_feature_supported(MHD_FEATURE_EPOLL) == MHD_YES);
       const bool has_poll =
           (MHD_is_feature_supported(MHD_FEATURE_POLL) == MHD_YES);
-      mhd_flags = MHD_USE_DUAL_STACK;
+      mhd_flags |= MHD_USE_DUAL_STACK;
 
       if (has_epoll)
   // In MHD version 0.9.44 the flag is renamed to
   // MHD_USE_EPOLL_INTERNALLY_LINUX_ONLY. In later versions both
   // are deprecated.
   #if defined(MHD_USE_EPOLL_INTERNALLY)
-        mhd_flags = MHD_USE_EPOLL_INTERNALLY;
+        mhd_flags |= MHD_USE_EPOLL_INTERNALLY;
   #else
-        mhd_flags = MHD_USE_EPOLL_INTERNALLY_LINUX_ONLY;
+        mhd_flags |= MHD_USE_EPOLL_INTERNALLY_LINUX_ONLY | MHD_USE_ITC;
   #endif
       else if (has_poll)
-        mhd_flags = MHD_USE_POLL_INTERNALLY;
+        mhd_flags |= MHD_USE_POLL_INTERNALLY;
         
     } else {
-      mhd_flags = MHD_USE_SELECT_INTERNALLY;
+      mhd_flags |= MHD_USE_SELECT_INTERNALLY;
     }
 
-
     if (this->bindlocalhost) {
-      LOG_GENERAL(INFO, "Start Listening at bind localhost");
+      LOG_GENERAL(INFO, "Start Listening at bind localhost, mhdflag: " << mhd_flags);
       memset(&this->loopback_addr, 0, sizeof(this->loopback_addr));
       loopback_addr.sin_family = AF_INET;
       loopback_addr.sin_port = htons(this->port);
@@ -97,7 +98,7 @@ bool SafeHttpServer::StartListening() {
 
     } else if (!this->path_sslcert.empty() && !this->path_sslkey.empty()) {
       try {
-        LOG_GENERAL(INFO, "Start Listening with ssl cert and key");
+        LOG_GENERAL(INFO, "Start Listening with ssl cert and key, mhdflag: " << mhd_flags);
         SpecificationParser::GetFileContent(this->path_sslcert, this->sslcert);
         SpecificationParser::GetFileContent(this->path_sslkey, this->sslkey);
 
@@ -111,7 +112,7 @@ bool SafeHttpServer::StartListening() {
         return false;
       }
     } else {
-      LOG_GENERAL(INFO, "Start Listening");
+      LOG_GENERAL(INFO, "Start Listening, mhdflag: " << mhd_flags);
       this->daemon = MHD_start_daemon(
           mhd_flags, this->port, NULL, NULL, SafeHttpServer::callback, this,
           MHD_OPTION_THREAD_POOL_SIZE, this->threads, MHD_OPTION_END);
@@ -175,7 +176,6 @@ int SafeHttpServer::callback(void *cls, MHD_Connection *connection, const char *
                          const char *method, const char *version,
                          const char *upload_data, size_t *upload_data_size,
                          void **con_cls) {
-
   (void)version;
   if (*con_cls == NULL) {
     struct mhd_coninfo *client_connection = new mhd_coninfo;

--- a/src/depends/safeserver/safehttpserver.h
+++ b/src/depends/safeserver/safehttpserver.h
@@ -49,7 +49,7 @@ public:
    * @param sslcert - defines the path to a SSL certificate, if this path is !=
    * "", then SSL/HTTPS is used with the given certificate.
    */
-  SafeHttpServer(int port, const std::string &sslcert = "",
+  SafeHttpServer(int port, bool useEpoll = true, const std::string &sslcert = "",
              const std::string &sslkey = "", int threads = 50);
 
   ~SafeHttpServer();
@@ -69,6 +69,7 @@ private:
   int port;
   int threads;
   bool running;
+  bool useEpoll;
   std::string path_sslcert;
   std::string path_sslkey;
   std::string sslcert;

--- a/src/libServer/StakingServer.cpp
+++ b/src/libServer/StakingServer.cpp
@@ -39,6 +39,8 @@ StakingServer::StakingServer(Mediator& mediator,
 }
 
 Json::Value StakingServer::GetRawDSBlock(const string& blockNum) {
+  LOG_MARKER();
+
   if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
   }
@@ -65,6 +67,8 @@ Json::Value StakingServer::GetRawDSBlock(const string& blockNum) {
 }
 
 Json::Value StakingServer::GetRawTxBlock(const string& blockNum) {
+  LOG_MARKER();
+
   if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
   }

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -462,7 +462,8 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     }
 
     if (ENABLE_STAKING_RPC) {
-      m_stakingServerConnector = make_unique<SafeHttpServer>(STAKING_RPC_PORT);
+      m_stakingServerConnector =
+          make_unique<SafeHttpServer>(STAKING_RPC_PORT, false);
       m_stakingServer =
           make_shared<StakingServer>(m_mediator, *m_stakingServerConnector);
 


### PR DESCRIPTION
## Description
Temporary fix for port 4501 CLOSE_WAIT stall on EPOLL.
In this PR, port 4201 and isolated server will still use EPOLL
Port 4501 will use SELECT

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
