### PR TITLE
[release-8.2] To Zilliqa v8.2.0-alpha.0 and Scilla v0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
   - bash ./cmake-3.19.3-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/
   - cmake --version
   - rm cmake-3.19.3-Linux-x86_64.sh
-  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:v0.10.0-alpha.1 cp -r /scilla /root/
+  - docker run --rm -it -v /scilla:/root/scilla zilliqa/scilla:v0.11.0 cp -r /scilla /root/
   - ls /scilla/0/
 
 script:

--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,7 @@
 === [Zilliqa]Major Version ===
-7
+8
 === [Zilliqa]Minor Version ===
-0
+2
 === [Zilliqa]Fix Version ===
 0
 === [Zilliqa] Expected DS Epoch===

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN cmake --version \
     && rm cmake-3.19.3-Linux-x86_64.sh
 
 # Manually input tag or commit, can be overwritten by docker build-args
-ARG COMMIT_OR_TAG=v7.0.0-alpha.0
+ARG COMMIT_OR_TAG=v8.2.0-alpha.0
 ARG REPO=https://github.com/Zilliqa/Zilliqa.git
 ARG SOURCE_DIR=/zilliqa
 ARG BUILD_DIR=/build

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -130,7 +130,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
 ####################### End of CUDA Installation ###############################
 
-ARG ZILLIQA_VERSION=v7.0.0-alpha.0
+ARG ZILLIQA_VERSION=v8.2.0-alpha.0
 ARG REPO=https://github.com/Zilliqa/Zilliqa.git
 ARG SOURCE_DIR=/zilliqa
 ARG BUILD_DIR=/build

--- a/src/libUtils/SWInfo.h
+++ b/src/libUtils/SWInfo.h
@@ -22,7 +22,7 @@
 #include <iostream>
 #include "common/Serializable.h"
 
-const std::string VERSION_TAG = "v7.0.0-alpha.0";
+const std::string VERSION_TAG = "v8.2.0-alpha.0";
 const std::string ZILLIQA_BRAND = "Copyright (C) Zilliqa. Version " +
                                   VERSION_TAG + ".  <https://www.zilliqa.com/>";
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
This PR sets the Scilla version in the new `release-8.2` branch to the one used for v8.1.1 along the `release-8.1` branch.
The Zilliqa version is also set to v8.2.0-alpha.0.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
