### PR TITLE
[release-8.1] Fix for CLOSE_WAIT on EPOLL

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -185,6 +185,10 @@
         <PENDING_TXN_QUERY_NUM_EPOCHS>3</PENDING_TXN_QUERY_NUM_EPOCHS>
         <PENDING_TXN_QUERY_MAX_RESULTS>1000</PENDING_TXN_QUERY_MAX_RESULTS>
         <CONNECTION_IO_USE_EPOLL>true</CONNECTION_IO_USE_EPOLL>
+        <!-- Timeout in seconds for ANY connection to safehttpserver port, 0 means no timeout-->
+        <CONNECTION_ALL_TIMEOUT>1</CONNECTION_ALL_TIMEOUT>
+        <!-- Timeout in seconds for ONLY connection that reach our callback function, 0 means no timeout-->
+        <CONNECTION_CALLBACK_TIMEOUT>0</CONNECTION_CALLBACK_TIMEOUT>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -184,6 +184,10 @@
         <PENDING_TXN_QUERY_NUM_EPOCHS>3</PENDING_TXN_QUERY_NUM_EPOCHS>
         <PENDING_TXN_QUERY_MAX_RESULTS>1000</PENDING_TXN_QUERY_MAX_RESULTS>
         <CONNECTION_IO_USE_EPOLL>true</CONNECTION_IO_USE_EPOLL>
+        <!-- Timeout in seconds for ANY connection to safehttpserver port, 0 means no timeout-->
+        <CONNECTION_ALL_TIMEOUT>1</CONNECTION_ALL_TIMEOUT>
+        <!-- Timeout in seconds for ONLY connection that reach our callback function, 0 means no timeout-->
+        <CONNECTION_CALLBACK_TIMEOUT>0</CONNECTION_CALLBACK_TIMEOUT>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -408,6 +408,10 @@ const unsigned int PENDING_TXN_QUERY_MAX_RESULTS{
     ReadConstantNumeric("PENDING_TXN_QUERY_MAX_RESULTS", "node.jsonrpc.")};
 const bool CONNECTION_IO_USE_EPOLL{
     ReadConstantString("CONNECTION_IO_USE_EPOLL", "node.jsonrpc.") == "true"};
+const unsigned int CONNECTION_ALL_TIMEOUT{
+    ReadConstantNumeric("CONNECTION_ALL_TIMEOUT", "node.jsonrpc.")};
+const unsigned int CONNECTION_CALLBACK_TIMEOUT{
+    ReadConstantNumeric("CONNECTION_CALLBACK_TIMEOUT", "node.jsonrpc.")};
 
 // Network composition constants
 const unsigned int COMM_SIZE{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -316,6 +316,8 @@ extern const unsigned int NUM_TXNS_PER_PAGE;
 extern const unsigned int PENDING_TXN_QUERY_NUM_EPOCHS;
 extern const unsigned int PENDING_TXN_QUERY_MAX_RESULTS;
 extern const bool CONNECTION_IO_USE_EPOLL;
+extern const unsigned int CONNECTION_ALL_TIMEOUT;
+extern const unsigned int CONNECTION_CALLBACK_TIMEOUT;
 
 // Network composition constants
 extern const unsigned int COMM_SIZE;

--- a/src/depends/safeserver/safehttpserver.h
+++ b/src/depends/safeserver/safehttpserver.h
@@ -49,7 +49,7 @@ public:
    * @param sslcert - defines the path to a SSL certificate, if this path is !=
    * "", then SSL/HTTPS is used with the given certificate.
    */
-  SafeHttpServer(int port, bool useEpoll = true, const std::string &sslcert = "",
+  SafeHttpServer(int port, const std::string &sslcert = "",
              const std::string &sslkey = "", int threads = 50);
 
   ~SafeHttpServer();
@@ -69,7 +69,6 @@ private:
   int port;
   int threads;
   bool running;
-  bool useEpoll;
   std::string path_sslcert;
   std::string path_sslkey;
   std::string sslcert;
@@ -84,6 +83,12 @@ private:
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls);
+
+  static void
+  notify_connection_callback(void *cls,
+                            struct MHD_Connection *connection,
+                            void **socket_context,
+                            enum MHD_ConnectionNotificationCode code);
 
   IClientConnectionHandler *GetHandler(const std::string &url);
 };

--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -462,8 +462,7 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     }
 
     if (ENABLE_STAKING_RPC) {
-      m_stakingServerConnector =
-          make_unique<SafeHttpServer>(STAKING_RPC_PORT, false);
+      m_stakingServerConnector = make_unique<SafeHttpServer>(STAKING_RPC_PORT);
       m_stakingServer =
           make_shared<StakingServer>(m_mediator, *m_stakingServerConnector);
 


### PR DESCRIPTION
## Description
Fixing the CLOSE_WAIT issue by adding 2 timeout
1st timeout is at notify_connection_callback for all connections passing by (Usually set to 1 second)
2nd timeout is at SafeHttpServer::callback where it look for our callback methods (Here we set it back to unlimited)

This filter out the CLOSE_WAIT connections, which will get eliminated in 1 second.

If we were to turn off the timeout feature, we can just set all timeout in constant to zero. (Zero = No timeout limit)

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
