### PR TITLE
[master] Prioritize DeserializeDelta call for AccountStore

### DIFF
--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -259,6 +259,9 @@ Json::Value IsolatedServer::CreateTransaction(const Json::Value& _json) {
     {
       shared_lock<shared_timed_mutex> lock(
           AccountStore::GetInstance().GetPrimaryMutex());
+      AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+        return AccountStore::GetInstance().GetPrimaryWriteAccess();
+      });
 
       const Account* sender = AccountStore::GetInstance().GetAccount(fromAddr);
 
@@ -303,6 +306,10 @@ Json::Value IsolatedServer::CreateTransaction(const Json::Value& _json) {
         {
           shared_lock<shared_timed_mutex> lock(
               AccountStore::GetInstance().GetPrimaryMutex());
+          AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(
+              lock, [] {
+                return AccountStore::GetInstance().GetPrimaryWriteAccess();
+              });
 
           const Account* account =
               AccountStore::GetInstance().GetAccount(tx.GetToAddr());

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -561,6 +561,9 @@ Json::Value LookupServer::CreateTransaction(
     {
       shared_lock<shared_timed_mutex> lock(
           AccountStore::GetInstance().GetPrimaryMutex());
+      AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+        return AccountStore::GetInstance().GetPrimaryWriteAccess();
+      });
 
       const Account* sender =
           AccountStore::GetInstance().GetAccount(fromAddr, true);
@@ -854,8 +857,12 @@ Json::Value LookupServer::GetBalance(const string& address) {
 
   try {
     Address addr{ToBase16AddrHelper(address)};
+
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
 
     const Account* account = AccountStore::GetInstance().GetAccount(addr, true);
 
@@ -897,8 +904,12 @@ Json::Value LookupServer::GetSmartContractState(const string& address,
 
   try {
     Address addr{ToBase16AddrHelper(address)};
+
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
 
     const Account* account = AccountStore::GetInstance().GetAccount(addr, true);
 
@@ -941,6 +952,9 @@ Json::Value LookupServer::GetSmartContractInit(const string& address) {
     {
       shared_lock<shared_timed_mutex> lock(
           AccountStore::GetInstance().GetPrimaryMutex());
+      AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+        return AccountStore::GetInstance().GetPrimaryWriteAccess();
+      });
 
       const Account* account =
           AccountStore::GetInstance().GetAccount(addr, true);
@@ -981,8 +995,12 @@ Json::Value LookupServer::GetSmartContractCode(const string& address) {
 
   try {
     Address addr{ToBase16AddrHelper(address)};
+
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
 
     const Account* account = AccountStore::GetInstance().GetAccount(addr, true);
 
@@ -1020,6 +1038,9 @@ Json::Value LookupServer::GetSmartContracts(const string& address) {
     {
       shared_lock<shared_timed_mutex> lock(
           AccountStore::GetInstance().GetPrimaryMutex());
+      AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+        return AccountStore::GetInstance().GetPrimaryWriteAccess();
+      });
 
       const Account* account =
           AccountStore::GetInstance().GetAccount(addr, true);
@@ -1043,6 +1064,10 @@ Json::Value LookupServer::GetSmartContracts(const string& address) {
       {
         shared_lock<shared_timed_mutex> lock(
             AccountStore::GetInstance().GetPrimaryMutex());
+        AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+          return AccountStore::GetInstance().GetPrimaryWriteAccess();
+        });
+
         const Account* contractAccount =
             AccountStore::GetInstance().GetAccount(contractAddr, true);
 
@@ -1342,6 +1367,10 @@ string LookupServer::GetTotalCoinSupply() {
   {
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
+
     balance =
         AccountStore::GetInstance().GetAccount(NullAddress, true)->GetBalance();
   }

--- a/src/libServer/WebsocketServer.cpp
+++ b/src/libServer/WebsocketServer.cpp
@@ -246,6 +246,10 @@ void WebsocketServer::on_message(const connection_hdl& hdl,
           {
             shared_lock<shared_timed_mutex> lock(
                 AccountStore::GetInstance().GetPrimaryMutex());
+            AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(
+                lock, [] {
+                  return AccountStore::GetInstance().GetPrimaryWriteAccess();
+                });
             for (const auto& address : j_query["addresses"]) {
               try {
                 const auto& addr_str = address.asString();

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -80,6 +80,9 @@ bool Validator::CheckCreatedTransaction(const Transaction& tx,
   {
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
     Account* account = AccountStore::GetInstance().GetAccount(fromAddr);
     if (account == nullptr) {
       LOG_GENERAL(WARNING, "fromAddr not found: " << fromAddr
@@ -223,6 +226,9 @@ bool Validator::CheckCreatedTransactionFromLookup(const Transaction& tx,
   {
     shared_lock<shared_timed_mutex> lock(
         AccountStore::GetInstance().GetPrimaryMutex());
+    AccountStore::GetInstance().GetPrimaryWriteAccessCond().wait(lock, [] {
+      return AccountStore::GetInstance().GetPrimaryWriteAccess();
+    });
     Account* account = AccountStore::GetInstance().GetAccount(fromAddr);
     if (account == nullptr) {
       LOG_GENERAL(WARNING, "fromAddr not found: " << fromAddr


### PR DESCRIPTION
Prioritize `AccountStore::DeserializeDelta` call and all readers updated to wait for the lock if there is any `DeserializeDelta` calls

Issue: https://github.com/Zilliqa/Issues/issues/752

We can now prioritize "write" calls with this mechanism implemented in this PR for `AccountStore`
Currently is there is any calls for `DeserializeDelta`, all read calls will be halted until it gets hold of the mutex. All write calls will still be contending for the mutex.

Below are some performance counters with the following code of 100 requests per second for 200 seconds:

```go
package main

import (
	"encoding/json"
	"fmt"
	"time"

	"github.com/Zilliqa/gozilliqa-sdk/provider"
)

var ADR0 = "17444c65ed1b02b508d8343a1e8d943c0102f91a"
var ADR1 = "2773ddfb707749717354fbb83176093112670483"
var ADR2 = "77878ad15e3fd847e29c5d848eca474f24fb1091"
var ADR3 = "9a476431e012a85041d4ab8ff986bd8446482825"

var API0 = "https://alv-priorm7-api.dev.z7a.xyz/"
var API1 = "https://alv-priorm8-api.dev.z7a.xyz/"
var API2 = "https://alv-priorm9-api.dev.z7a.xyz/"
var API3 = "https://alv-priorm10-api.dev.z7a.xyz/"

// var API = "https://api.zilliqa.com/"

func TestGetBalance(add string, p *provider.Provider) {
	response, err := p.GetBalance(add)
	if err != nil {
		fmt.Println("GetBalance failed")
		return
	}
	result, err := json.Marshal(response)
	if err != nil {
		fmt.Println("GetBalance marshalling failed")
		return
	}
	fmt.Println(string(result))
}

func TestGetSmartContractInit(add string, p *provider.Provider) {
	response, err := p.GetSmartContractInit(add)
	if err != nil {
		fmt.Println("GetSmartContractInit failed")
		return
	}
	result, err := json.Marshal(response)
	if err != nil {
		fmt.Println("GetSmartContractInit marshalling failed")
		return
	}
	fmt.Println(string(result))
}

func TestGetSmartContractState(add string, p *provider.Provider) {
	response, err := p.GetSmartContractState(add)
	if err != nil {
		fmt.Println("GetSmartContractState failed")
		return
	}
	result, err := json.Marshal(response)
	if err != nil {
		fmt.Println("GetSmartContractState marshalling failed")
		return
	}
	fmt.Println(string(result))
}

func TestGetSmartContractCode(add string, p *provider.Provider) {
	response, err := p.GetSmartContractCode(add)
	if err != nil {
		fmt.Println("GetSmartContractCode failed")
		return
	}
	result, err := json.Marshal(response)
	if err != nil {
		fmt.Println("GetSmartContractCode marshalling failed")
		return
	}
	fmt.Println(string(result))
}

func TestGetTotalCoinSupply(p *provider.Provider) {
	response, err := p.GetTotalCoinSupply()
	if err != nil {
		fmt.Println("GetTotalCoinSupply failed")
		return
	}
	result, err := json.Marshal(response)
	if err != nil {
		fmt.Println("GetTotalCoinSupply marshalling failed")
		return
	}
	fmt.Println(string(result))
}

func main() {
	// p0 := provider.NewProvider(API0)
	// p1 := provider.NewProvider(API1)
	// p2 := provider.NewProvider(API2)
	p3 := provider.NewProvider(API3)

	r := 200
	for x := 0; x < r; x++ {
		fmt.Printf("Round %d\n", x)
		for i := 0; i < 25; i++ {
			// go TestGetBalance(ADR0, p0)
			// go TestGetBalance(ADR1, p1)
			// go TestGetBalance(ADR2, p2)
			go TestGetBalance(ADR3, p3)

			// go TestGetSmartContractInit(ADR0, p0)
			// go TestGetSmartContractInit(ADR1, p1)
			// go TestGetSmartContractInit(ADR2, p2)
			go TestGetSmartContractInit(ADR3, p3)

			// go TestGetSmartContractState(ADR0, p0)
			// go TestGetSmartContractState(ADR1, p1)
			// go TestGetSmartContractState(ADR2, p2)
			go TestGetSmartContractState(ADR3, p3)

			// go TestGetTotalCoinSupply(p0)
			// go TestGetTotalCoinSupply(p1)
			// go TestGetTotalCoinSupply(p2)
			go TestGetTotalCoinSupply(p3)
		}
		time.Sleep(1 * time.Second)
	}

	fmt.Printf("Done %d rounds\n", r)
}
```

Usage of `atomic<int>`:

- Without `atomic<int>` only read calls
```
GetSmartContractState time spent: 2.04e-06s
GetSmartContractState min   time spent: 7.29e-07s
GetSmartContractState max   time spent: 0.00482894s
GetSmartContractState total time spent: 0.0382569s

GetSmartContractInit time spent: 8.29e-07s
GetSmartContractInit min   time spent: 7.75e-07s
GetSmartContractInit max   time spent: 0.00466694s
GetSmartContractInit total time spent: 0.0365533s

GetBalance time spent: 8.55e-07s
GetBalance min   time spent: 7.29e-07s
GetBalance max   time spent: 0.00664215s
GetBalance total time spent: 0.0329086s

GetTotalCoinSupply time spent: 1.698e-06s
GetTotalCoinSupply min   time spent: 7.68e-07s
GetTotalCoinSupply max   time spent: 0.0152756s
GetTotalCoinSupply total time spent: 0.0513596s
```

- With 'atomic<int>`  only read calls

```
GetSmartContractState time spent: 9.7e-07s
GetSmartContractState min   time spent: 7.92e-07s
GetSmartContractState max   time spent: 0.024221s
GetSmartContractState total time spent: 0.103878s

GetSmartContractInit time spent: 2.39e-06s
GetSmartContractInit min   time spent: 7.42e-07s
GetSmartContractInit max   time spent: 0.0242975s
GetSmartContractInit total time spent: 0.182509s

GetBalance time spent: 2.242e-06s
GetBalance min   time spent: 7.29e-07s
GetBalance max   time spent: 0.0259305s
GetBalance total time spent: 0.0763497s

GetTotalCoinSupply time spent: 1.061e-06s
GetTotalCoinSupply min   time spent: 8.04e-07s
GetTotalCoinSupply max   time spent: 0.0225439s
GetTotalCoinSupply total time spent: 0.0880909s
```

- With `atomic<int>` with both read and write calls (GetSmartContract* are emulated as write calls)

```
GetSmartContractInit time spent: 1.367e-06s
GetSmartContractInit min   time spent: 7.93e-07s
GetSmartContractInit max   time spent: 0.00465036s
GetSmartContractInit total time spent: 0.328436s

GetBalance min   time spent: 7.83e-07s
GetBalance max   time spent: 0.146925s
GetBalance total time spent: 0.290425s

GetTotalCoinSupply time spent: 1.654e-06s
GetTotalCoinSupply min   time spent: 7.01e-07s
GetTotalCoinSupply max   time spent: 0.147356s
GetTotalCoinSupply total time spent: 0.29106s
```

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
