### PR TITLE
[master] Fix Scilla IPC tests. Add BCInfo provider

### DIFF
--- a/src/libServer/ScillaIPCServer.cpp
+++ b/src/libServer/ScillaIPCServer.cpp
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <jsonrpccpp/common/specification.h>
 #include <jsonrpccpp/server/connectors/unixdomainsocketserver.h>
 
 #include "libPersistence/ContractStorage.h"

--- a/tests/Server/Test_ScillaIPCServer.cpp
+++ b/tests/Server/Test_ScillaIPCServer.cpp
@@ -34,6 +34,14 @@
 using namespace std;
 using namespace jsonrpc;
 
+namespace {
+
+// Create a dummy BCInfo provider. The details do not matter for the tests here.
+auto makeBCInfo() {
+  return std::make_unique<ScillaBCInfo>(0, Address(), dev::h256(), 0);
+}
+}  // namespace
+
 BOOST_AUTO_TEST_SUITE(scillaipc)
 
 // NOTE: Remember to use unique field names for different tests
@@ -61,6 +69,7 @@ BOOST_AUTO_TEST_CASE(test_query_simple) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a query to "set field foo with value".
@@ -109,6 +118,7 @@ BOOST_AUTO_TEST_CASE(test_query_map_1) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -191,6 +201,7 @@ BOOST_AUTO_TEST_CASE(test_query_empty_key) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -262,6 +273,7 @@ BOOST_AUTO_TEST_CASE(test_query_map_2) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -485,6 +497,7 @@ BOOST_AUTO_TEST_CASE(test_query_empty_map) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -570,6 +583,7 @@ BOOST_AUTO_TEST_CASE(test_query_delete_to_empty) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -634,6 +648,7 @@ BOOST_AUTO_TEST_CASE(test_query_empty_map_2) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -724,6 +739,7 @@ BOOST_AUTO_TEST_CASE(test_query_empty_map_3) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -810,6 +826,7 @@ BOOST_AUTO_TEST_CASE(test_query_update_fetch_nested) {
   UnixDomainSocketClient c(SCILLA_IPC_SOCKET_PATH);
   Client client(c);
 
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
 
   // Prepare a map key insertion query.
@@ -919,6 +936,7 @@ BOOST_AUTO_TEST_CASE(test_scillatestsuite) {
   ScillaIPCServer server(s);
   s.SetWaitTime(SCILLA_SERVER_LOOP_WAIT_MICROSECONDS);
   LOG_GENERAL(INFO, "Test_ScillaIPCServer: initialized server.");
+  server.setBCInfoProvider(makeBCInfo());
   server.StartListening();
   LOG_GENERAL(INFO, "Test_ScillaIPCServer: server is now listening.");
 


### PR DESCRIPTION
## Description
This PR fixes the Scilla IPC tests which broke after https://github.com/Zilliqa/Zilliqa/pull/2757. The IPC server now needs (at least a dummy) a blockchain-info provider to be set.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status
Ready to review and merge.

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
