### PR TITLE
[master] Add shared_lock for GetBalance

### DIFF
--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -88,17 +88,17 @@ bool Validator::CheckCreatedTransaction(const Transaction& tx,
       error_code = TxnStatus::INVALID_FROM_ACCOUNT;
       return false;
     }
-  }
 
-  // Check if transaction amount is valid
-  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
-    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "Insufficient funds in source account!"
-                  << " From Account  = 0x" << fromAddr << " Balance = "
-                  << AccountStore::GetInstance().GetBalance(fromAddr)
-                  << " Debit Amount = " << tx.GetAmount());
-    error_code = TxnStatus::INSUFFICIENT_BALANCE;
-    return false;
+    // Check if transaction amount is valid
+    if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
+      LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+                "Insufficient funds in source account!"
+                    << " From Account  = 0x" << fromAddr << " Balance = "
+                    << AccountStore::GetInstance().GetBalance(fromAddr)
+                    << " Debit Amount = " << tx.GetAmount());
+      error_code = TxnStatus::INSUFFICIENT_BALANCE;
+      return false;
+    }
   }
 
   receipt.SetEpochNum(m_mediator.m_currentEpochNum);
@@ -231,17 +231,17 @@ bool Validator::CheckCreatedTransactionFromLookup(const Transaction& tx,
       error_code = TxnStatus::INVALID_FROM_ACCOUNT;
       return false;
     }
-  }
 
-  // Check if transaction amount is valid
-  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
-    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "Insufficient funds in source account!"
-                  << " From Account  = 0x" << fromAddr << " Balance = "
-                  << AccountStore::GetInstance().GetBalance(fromAddr)
-                  << " Debit Amount = " << tx.GetAmount());
-    error_code = TxnStatus::INSUFFICIENT_BALANCE;
-    return false;
+    // Check if transaction amount is valid
+    if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
+      LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+                "Insufficient funds in source account!"
+                    << " From Account  = 0x" << fromAddr << " Balance = "
+                    << AccountStore::GetInstance().GetBalance(fromAddr)
+                    << " Debit Amount = " << tx.GetAmount());
+      error_code = TxnStatus::INSUFFICIENT_BALANCE;
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
PR for issue https://github.com/Zilliqa/Issues/issues/749

Prevent race condition for accessing `GetBalance(fromAccount)` when the underlying map is accessed concurrently

Added `shared_lock` when getting balance while checking for transaction from lookup

`testnet` ran for 1600 epochs and there is no transactions failure and viewchange

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
