### PR TITLE
[master] temp fix for CLOSE_WAIT stall on epoll in port 4501

### DIFF
--- a/src/depends/safeserver/safehttpserver.h
+++ b/src/depends/safeserver/safehttpserver.h
@@ -49,7 +49,7 @@ public:
    * @param sslcert - defines the path to a SSL certificate, if this path is !=
    * "", then SSL/HTTPS is used with the given certificate.
    */
-  SafeHttpServer(int port, const std::string &sslcert = "",
+  SafeHttpServer(int port, bool useEpoll = true, const std::string &sslcert = "",
              const std::string &sslkey = "", int threads = 50);
 
   ~SafeHttpServer();
@@ -69,6 +69,7 @@ private:
   int port;
   int threads;
   bool running;
+  bool useEpoll;
   std::string path_sslcert;
   std::string path_sslkey;
   std::string sslcert;

--- a/src/libServer/StakingServer.cpp
+++ b/src/libServer/StakingServer.cpp
@@ -39,6 +39,8 @@ StakingServer::StakingServer(Mediator& mediator,
 }
 
 Json::Value StakingServer::GetRawDSBlock(const string& blockNum) {
+  LOG_MARKER();
+
   if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
   }
@@ -65,6 +67,8 @@ Json::Value StakingServer::GetRawDSBlock(const string& blockNum) {
 }
 
 Json::Value StakingServer::GetRawTxBlock(const string& blockNum) {
+  LOG_MARKER();
+
   if (!LOOKUP_NODE_MODE) {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
   }

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -462,7 +462,8 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     }
 
     if (ENABLE_STAKING_RPC) {
-      m_stakingServerConnector = make_unique<SafeHttpServer>(STAKING_RPC_PORT);
+      m_stakingServerConnector =
+          make_unique<SafeHttpServer>(STAKING_RPC_PORT, false);
       m_stakingServer =
           make_shared<StakingServer>(m_mediator, *m_stakingServerConnector);
 


### PR DESCRIPTION
## Description
Temporary fix via putting port 4501 to use SELECT, and other ports to use EPOLL, due to CLOSE_WAIT on port 4501

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
