### PR TITLE
[release-8.1] Add extra txn distribution time before FB consensus when no shard

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -593,12 +593,15 @@ void DirectoryService::StartFirstTxEpoch() {
       P2PComm::GetInstance().InitializeRumorManager(peers, pubKeys);
     }
     if (m_mediator.m_node->m_myshardId == 0) {
-      LOG_GENERAL(
-          INFO,
-          "No other shards. So no other microblocks expected to be received");
-      m_stopRecvNewMBSubmission = true;
+      auto func = [this]() mutable -> void {
+        LOG_GENERAL(
+            INFO,
+            "No other shards. So no other microblocks expected to be received");
+        m_stopRecvNewMBSubmission = true;
 
-      RunConsensusOnFinalBlock();
+        RunConsensusOnFinalBlock();
+      };
+      DetachedFunction(1, func);
     } else {
       auto func = [this]() mutable -> void {
         // Check for state change. If it get stuck at microblock submission for

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -237,7 +237,8 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSPrimary() {
   // No other shards exists, then allow additional time for txns distribution.
   if (m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
       m_mediator.m_node->m_myshardId == 0 && !m_mediator.GetIsVacuousEpoch()) {
-    std::this_thread::sleep_for(chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS));
+    std::this_thread::sleep_for(chrono::milliseconds(
+        EXTRA_TX_DISTRIBUTE_TIME_IN_MS + LOOKUP_DELAY_SEND_TXNPACKET_IN_MS));
   }
 
   m_mediator.m_node->m_txn_distribute_window_open = false;
@@ -1205,7 +1206,8 @@ bool DirectoryService::RunConsensusOnFinalBlockWhenDSBackup() {
   // No other shards exists, then allow additional time for txns distribution.
   if (m_mediator.m_ds->m_mode != DirectoryService::Mode::IDLE &&
       m_mediator.m_node->m_myshardId == 0 && !m_mediator.GetIsVacuousEpoch()) {
-    std::this_thread::sleep_for(chrono::milliseconds(TX_DISTRIBUTE_TIME_IN_MS));
+    std::this_thread::sleep_for(chrono::milliseconds(
+        EXTRA_TX_DISTRIBUTE_TIME_IN_MS + LOOKUP_DELAY_SEND_TXNPACKET_IN_MS));
   }
 
   m_mediator.m_node->m_txn_distribute_window_open = false;


### PR DESCRIPTION
## Description
Fix issue:
https://github.com/Zilliqa/Issues/issues/743
https://github.com/Zilliqa/Issues/issues/744

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
