### PR TITLE
[master] Disable CI when 'NOCI' is present in the commit message

### DIFF
--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -19,6 +19,12 @@
 
 set -e
 
+re="\\bNOCI\\b"
+if [[ "$TRAVIS_COMMIT_MESSAGE" =~ $re ]]
+then
+    exit 0
+fi
+
 # set n_parallel to fully utilize the resources
 os=$(uname)
 case $os in


### PR DESCRIPTION
## Description
Allows us to skip CI when it is about something that is not tested by the CI, such as:
 - emergency fixes that need to be merged now
 - dependency bumps
 - etc.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
