### PR TITLE
[master] fix on isolated server for microblock tx hash

### DIFF
--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -900,9 +900,6 @@ TxBlock IsolatedServer::GenerateTxBlock() {
     txnhashes = m_txnBlockNumMap[m_blocknum];
     m_txnBlockNumMap[m_blocknum].clear();
   }
-  TxBlockHeader txblockheader(0, m_currEpochGas, 0, m_blocknum,
-                              TxBlockHashSet(), numtxns, m_key.first,
-                              TXBLOCK_VERSION);
 
   // In order that the m_txRootHash is not empty if there are actually TXs
   // in the microblock, set the root hash to a TXn hash if there is one
@@ -911,6 +908,9 @@ TxBlock IsolatedServer::GenerateTxBlock() {
     hashSet.m_txRootHash = txnhashes[0];
   }
 
+  TxBlockHeader txblockheader(0, m_currEpochGas, 0, m_blocknum,
+                              TxBlockHashSet(), numtxns, m_key.first,
+                              TXBLOCK_VERSION);
   MicroBlockHeader mbh(0, 0, m_currEpochGas, 0, m_blocknum, hashSet, numtxns,
                        m_key.first, 0);
   MicroBlock mb(mbh, txnhashes, CoSignatures());
@@ -922,8 +922,8 @@ TxBlock IsolatedServer::GenerateTxBlock() {
   mb.Serialize(body, 0);
 
   if (!BlockStorage::GetBlockStorage().PutMicroBlock(
-      mb.GetBlockHash(), mb.GetHeader().GetEpochNum(),
-      mb.GetHeader().GetShardId(), body)) {
+          mb.GetBlockHash(), mb.GetHeader().GetEpochNum(),
+          mb.GetHeader().GetShardId(), body)) {
     LOG_GENERAL(WARNING, "Failed to put microblock in body");
   }
   TxBlock txblock(txblockheader, {mbInfo}, CoSignatures());


### PR DESCRIPTION
The microblock TX root hash was always empty when running in isolated server. This meant that the api calls for get block by hash etc. always thought that there was no transactions in the block.

This sets it to the hash of one of the TXs if there is one there, which enables it to work. I have grepped the codebase for where `m_txnRootHash` is set and I am a little confused how it is supposed to be used in prod.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X ] This is not a breaking change
- [ ] This is a breaking change
