### PR TITLE
[master] Set timeout at start daemon for all connections

### DIFF
--- a/src/depends/safeserver/safehttpserver.cpp
+++ b/src/depends/safeserver/safehttpserver.cpp
@@ -116,7 +116,7 @@ bool SafeHttpServer::StartListening() {
       this->daemon = MHD_start_daemon(
         mhd_flags, this->port, NULL, NULL, SafeHttpServer::callback, this,
         MHD_OPTION_THREAD_POOL_SIZE, this->threads,
-        MHD_OPTION_NOTIFY_CONNECTION, &SafeHttpServer::notify_connection_callback, NULL,
+        MHD_OPTION_CONNECTION_TIMEOUT, CONNECTION_ALL_TIMEOUT,
         MHD_OPTION_END);
     }
     if (this->daemon != NULL)
@@ -227,27 +227,6 @@ int SafeHttpServer::callback(void *cls, MHD_Connection *connection, const char *
   *con_cls = NULL;
 
   return MHD_YES;
-}
-
-void SafeHttpServer::notify_connection_callback(void* cls,
-                      struct MHD_Connection* connection,
-                      void** socket_context,
-                      enum MHD_ConnectionNotificationCode code)
-{
-  (void) cls;
-  (void) socket_context;
-
-  switch (code)
-  {
-  case MHD_CONNECTION_NOTIFY_STARTED: {    
-    MHD_set_connection_option(connection, MHD_CONNECTION_OPTION_TIMEOUT, CONNECTION_ALL_TIMEOUT);
-    break;
-  }
-  case MHD_CONNECTION_NOTIFY_CLOSED:
-    break;
-  default:
-    break;
-  }
 }
 
 SafeHttpServer &SafeHttpServer::BindLocalhost() {

--- a/src/depends/safeserver/safehttpserver.h
+++ b/src/depends/safeserver/safehttpserver.h
@@ -84,12 +84,6 @@ private:
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls);
 
-  static void
-  notify_connection_callback(void *cls,
-                            struct MHD_Connection *connection,
-                            void **socket_context,
-                            enum MHD_ConnectionNotificationCode code);
-
   IClientConnectionHandler *GetHandler(const std::string &url);
 };
 


### PR DESCRIPTION
## Description
Putting the timeout for all connections at start daemon.
In case where connections may not reach the notify_connection function.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
