### PR TITLE
[master] Improve node startup logging information

### DIFF
--- a/src/libZilliqa/Zilliqa.cpp
+++ b/src/libZilliqa/Zilliqa.cpp
@@ -148,6 +148,38 @@ Zilliqa::Zilliqa(const PairOfKey& key, const Peer& peer, SyncType syncType,
     LOG_STATE("[IDENT] " << string(key.second).substr(0, 8));
   }
 
+  // Logging useful information for seed nodes
+  if (ARCHIVAL_LOOKUP && LOOKUP_NODE_MODE) {
+    std::string startupInfo{"Node startup Information\n"};
+
+    // 3 mode: IP/Key/P2P Seed Key (ENABLE_SEED_TO_SEED_COMMUNICATION)
+    startupInfo += "Whitelisting mode   = ";
+    startupInfo += multiplierSyncMode
+                       ? "IP whitelisting mode\n"
+                       : ENABLE_SEED_TO_SEED_COMMUNICATION
+                             ? "Public Key (P2P Seed) whitelisting mode\n"
+                             : "Public Key only whitelisting mode\n";
+    // IP Address
+    startupInfo += "IP Address          = ";
+    startupInfo += peer.GetPrintableIPAddress();
+    startupInfo += "\n";
+
+    // External Seed Public Key
+    startupInfo += "ExtSeed Public Key  = ";
+    startupInfo += multiplierSyncMode ? "N/A" : std::string{extSeedKey.second};
+    startupInfo += "\n";
+
+    // Listening Port
+    startupInfo += "Listening Port      = ";
+    startupInfo += std::to_string(peer.GetListenPortHost());
+    startupInfo += "\n";
+
+    // Staking status
+    startupInfo += "Staking RPC status  = ";
+    startupInfo += ENABLE_STAKING_RPC ? "Enabled" : "Disabled";
+    LOG_GENERAL(INFO, startupInfo);
+  }
+
   // Launch the thread that reads messages from the queue
   auto funcCheckMsgQueue = [this]() mutable -> void {
     pair<bytes, std::pair<Peer, const unsigned char>>* message = NULL;


### PR DESCRIPTION
## Description
Displays the following information:
- Whitelisting mode
- IP Address
- Public Key
- Listening Port
- Staking RPC Status

Refer to this issue for more details : https://github.com/Zilliqa/Issues/issues/741

Example Output:
```
$ ./build/bin/zilliqa --privk B4DB39E759A483387B6ED166A88B020********************************* --pubk 02BB82C9DDD949375907E5B08AC22CA1F********************************* --address 127.0.0.1 --port 33133 --synctype 6 -o --logpath ./tmp/

[46568][21-09-09T19:09:57.178][liqa/Zilliqa.cpp:185][Zilliqa             ] Node startup Information
Whitelisting mode   = IP whitelisting mode
IP Address          = 127.0.0.1
ExtSeed Public Key  = N/A
Listening Port      = 33133
Staking RPC status  = Disabled

$ ./build/bin/zilliqa --privk B4DB39E759A483387B6ED166A88B020********************************* --pubk 02BB82C9DDD949375907E5B08AC22CA1F********************************* --address 127.0.0.1 --port 33133 --synctype 6 -o -e 1342F469FCEC36EB942825E097B93CD********************************* -m --logpath ./tmp/

[ 9094][21-09-10T04:56:51.773][liqa/Zilliqa.cpp:185][Zilliqa             ] Node startup Information
Whitelisting mode   = Public Key only whitelisting mode
IP Address          = 127.0.0.1
ExtSeed Public Key  = 0x02CDDA9C5C40F6DF853B50E2CE3EBF7CB*********************************
Listening Port      = 33133
Staking RPC status  = Disabled

# With `ENABLE_SEED_TO_SEED_COMMUNICATION` enabled
$ ./build/bin/zilliqa --privk B4DB39E759A483387B6ED166A88B020********************************* --pubk 02BB82C9DDD949375907E5B08AC22CA1F********************************* --address 127.0.0.1 --port 33133 --synctype 6 -o -e 1342F469FCEC36EB942825E097B93CD********************************* -m --logpath ./tmp/

[10113][21-09-10T04:58:38.466][liqa/Zilliqa.cpp:185][Zilliqa             ] Node startup Information
Whitelisting mode   = Public Key (P2P Seed) whitelisting mode
IP Address          = 127.0.0.1
ExtSeed Public Key  = 0x02CDDA9C5C40F6DF853B50E2CE3EBF7CB4CD66B8339685306B8A8A0140EE518576
Listening Port      = 33133
Staking RPC status  = Disabled
```
## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
- [ ] small-scale cloud test
