### PR TITLE
[master] calculate txblockrate over last 50 txblks stored in memory

### DIFF
--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1272,32 +1272,52 @@ double LookupServer::GetTxBlockRate() {
     throw JsonRpcException(RPC_INVALID_REQUEST, "Sent to a non-lookup");
   }
 
-  string numTxblockStr = to_string(m_mediator.m_txBlockChain.GetBlockCount());
-  boost::multiprecision::cpp_dec_float_50 numTx(numTxblockStr);
+  auto lastBlock = m_mediator.m_txBlockChain.GetLastBlock();
+  uint64_t refBlockNum = lastBlock.GetHeader().GetBlockNum();
 
-  if (m_StartTimeTx == 0) {
-    try {
-      // Reference Time chosen to be first block's timestamp
-      TxBlock txb = m_mediator.m_txBlockChain.GetBlock(1);
-      m_StartTimeTx = txb.GetTimestamp();
-    } catch (const char* msg) {
-      if (string(msg) == "Blocknumber Absent") {
-        LOG_GENERAL(INFO, "No TxBlock has been mined yet");
-      }
+  uint64_t refTimeTx = 0;
+  uint64_t numTxBlocks = BLOCKCHAIN_SIZE;
+
+  if (refBlockNum <= BLOCKCHAIN_SIZE) {
+    if (refBlockNum <= 1) {
+      LOG_GENERAL(INFO, "Not enough blocks for information");
       return 0;
+    } else {
+      // In case there are less than BLOCKCHAIN_SIZE blocks in blockchain,
+      // blocknum 1 can be ref block;
+      refBlockNum = 1;
+      numTxBlocks = lastBlock.GetHeader().GetBlockNum();  // <= BLOCKCHAIN_SIZE
     }
+  } else {
+    refBlockNum = refBlockNum - BLOCKCHAIN_SIZE + 1;
   }
-  uint64_t TimeDiff =
-      m_mediator.m_txBlockChain.GetLastBlock().GetTimestamp() - m_StartTimeTx;
 
-  if (TimeDiff == 0) {
-    LOG_GENERAL(INFO, "Wait till the second block");
+  try {
+    TxBlock tx = m_mediator.m_txBlockChain.GetBlock(refBlockNum);
+    refTimeTx = tx.GetTimestamp();
+  } catch (const char* msg) {
+    if (string(msg) == "Blocknumber Absent") {
+      LOG_GENERAL(INFO, "No TxBlock has been mined yet");
+    }
     return 0;
   }
+
+  uint64_t TimeDiff = lastBlock.GetTimestamp() - refTimeTx;
+
+  if (TimeDiff == 0 || refTimeTx == 0) {
+    // something went wrong
+    LOG_GENERAL(INFO, "TimeDiff or refTimeTx = 0 \n TimeDiff:"
+                          << TimeDiff << " refTimeTx:" << refTimeTx);
+    return 0;
+  }
+
   // To convert from microSeconds to seconds
-  numTx = numTx * 1000000;
+  numTxBlocks = numTxBlocks * 1000000;
   boost::multiprecision::cpp_dec_float_50 TimeDiffFloat(to_string(TimeDiff));
-  boost::multiprecision::cpp_dec_float_50 ans = numTx / TimeDiffFloat;
+  boost::multiprecision::cpp_dec_float_50 numTxBlocksFloat(
+      to_string(numTxBlocks));
+  boost::multiprecision::cpp_dec_float_50 ans =
+      numTxBlocksFloat / TimeDiffFloat;
   return ans.convert_to<double>();
 }
 


### PR DESCRIPTION
## Description
`GetTxBlockRate` now perform calculation only based on last 50 txblocks. Previously, it was averaged out starting from genesis block.
Reason to keep it **50** is so that its lightweight fetching from memory otherwise would result in query to persistence for range older than 50.

**Without fix:**
```
$  curl -d '{      "id": "1",      "jsonrpc": "2.0",      "method": "GetTxBlockRate",      "params": [""]  }' -H "Content-Type: application/json" -X POST "https://sandip-gettxblkrate-l2api.dev.z7a.xyz/"
{"id":"1","jsonrpc":"2.0","result":0.017568050773711118}
```

**With fix:**
```
$  curl -d '{      "id": "1",      "jsonrpc": "2.0",      "method": "GetTxBlockRate",      "params": [""]  }' -H "Content-Type: application/json" -X POST "localhost:4201"
{"id":"1","jsonrpc":"2.0","result":0.033478276078891596}
```

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
