### PR TITLE
[master] fix bug where 0x is not stripped

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -434,7 +434,9 @@ Address JSONConversion::checkJsonGetEthCall(const Json::Value& _json) {
                                     "must contain toAddr");
   }
 
-  string lower_case_addr = boost::to_lower_copy(_json["toAddr"].asString());
+  auto lower_case_addr = _json["toAddr"].asString();
+
+  DataConversion::NormalizeHexString(lower_case_addr);
 
   bytes toAddr_ser;
   if (!DataConversion::HexStrToUint8Vec(lower_case_addr, toAddr_ser)) {


### PR DESCRIPTION
## Description
Fix bug where the address given to evm call has an 0x prefix and it is not stripped: https://github.com/Zilliqa/evm_ds_test/pull/4

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x ] This is not a breaking change
- [ ] This is a breaking change
