### PR TITLE
[release-8.1.2] Bypass validation for missing microblock

### DIFF
--- a/constants.xml
+++ b/constants.xml
@@ -368,6 +368,12 @@
             </entry>
         </exclusion_list>
         <IGNORE_BLOCKCOSIG_CHECK>false</IGNORE_BLOCKCOSIG_CHECK>
+        <microblock_exclusion_list>
+            <entry>
+                <TXBLOCK>1664279</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+        </microblock_exclusion_list>
     </verifier>
     <viewchange>
         <POST_VIEWCHANGE_BUFFER>10</POST_VIEWCHANGE_BUFFER>

--- a/constants_local.xml
+++ b/constants_local.xml
@@ -367,6 +367,12 @@
             </entry>
         </exclusion_list>
         <IGNORE_BLOCKCOSIG_CHECK>false</IGNORE_BLOCKCOSIG_CHECK>
+        <microblock_exclusion_list>
+            <entry>
+                <TXBLOCK>1664279</TXBLOCK>
+                <MICROBLOCK>0</MICROBLOCK>
+            </entry>
+        </microblock_exclusion_list>
     </verifier>
     <viewchange>
         <POST_VIEWCHANGE_BUFFER>5</POST_VIEWCHANGE_BUFFER>

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -85,6 +85,17 @@ ReadVerifierExclusionListFromConstantsFile() {
   return result;
 }
 
+const vector<pair<uint64_t, uint32_t>>
+ReadVerifierMicroblockExclusionListFromConstantsFile() {
+  auto pt = PTree::GetInstance();
+  vector<pair<uint64_t, uint32_t>> result;
+  for (auto& entry : pt.get_child("node.verifier.microblock_exclusion_list")) {
+    result.emplace_back(make_pair(entry.second.get<uint64_t>("TXBLOCK"),
+                                  entry.second.get<uint32_t>("MICROBLOCK")));
+  }
+  return result;
+}
+
 bool ISOLATED_SERVER = false;
 
 bool SCILLA_PPLIT_FLAG = true;
@@ -716,3 +727,5 @@ const vector<pair<uint64_t, uint32_t>> VERIFIER_EXCLUSION_LIST{
     ReadVerifierExclusionListFromConstantsFile()};
 const bool IGNORE_BLOCKCOSIG_CHECK{
     ReadConstantString("IGNORE_BLOCKCOSIG_CHECK", "node.verifier.") == "true"};
+const vector<pair<uint64_t, uint32_t>> VERIFIER_MICROBLOCK_EXCLUSION_LIST{
+    ReadVerifierMicroblockExclusionListFromConstantsFile()};

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -487,4 +487,6 @@ extern const std::vector<std::string> DS_GENESIS_KEYS;
 // DBVerifier constants
 extern const std::vector<std::pair<uint64_t, uint32_t>> VERIFIER_EXCLUSION_LIST;
 extern const bool IGNORE_BLOCKCOSIG_CHECK;
+extern const std::vector<std::pair<uint64_t, uint32_t>>
+    VERIFIER_MICROBLOCK_EXCLUSION_LIST;
 #endif  // ZILLIQA_SRC_COMMON_CONSTANTS_H_

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -556,8 +556,16 @@ bool Node::CheckIntegrity(const bool fromValidateDBBinary) {
           }
         }
       } else {
-        LOG_GENERAL(WARNING, "FB: " << blockNum << " Missing MB: "
-                                    << mbInfo.m_microBlockHash);
+        LOG_GENERAL(WARNING,
+                    "FB: " << blockNum
+                           << " Missing MB: " << mbInfo.m_microBlockHash
+                           << " Check if MB is in microblock exclusion list");
+        if (find(VERIFIER_MICROBLOCK_EXCLUSION_LIST.begin(),
+                 VERIFIER_MICROBLOCK_EXCLUSION_LIST.end(),
+                 make_pair(blockNum, mbInfo.m_shardId)) !=
+            VERIFIER_MICROBLOCK_EXCLUSION_LIST.end()) {
+          continue;
+        }
         *result = false;
       }
     }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
Need to add the excluded microblock in the release 8.1.2.
<!-- What is the context of your pull request? -->
Context explained in the case: https://zilliqa-docs.atlassian.net/wiki/spaces/ZILLIQA/pages/618463233/Updated+validator+config+with+excluded+microblocks
<!-- What are the related issues and pull requests? -->
Issue mentioned in the case: https://zilliqa-docs.atlassian.net/wiki/spaces/ZILLIQA/pages/618463233/Updated+validator+config+with+excluded+microblocks

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change
