### PR TITLE
[release-8.2] Download historical data before actual persistence download

### DIFF
--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -108,6 +108,17 @@ def GetStateDeltaFromS3():
 	GetAllObjectsFromS3(getURL(), STATEDELTA_DIFF_NAME)
 	ExtractAllGzippedObjects()
 
+# When the DS epoch crossover happens, currTxBlk and newTxBlk will be from different DSepoch.
+# As per the current behavior, Persistence is overwritten after every NUM_DSBLOCK * NUM_FINAL_BLOCK_PER_POW.
+# This function ensures that if currTxBlk DS epoch is different from the persistence overwritten DS epoch, then the node restart the download again.
+# If we don't restart the download, In such a case, the node will receive 404 during persistence download and the node can get leveldb related issues.
+def IsDownloadRestartRequired(currTxBlk, latestTxBlk) :
+    print("currTxBlk = "+ str(currTxBlk) + " latestTxBlk = "+ str(latestTxBlk) + " NUM_DSBLOCK = " +str(NUM_DSBLOCK))
+    if((latestTxBlk // (NUM_DSBLOCK * NUM_FINAL_BLOCK_PER_POW)) != (currTxBlk // (NUM_DSBLOCK * NUM_FINAL_BLOCK_PER_POW))):
+        return True
+    return False
+
+
 def RsyncBlockChainData(source,destination):
 	bashCommand = "rsync --recursive --inplace "
 	bashCommand = bashCommand + source + " "
@@ -301,6 +312,26 @@ def calculate_multipart_etag(source_path, chunk_size):
 	return new_etag
 				
 def run():
+	dir_name = STORAGE_PATH + "/historical-data"
+	main_persistence = STORAGE_PATH + "/persistence"
+	try:
+		if(Exclude_microBlocks == False and Exclude_txnBodies == False):
+			if os.path.exists(dir_name) and os.path.isdir(dir_name):
+				if not os.listdir(dir_name):
+					# download the static db
+					print("Dowloading static historical-data")
+					download_static_DB.start(STORAGE_PATH)
+				else:
+					print("Already have historical blockchain-data!. Skip downloading again!")
+			else:
+				# download the static db
+				print("Dowloading static historical-data")
+				download_static_DB.start(STORAGE_PATH)
+	except Exception as e:
+		print(e)
+		print("Failed to download static historical-data!")
+		pass
+
 	while (True):
 		try:
 			currTxBlk = -1
@@ -325,9 +356,9 @@ def run():
 					time.sleep(1)
 			else:
 				break
-			if(newTxBlk % (NUM_DSBLOCK * NUM_FINAL_BLOCK_PER_POW) == 0):
-				# new base persistence already. So start again :(
-				continue					
+			if(IsDownloadRestartRequired(currTxBlk, newTxBlk)):
+				print("Redownload persistence as the persistence is overwritten")
+				continue
 			#get diff of persistence and stadedeltas for newly mined txblocks
 			lst = []
 			while(currTxBlk < newTxBlk):
@@ -343,30 +374,10 @@ def run():
 			print("Error downloading!! Will try again")
 			time.sleep(5)
 			continue
+	if os.path.exists(dir_name):
+		RsyncBlockChainData(dir_name+"/", main_persistence)
 
 	print("[" + str(datetime.datetime.now()) + "] Done!")
-
-	try:
-		if(Exclude_microBlocks == False and Exclude_txnBodies == False):
-			dir_name = STORAGE_PATH + "/historical-data"
-			main_persistence = STORAGE_PATH + "/persistence"
-			if os.path.exists(dir_name) and os.path.isdir(dir_name):
-				if not os.listdir(dir_name):
-					# download the static db
-					print("Dowloading static historical-data")
-					download_static_DB.start(STORAGE_PATH)
-				else:    
-					print("Already have historical blockchain-data!. Skip downloading again!")
-			else:
-				# download the static db
-				print("Dowloading static historical-data")
-				download_static_DB.start(STORAGE_PATH)
-			if os.path.exists(dir_name):
-				RsyncBlockChainData(dir_name+"/", main_persistence)
-	except Exception as e:
-		print(e)
-		print("Failed to download static historical-data!")
-		pass
 
 	return True
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Download historical data first before actual persistence download. The reason for doing so is because of the increasing size of persistence, historical data download takes a long time(around ~15 mins). By the time, the data gets downloaded, it may be possible that we are in a new DS epoch already and this may cause the node to unnecessarily rejoin. This scenario can happen if the node operator starts a seed node at later TX epochs of DS epoch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestions
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
