### PR TITLE
[master] Basic eth-getBlockByNum implementation

### DIFF
--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -52,48 +52,6 @@ Json::Value populateReceiptHelper(std::string const& txnhash) {
   return ret;
 }
 
-Json::Value populateBlockHelper() {
-  Json::Value ret;
-
-  ret["difficulty"] = "0x3ff800000";
-  ret["extraData"] = "0x476574682f76312e302e302f6c696e75782f676f312e342e32";
-  ret["gasLimit"] = "0x1388";
-  ret["gasUsed"] = "0x0";
-  ret["hash"] =
-      "0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6";
-  ret["logsBloom"] =
-      "0x00000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "0000000000000000000000000000000000000000000000000000000000000000000000"
-      "000000000000000000000000";
-  ret["miner"] = "0x05a56e2d52c817161883f50c441c3228cfe54d9f";
-  ret["mixHash"] =
-      "0x969b900de27b6ac6a67742365dd65f55a0526c41fd18e1b16f1a1215c2e66f59";
-  ret["nonce"] = "0x539bd4979fef1ec4";
-  ret["number"] = "0x1";
-  ret["parentHash"] =
-      "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
-  ret["receiptsRoot"] =
-      "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421";
-  ret["sha3Uncles"] =
-      "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
-  ret["size"] = "0x219";
-  ret["stateRoot"] =
-      "0xd67e4d450343046425ae4271474353857ab860dbc0a1dde64b41b5cd3a532bf3";
-  ret["timestamp"] = "0x55ba4224";
-  ret["totalDifficulty"] = "0x7ff800000";
-  ret["transactions"] = Json::arrayValue;
-  ret["transactionsRoot"] =
-      "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421";
-  ret["uncles"] = Json::arrayValue;
-
-  return ret;
-}
-
 // Given a RLP message, parse out the fields and return a EthFields object
 EthFields parseRawTxFields(std::string const& message) {
   EthFields ret;

--- a/src/libEth/Eth.h
+++ b/src/libEth/Eth.h
@@ -35,7 +35,6 @@ struct EthFields {
 };
 
 Json::Value populateReceiptHelper(std::string const& txnhash);
-Json::Value populateBlockHelper();
 
 EthFields parseRawTxFields(std::string const& message);
 

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -118,6 +118,45 @@ const Json::Value JSONConversion::convertTxBlocktoJson(const TxBlock& txblock,
   return ret;
 }
 
+const Json::Value JSONConversion::convertTxBlocktoEthJson(
+    const TxBlock& txblock, const DSBlock& dsBlock,
+    const std::vector<TxBodySharedPtr>& transactions,
+    const std::vector<TxnHash>& transactionHashes,
+    bool includeFullTransactions) {
+  (void)transactions;
+  const TxBlockHeader& txheader = txblock.GetHeader();
+
+  Json::Value retJson;
+
+  retJson["number"] = std::to_string(txheader.GetBlockNum());
+  retJson["hash"] = txblock.GetBlockHash().hex();
+  retJson["PrevBlockHash"] = txheader.GetPrevHash().hex();
+  retJson["sha3Uncles"] = Json::arrayValue;
+  retJson["stateRoot"] = txheader.GetStateRootHash().hex();
+  retJson["miner"] =
+      Account::GetAddressFromPublicKeyEth(txheader.GetMinerPubKey()).hex();
+  retJson["difficulty"] = dsBlock.GetHeader().GetDifficulty();
+
+  bytes serializedTxBlock;
+  txblock.Serialize(serializedTxBlock, 0);
+
+  retJson["size"] = std::to_string(serializedTxBlock.size());
+  retJson["gasLimit"] = std::to_string(txheader.GetGasLimit());
+  retJson["gasUsed"] = std::to_string(txheader.GetGasUsed());
+  retJson["gasLimit"] = std::to_string(txblock.GetTimestamp());
+  retJson["Version"] = txheader.GetVersion();
+
+  // Todo: prepare transaction to eth-like json conversion
+  if (!includeFullTransactions) {
+    auto transactionHashesJson = Json::Value(Json::arrayValue);
+    for (const auto& hash : transactionHashes) {
+      transactionHashesJson.append(hash.hex());
+    }
+    retJson["transactions"] = transactionHashesJson;
+  }
+  return retJson;
+}
+
 const Json::Value JSONConversion::convertRawTxBlocktoJson(
     const TxBlock& txblock) {
   Json::Value ret;

--- a/src/libServer/JSONConversion.h
+++ b/src/libServer/JSONConversion.h
@@ -43,7 +43,7 @@ class JSONConversion {
       const TxBlock& txblock, const DSBlock& dsBlock,
       const std::vector<TxBodySharedPtr>& transactions,
       const std::vector<TxnHash>& transactionHashes,
-      bool includeTransactionHashes = false);
+      bool includeFullTransactions = false);
   // converts raw TxBlock to JSON object (for staking)
   static const Json::Value convertRawTxBlocktoJson(const TxBlock& txblock);
   // converts a DSBlocck to JSON object

--- a/src/libServer/JSONConversion.h
+++ b/src/libServer/JSONConversion.h
@@ -26,6 +26,8 @@
 #include "libData/BlockData/BlockHeader/BlockHashSet.h"
 
 class JSONConversion {
+  using TxBodySharedPtr = std::shared_ptr<TransactionWithReceipt>;
+
  public:
   // converts a uint32_t array to JSON array containing shard ids
   static const Json::Value convertMicroBlockInfoArraytoJson(
@@ -36,6 +38,12 @@ class JSONConversion {
   // converts a TxBlock to JSON object
   static const Json::Value convertTxBlocktoJson(const TxBlock& txblock,
                                                 bool verbose = false);
+  // converts a TxBlock to JSON object (Eth style)
+  static const Json::Value convertTxBlocktoEthJson(
+      const TxBlock& txblock, const DSBlock& dsBlock,
+      const std::vector<TxBodySharedPtr>& transactions,
+      const std::vector<TxnHash>& transactionHashes,
+      bool includeTransactionHashes = false);
   // converts raw TxBlock to JSON object (for staking)
   static const Json::Value convertRawTxBlocktoJson(const TxBlock& txblock);
   // converts a DSBlocck to JSON object

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -321,8 +321,8 @@ class LookupServer : public Server,
 
   inline virtual void GetEthBlockByNumberI(const Json::Value& request,
                                            Json::Value& response) {
-    (void)request;
-    response = this->GetEthBlockByNumber();
+    response =
+        this->GetEthBlockByNumber(request[0u].asString(), request[1u].asBool());
   }
 
   inline virtual void GetEthGasPriceI(const Json::Value& request,
@@ -609,7 +609,8 @@ class LookupServer : public Server,
 
   // Eth calls
   Json::Value GetTransactionReceipt(const std::string& txnhash);
-  Json::Value GetEthBlockByNumber();
+  Json::Value GetEthBlockByNumber(const std::string& blockNumberStr,
+                                  bool includeTransactionHashes);
   Json::Value CreateTransactionEth(
       EthFields const& fields, bytes const& pubKey,
       const unsigned int num_shards, const uint128_t& gasPrice,


### PR DESCRIPTION
## Description
This PR adds support for eth_getBlockByNumer call. It lacks full transaction conversion to json (if requested by a caller). There're also no tests yet. I decided to keep this PR short and add missing things in next PRs

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X ] This is not a breaking change

- [X ] **ready for review**