### PR TITLE
[evm_support_main] Clean up constants related to evm-ds.

### DIFF
--- a/ISOLATED_SERVER_setup.md
+++ b/ISOLATED_SERVER_setup.md
@@ -37,10 +37,16 @@ make clean; make
 
 ## Steps to Enable EVM for a run this temporarily replaces the Scilla Interpreter
 <ENABLE_EVM>true</ENABLE_EVM>
-<EVM_ROOT>evm-ds</EVM_ROOT>
+<EVM_SERVER_BINARY>/usr/local/bin/evm-ds</EVM_SERVER_BINARY>
 <EVM_SERVER_SOCKET_PATH>/tmp/evm-server.sock</EVM_SERVER_SOCKET_PATH>
-<EVM_SERVER_BINARY>evm-ds</EVM_SERVER_BINARY>
 ```
+
+Create a symlink to evm-ds at `/usr/local/bin/evm-ds`:
+
+```
+sudo ln -s ~/evm-ds/target/debug/evm-ds /usr/local/bin/evm-ds
+```
+
 4. Create swapfile
 ```
 // Recommended to have at least 4GB of free memory

--- a/constants.xml
+++ b/constants.xml
@@ -189,11 +189,9 @@
         <CONNECTION_ALL_TIMEOUT>1</CONNECTION_ALL_TIMEOUT>
         <!-- Timeout in seconds for ONLY connection that reach our callback function, 0 means no timeout-->
         <CONNECTION_CALLBACK_TIMEOUT>0</CONNECTION_CALLBACK_TIMEOUT>
-        <ENABLE_EVM>true</ENABLE_EVM>
-        <EVM_ROOT>evm-ds</EVM_ROOT>
-        <EVM_SERVER_PATH>/target/release/</EVM_SERVER_PATH>
+        <ENABLE_EVM>false</ENABLE_EVM>
+        <EVM_SERVER_BINARY>/usr/local/bin/evm-ds</EVM_SERVER_BINARY>
         <EVM_SERVER_SOCKET_PATH>/tmp/evm-server.sock</EVM_SERVER_SOCKET_PATH>
-        <EVM_SERVER_BINARY>evm-ds</EVM_SERVER_BINARY>
     </jsonrpc>
     <network_composition>
         <!-- Shard size will be automatically calculated if COMM_SIZE = 0 -->

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -736,6 +736,3 @@ const std::string EVM_SERVER_SOCKET_PATH{
     ReadConstantString("EVM_SERVER_SOCKET_PATH", "node.jsonrpc.")};
 const std::string EVM_SERVER_BINARY{
     ReadConstantString("EVM_SERVER_BINARY", "node.jsonrpc.")};
-const std::string EVM_SERVER_PATH{
-    ReadConstantString("EVM_SERVER_PATH", "node.jsonrpc.")};
-const std::string EVM_ROOT{ReadConstantString("EVM_ROOT", "node.jsonrpc.")};

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -305,10 +305,8 @@ extern const unsigned int STATUS_RPC_PORT;
 // EVM
 
 extern const bool ENABLE_EVM;
-extern const std::string EVM_ROOT;
 extern const std::string EVM_SERVER_SOCKET_PATH;
 extern const std::string EVM_SERVER_BINARY;
-extern const std::string EVM_SERVER_PATH;
 
 extern const std::string IP_TO_BIND;  // Only for non-lookup nodes
 extern const bool ENABLE_STAKING_RPC;

--- a/src/libData/AccountData/EvmClient.cpp
+++ b/src/libData/AccountData/EvmClient.cpp
@@ -18,6 +18,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range/iterator_range.hpp>
+#include <boost/filesystem.hpp>
 #include <thread>
 
 #include "EvmClient.h"
@@ -37,19 +38,8 @@ void EvmClient::Init() {
 bool EvmClient::OpenServer() {
   LOG_MARKER();
 
-  std::string cmdStr;
-  std::string root_w_version;
-
-  if (!EvmUtils::PrepareRootPathWVersion(root_w_version)) {
-    LOG_GENERAL(WARNING, "EvmUtils::PrepareRootPathWVersion failed");
-    return false;
-  }
-
-  std::string server_path =
-      root_w_version + EVM_SERVER_PATH + EVM_SERVER_BINARY;
-  std::string killStr, executeStr;
-
-  cmdStr = "pkill " + EVM_SERVER_BINARY + " ; " + server_path + " --socket " +
+  std::string programName = boost::filesystem::path(EVM_SERVER_BINARY).filename().string();
+  std::string cmdStr = "pkill " + programName + " ; " + EVM_SERVER_BINARY + " --socket " +
            EVM_SERVER_SOCKET_PATH + " --tracing >/dev/null &";
 
   LOG_GENERAL(INFO, "running cmdStr: " << cmdStr);

--- a/src/libData/AccountData/EvmClient.cpp
+++ b/src/libData/AccountData/EvmClient.cpp
@@ -18,7 +18,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range/iterator_range.hpp>
-#include <boost/filesystem.hpp>
 #include <thread>
 
 #include "EvmClient.h"
@@ -38,9 +37,11 @@ void EvmClient::Init() {
 bool EvmClient::OpenServer() {
   LOG_MARKER();
 
-  std::string programName = boost::filesystem::path(EVM_SERVER_BINARY).filename().string();
-  std::string cmdStr = "pkill " + programName + " ; " + EVM_SERVER_BINARY + " --socket " +
-           EVM_SERVER_SOCKET_PATH + " --tracing >/dev/null &";
+  std::string programName =
+      boost::filesystem::path(EVM_SERVER_BINARY).filename().string();
+  std::string cmdStr = "pkill " + programName + " ; " + EVM_SERVER_BINARY +
+                       " --socket " + EVM_SERVER_SOCKET_PATH +
+                       " --tracing >/dev/null &";
 
   LOG_GENERAL(INFO, "running cmdStr: " << cmdStr);
 

--- a/src/libUtils/EvmUtils.cpp
+++ b/src/libUtils/EvmUtils.cpp
@@ -36,18 +36,6 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-bool EvmUtils::PrepareRootPathWVersion(string& root_w_version) {
-  root_w_version = EVM_ROOT;
-
-  if (!boost::filesystem::exists(root_w_version)) {
-    LOG_GENERAL(WARNING, "Folder for desired version (" << root_w_version
-                                                        << ") doesn't exists");
-    return false;
-  }
-
-  return true;
-}
-
 Json::Value EvmUtils::GetEvmCallJson(const EvmCallParameters& params) {
   Json::Value arr_ret(Json::arrayValue);
 

--- a/src/libUtils/EvmUtils.h
+++ b/src/libUtils/EvmUtils.h
@@ -35,8 +35,6 @@ struct ApplyInstructions;
 
 class EvmUtils {
  public:
-  static bool PrepareRootPathWVersion(std::string& root_w_version);
-
   /// get the command for invoking the evm_runner while calling
   static Json::Value GetEvmCallJson(const EvmCallParameters& params);
 


### PR DESCRIPTION
Set EVM_SERVER_BINARY to the full path of the binary. The default is /usr/local/bin/evm-ds.
