### PR TITLE
[master] Remove partialRetrieve from RetrieveDSBlocks

### DIFF
--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1837,7 +1837,7 @@ bool Lookup::ProcessGetDSBlockFromSeed(const bytes& message,
 // lowBlockNum = 0 => lowBlockNum set to 1
 // highBlockNum = 0 => Latest block number
 void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
-                              uint64_t& highBlockNum, bool partialRetrieve) {
+                              uint64_t& highBlockNum) {
   lock_guard<mutex> g(m_mediator.m_node->m_mutexDSBlock);
 
   uint64_t curBlockNum =
@@ -1849,27 +1849,19 @@ void Lookup::RetrieveDSBlocks(vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
     return;
   }
 
-  uint64_t minBlockNum = (curBlockNum > MEAN_GAS_PRICE_DS_NUM)
-                             ? (curBlockNum - MEAN_GAS_PRICE_DS_NUM)
-                             : 1;
-
-  if (lowBlockNum == 1) {
-    lowBlockNum = minBlockNum;
-  } else if (lowBlockNum == 0) {
-    // give all the blocks in the ds blockchain
-    lowBlockNum = 1;
-  }
-
-  lowBlockNum = partialRetrieve ? max(minBlockNum, lowBlockNum)
-                                : min(minBlockNum, lowBlockNum);
-
   if (highBlockNum == 0) {
     highBlockNum = curBlockNum;
   }
 
+  if (highBlockNum < lowBlockNum) {
+    LOG_GENERAL(WARNING, "Request lowBlockNum: "
+                             << lowBlockNum << " is higher than highBlockNum: "
+                             << highBlockNum);
+    return;
+  }
+
   uint64_t diff = 0;
-  if (!partialRetrieve &&
-      SafeMath<uint64_t>::sub(highBlockNum, lowBlockNum, diff)) {
+  if (SafeMath<uint64_t>::sub(highBlockNum, lowBlockNum, diff)) {
     if (diff >= FETCH_DS_BLOCK_LIMIT) {
       highBlockNum = lowBlockNum + FETCH_DS_BLOCK_LIMIT - 1;
       LOG_GENERAL(INFO, "Requested "
@@ -5736,7 +5728,7 @@ bool Lookup::ProcessVCGetLatestDSTxBlockFromSeed(
                 << listenPort);
 
   vector<DSBlock> dsBlocks;
-  RetrieveDSBlocks(dsBlocks, dsLowBlockNum, dsHighBlockNum, true);
+  RetrieveDSBlocks(dsBlocks, dsLowBlockNum, dsHighBlockNum);
 
   vector<TxBlock> txBlocks;
   RetrieveTxBlocks(txBlocks, txLowBlockNum, txHighBlockNum);

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -160,7 +160,7 @@ class Lookup : public Executable {
   bytes ComposeGetOfflineLookupNodes();
 
   void RetrieveDSBlocks(std::vector<DSBlock>& dsBlocks, uint64_t& lowBlockNum,
-                        uint64_t& highBlockNum, bool partialRetrieve = false);
+                        uint64_t& highBlockNum);
   void RetrieveTxBlocks(std::vector<TxBlock>& txBlocks, uint64_t& lowBlockNum,
                         uint64_t& highBlockNum);
   void GetInitialBlocksAndShardingStructure();


### PR DESCRIPTION
## Description
Removing partialRetrieve variable and other code that won't affect the lowBlockNum calculation

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [x] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
