### PR TITLE
[master] Update Schnorr submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 [submodule "src/depends/Schnorr"]
 	path = src/depends/Schnorr
 	url = https://github.com/Zilliqa/schnorr.git
-	branch = fix_bn2
+	branch = sig_fix_plus_bn
 [submodule "src/depends/mongo-c-driver"]
 	path = src/depends/mongo-c-driver
 	url = https://github.com/mongodb/mongo-c-driver.git

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The current release has the following features implemented:
 * State delta forwarding
 * Lookup nodes and Seed nodes for receiving and dispatching transactions
 * Persistent storage for transactions and state
-* S3 storage retrieval from archival nodes
+* S3 storage retrieval from archival nodes.
 * [View change mechanism](https://dev.zilliqa.com/docs/contributors/core-view-change)
 * Node recovery mechanism
 * Protocol upgrade mechanism


### PR DESCRIPTION
🔥 🔥 🔥  MASSIVE THANKS TO STEVE @CSideSteve FOR FINDING THIS BUG 🔥 🔥 🔥 

This fix which is required for etherum uncompressed signatures seems to cause schorr signing to fail when gossiping: https://github.com/Zilliqa/schnorr/pull/15/files

I have split the fix_bn2 branch into just the BN fix and just the signature fix, in order to isolate the issue. This points to a branch that has both (so does not yet fix the issue)