### PR TITLE
[master] Support timestamp in fetchBlockchainInfo for Scilla IPC server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - bash ./cmake-3.19.3-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/
   - cmake --version
   - rm cmake-3.19.3-Linux-x86_64.sh
-  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:47de22b4 cp -r /scilla /root/
+  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:9622a497 cp -r /scilla /root/
   - ls /scilla/0/
 
 script:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-ARG BASE=zilliqa/scilla:47de22b4
+ARG BASE=zilliqa/scilla:9622a497
 FROM ${BASE} AS scilla
 # run a copy -L to unfold the symlinkes, and strip all exes
 RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-FROM zilliqa/scilla:47de22b4
+FROM zilliqa/scilla:9622a497
 
 COPY requirements3.cuda.txt ./
 


### PR DESCRIPTION
## Description
To add support for timestamp in fetchBlockchainInfo.

The timestamp obtained will be from 1 txBlock before the queried one.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
