### PR TITLE
[master] Added flag nonisoload to allow generate state from statedeltas

### DIFF
--- a/src/cmd/isolated_server.cpp
+++ b/src/cmd/isolated_server.cpp
@@ -77,6 +77,7 @@ int main(int argc, const char* argv[]) {
   string blocknum_str{"1"};
   uint timeDelta{0};
   bool loadPersistence{false};
+  bool nonisoload{false};
   string uuid;
   try {
     po::options_description desc("Options");
@@ -93,6 +94,9 @@ int main(int argc, const char* argv[]) {
         "(Disabled by default)")(
         "load,l", po::bool_switch()->default_value(false),
         "Load from persistence folder (False by default)")(
+        "nonisoload,n", po::bool_switch()->default_value(false),
+        "Load is either of testnet or mainnet having state-deltas (False by "
+        "default)")(
         "uuid,u", po::value<string>(&uuid),
         "unique id to be provided upon startup (can be any string)");
 
@@ -108,6 +112,9 @@ int main(int argc, const char* argv[]) {
       }
       po::notify(vm);
       loadPersistence = vm["load"].as<bool>();
+      if (loadPersistence) {
+        nonisoload = vm["nonisoload"].as<bool>();
+      }
     } catch (boost::program_options::required_option& e) {
       std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
       std::cout << desc;
@@ -181,7 +188,7 @@ int main(int argc, const char* argv[]) {
 
     if (loadPersistence) {
       LOG_GENERAL(INFO, "Trying to load persistence.. ");
-      if (!isolatedServer->RetrieveHistory()) {
+      if (!isolatedServer->RetrieveHistory(nonisoload)) {
         LOG_GENERAL(WARNING, "RetrieveHistory Failed");
         return ERROR_UNHANDLED_EXCEPTION;
       }

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -89,6 +89,20 @@ bool Retriever::RetrieveTxBlocks() {
     extraStateDeltas.push_back(stateDelta);
   }
 
+  if (!ConstructFromStateDeltas(lastBlockNum, extra_txblocks, extraStateDeltas,
+                                trimIncompletedBlocks)) {
+    return false;
+  }
+
+  m_mediator.m_node->AddBlock(*latestTxBlock);
+
+  return true;
+}
+
+bool Retriever::ConstructFromStateDeltas(const uint64_t& lastBlockNum,
+                                         unsigned int extra_txblocks,
+                                         std::vector<bytes>& extraStateDeltas,
+                                         bool trimIncompletedBlocks) {
   if ((lastBlockNum - extra_txblocks + 1) %
           (INCRDB_DSNUMS_WITH_STATEDELTAS * NUM_FINAL_BLOCK_PER_POW) ==
       0) {
@@ -232,8 +246,6 @@ bool Retriever::RetrieveTxBlocks() {
                                                     stateDelta);
     }
   }
-
-  m_mediator.m_node->AddBlock(*latestTxBlock);
 
   return true;
 }

--- a/src/libPersistence/Retriever.h
+++ b/src/libPersistence/Retriever.h
@@ -41,6 +41,10 @@ class Retriever {
       const std::string& normal_address_output_filename,
       const uint64_t& updateDiskFrequency);
   void CleanAll();
+  bool ConstructFromStateDeltas(const uint64_t& lastBlockNum,
+                                unsigned int extra_txblocks,
+                                std::vector<bytes>& extraStateDeltas,
+                                bool trimIncompletedBlocks);
 
  private:
   Mediator& m_mediator;

--- a/src/libServer/IsolatedServer.h
+++ b/src/libServer/IsolatedServer.h
@@ -94,7 +94,7 @@ class IsolatedServer : public LookupServer,
   Json::Value GetTransactionsForTxBlock(const std::string& txBlockNum);
   bool ValidateTxn(const Transaction& tx, const Address& fromAddr,
                    const Account* sender, const uint128_t& gasPrice);
-  bool RetrieveHistory();
+  bool RetrieveHistory(const bool& nonisoload);
 };
 
 #endif  // ZILLIQA_SRC_LIBSERVER_ISOLATEDSERVER_H_


### PR DESCRIPTION
Allow isolated server to run testnet or mainnet persistence.
New paramter added : `nonisoload`

This flag should be set so that isolated server can load mainnet/testnet persistence which can also have statedeltas.

```
desc.add_options()("help,h", "Print help message")(
        "file,f", po::value<string>(&accountJsonFilePath),
        "Json file containing bootstrap accounts")(
        "port,p", po::value<uint>(&port),
        "Port to run server on {default: 5555")(
        "blocknum,b", po::value<string>(&blocknum_str),
        "Initial blocknumber {default : 1 }")(
        "time,t", po::value<uint>(&timeDelta),
        "the automatic blocktime for incrementing block number (in ms)  "
        "(Disabled by default)")(
        "load,l", po::bool_switch()->default_value(false),
        "Load from persistence folder (False by default)")(
        "nonisoload,n", po::bool_switch()->default_value(false),    <================== New Flag
        "Load is either of testnet or mainnet having state-deltas (False by default)")(
        "uuid,u", po::value<string>(&uuid),
        "unique id to be provided upon startup (can be any string)");
```


## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
