### PR TITLE
[master] Support fetching of Chain ID in fetchBlockchainInfo in Scilla IPC server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - bash ./cmake-3.19.3-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/
   - cmake --version
   - rm cmake-3.19.3-Linux-x86_64.sh
-  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:3091ee51 cp -r /scilla /root/
+  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:fbdfda61 cp -r /scilla /root/
   - ls /scilla/0/
 
 script:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-ARG BASE=zilliqa/scilla:3091ee51
+ARG BASE=zilliqa/scilla:fbdfda61
 FROM ${BASE} AS scilla
 # run a copy -L to unfold the symlinkes, and strip all exes
 RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-FROM zilliqa/scilla:3091ee51
+FROM zilliqa/scilla:fbdfda61
 
 COPY requirements3.cuda.txt ./
 

--- a/src/libServer/ScillaIPCServer.cpp
+++ b/src/libServer/ScillaIPCServer.cpp
@@ -169,7 +169,11 @@ bool ScillaIPCServer::fetchBlockchainInfo(const std::string &query_name,
 
     value = std::to_string(txBlockSharedPtr->GetTimestamp());
     return true;
+  } else if (query_name == "CHAINID") {
+    value = std::to_string(CHAIN_ID);
+    return true;
   }
 
+  LOG_GENERAL(WARNING, "Invalid query_name: " << query_name);
   return false;
 }


### PR DESCRIPTION
## Description
Add support for fetching Chain ID in `fetchBlockchainInfo` in `ScillaIPCServer.cpp`
The Chain ID fetched is from the one stated in `constants.xml`

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [x] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
