### PR TITLE
[master] Adding support for two new eth calls

### DIFF
--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -352,13 +352,13 @@ IsolatedServer::IsolatedServer(Mediator& mediator,
       jsonrpc::Procedure("eth_getBlockTransactionCountByHash",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
                          "param01", jsonrpc::JSON_STRING, NULL),
-      &LookupServer::GetBlockTransactionCountByHashI);
+      &LookupServer::GetEthBlockTransactionCountByHashI);
 
   AbstractServer<IsolatedServer>::bindAndAddMethod(
       jsonrpc::Procedure("eth_getBlockTransactionCountByNumber",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
                          "param01", jsonrpc::JSON_STRING, NULL),
-      &LookupServer::GetBlockTransactionCountByNumberI);
+      &LookupServer::GetEthBlockTransactionCountByNumberI);
 }
 
 bool IsolatedServer::ValidateTxn(const Transaction& tx, const Address& fromAddr,

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -347,6 +347,18 @@ IsolatedServer::IsolatedServer(Mediator& mediator,
                          jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
                          "param02", jsonrpc::JSON_STRING, NULL),
       &LookupServer::GetEthCodeI);
+
+  AbstractServer<IsolatedServer>::bindAndAddMethod(
+      jsonrpc::Procedure("eth_getBlockTransactionCountByHash",
+                         jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
+                         "param01", jsonrpc::JSON_STRING, NULL),
+      &LookupServer::GetBlockTransactionCountByHashI);
+
+  AbstractServer<IsolatedServer>::bindAndAddMethod(
+      jsonrpc::Procedure("eth_getBlockTransactionCountByNumber",
+                         jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
+                         "param01", jsonrpc::JSON_STRING, NULL),
+      &LookupServer::GetBlockTransactionCountByNumberI);
 }
 
 bool IsolatedServer::ValidateTxn(const Transaction& tx, const Address& fromAddr,

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1106,6 +1106,34 @@ Json::Value LookupServer::GetEthBlockCommon(const TxBlock& txBlock,
                                                  includeFullTransactions);
 }
 
+Json::Value LookupServer::GetBlockTransactionCountByHash(
+    const std::string& inputHash) {
+  try {
+    const BlockHash blockHash{inputHash};
+    const auto txBlock = m_mediator.m_txBlockChain.GetBlockByHash(blockHash);
+    return txBlock.GetHeader().GetNumTxs();
+
+  } catch (std::exception& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << inputHash);
+
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process");
+  }
+}
+
+Json::Value LookupServer::GetBlockTransactionCountByNumber(
+    const std::string& blockNumberStr) {
+  try {
+    const uint64_t blockNum = std::strtoull(blockNumberStr.c_str(), nullptr, 0);
+    const auto txBlock = m_mediator.m_txBlockChain.GetBlock(blockNum);
+    return txBlock.GetHeader().GetNumTxs();
+
+  } catch (std::exception& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNumberStr);
+
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process");
+  }
+}
+
 Json::Value LookupServer::GetTransactionReceipt(const std::string& txnhash) {
   Json::Value ret;
 

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -752,7 +752,8 @@ std::pair<std::string, unsigned int> LookupServer::CheckContractTxnShards(
   }
 
   if (!toAccountExist) {
-    throw JsonRpcException(RPC_INVALID_ADDRESS_OR_KEY, "Target account does not exist");
+    throw JsonRpcException(RPC_INVALID_ADDRESS_OR_KEY,
+                           "Target account does not exist");
   }
 
   else if (Transaction::GetTransactionType(tx) == Transaction::CONTRACT_CALL &&

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1106,7 +1106,7 @@ Json::Value LookupServer::GetEthBlockCommon(const TxBlock& txBlock,
                                                  includeFullTransactions);
 }
 
-Json::Value LookupServer::GetBlockTransactionCountByHash(
+Json::Value LookupServer::GetEthBlockTransactionCountByHash(
     const std::string& inputHash) {
   try {
     const BlockHash blockHash{inputHash};
@@ -1120,7 +1120,7 @@ Json::Value LookupServer::GetBlockTransactionCountByHash(
   }
 }
 
-Json::Value LookupServer::GetBlockTransactionCountByNumber(
+Json::Value LookupServer::GetEthBlockTransactionCountByNumber(
     const std::string& blockNumberStr) {
   try {
     const uint64_t blockNum = std::strtoull(blockNumberStr.c_str(), nullptr, 0);

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -611,6 +611,32 @@ class LookupServer : public Server,
     response = this->GetEmptyResponse();
   }
 
+  /**
+   * @brief Handles json rpc 2.0 request on method:
+   * eth_getBlockTransactionCountByHash Returns transactions count for given
+   * block.
+   * @param request : params: block hash
+   * @param response : numbner of transactions.
+   */
+
+  inline virtual void GetBlockTransactionCountByHashI(
+      const Json::Value& request, Json::Value& response) {
+    response = this->GetBlockTransactionCountByHash(request[0u].asString());
+  }
+
+  /**
+   * @brief Handles json rpc 2.0 request on method:
+   * eth_getBlockTransactionCountByNumber Returns transactions count for given
+   * block.
+   * @param request : params: block hash
+   * @param response : numbner of transactions.
+   */
+
+  inline virtual void GetBlockTransactionCountByNumberI(
+      const Json::Value& request, Json::Value& response) {
+    response = this->GetBlockTransactionCountByNumber(request[0u].asString());
+  }
+
   std::string GetNetworkId();
 
   Json::Value CreateTransaction(const Json::Value& _json,
@@ -684,6 +710,9 @@ class LookupServer : public Server,
       EthFields const& fields, bytes const& pubKey,
       const unsigned int num_shards, const uint128_t& gasPrice,
       const CreateTransactionTargetFunc& targetFunc);
+
+  Json::Value GetBlockTransactionCountByHash(const std::string& blockHash);
+  Json::Value GetBlockTransactionCountByNumber(const std::string& blockNumber);
 
   size_t GetNumTransactions(uint64_t blockNum);
   bool StartCollectorThread();

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -619,9 +619,9 @@ class LookupServer : public Server,
    * @param response : numbner of transactions.
    */
 
-  inline virtual void GetBlockTransactionCountByHashI(
+  inline virtual void GetEthBlockTransactionCountByHashI(
       const Json::Value& request, Json::Value& response) {
-    response = this->GetBlockTransactionCountByHash(request[0u].asString());
+    response = this->GetEthBlockTransactionCountByHash(request[0u].asString());
   }
 
   /**
@@ -632,9 +632,10 @@ class LookupServer : public Server,
    * @param response : numbner of transactions.
    */
 
-  inline virtual void GetBlockTransactionCountByNumberI(
+  inline virtual void GetEthBlockTransactionCountByNumberI(
       const Json::Value& request, Json::Value& response) {
-    response = this->GetBlockTransactionCountByNumber(request[0u].asString());
+    response =
+        this->GetEthBlockTransactionCountByNumber(request[0u].asString());
   }
 
   std::string GetNetworkId();
@@ -711,8 +712,9 @@ class LookupServer : public Server,
       const unsigned int num_shards, const uint128_t& gasPrice,
       const CreateTransactionTargetFunc& targetFunc);
 
-  Json::Value GetBlockTransactionCountByHash(const std::string& blockHash);
-  Json::Value GetBlockTransactionCountByNumber(const std::string& blockNumber);
+  Json::Value GetEthBlockTransactionCountByHash(const std::string& blockHash);
+  Json::Value GetEthBlockTransactionCountByNumber(
+      const std::string& blockNumber);
 
   size_t GetNumTransactions(uint64_t blockNum);
   bool StartCollectorThread();

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -938,4 +938,76 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_by_hash) {
   BOOST_TEST_CHECK(response == Json::nullValue);
 }
 
+BOOST_AUTO_TEST_CASE(test_eth_get_transaction_count_by_hash_or_num) {
+  INIT_STDOUT_LOGGER();
+
+  LOG_MARKER();
+
+  EvmClient::GetInstance([]() { return std::make_shared<EvmClientMock>(); });
+
+  PairOfKey pairOfKey = Schnorr::GenKeyPair();
+  Peer peer;
+  Mediator mediator(pairOfKey, peer);
+  AbstractServerConnectorMock abstractServerConnector;
+
+  LookupServer lookupServer(mediator, abstractServerConnector);
+
+  // Construct all relevant structures (sample transactions, microblock and
+  // txBlock)
+  std::vector<TransactionWithReceipt> transactions;
+
+  constexpr uint32_t TRANSACTIONS_COUNT = 31;
+  for (uint32_t i = 0; i < TRANSACTIONS_COUNT; ++i) {
+    transactions.emplace_back(constructTxWithReceipt(i, pairOfKey));
+  }
+
+  constexpr auto BLOCK_NUM = 1;
+  const auto txBlock =
+      buildCommonEthBlockCase(mediator, BLOCK_NUM, transactions, pairOfKey);
+
+  // Existing block by Hash
+  {
+    Json::Value paramsRequest = Json::Value(Json::arrayValue);
+    paramsRequest[0u] = txBlock.GetBlockHash().hex();
+
+    Json::Value response;
+
+    lookupServer.GetBlockTransactionCountByHashI(paramsRequest, response);
+    BOOST_TEST_CHECK(response.asUInt64() == TRANSACTIONS_COUNT);
+  }
+
+  // Non existing block by Hash
+  {
+    Json::Value paramsRequest = Json::Value(Json::arrayValue);
+    paramsRequest[0u] = "abcdeffedcba01234567890";
+
+    Json::Value response;
+
+    lookupServer.GetBlockTransactionCountByHashI(paramsRequest, response);
+    BOOST_TEST_CHECK(response.asUInt64() == 0);
+  }
+
+  // Existing block by number
+  {
+    Json::Value paramsRequest = Json::Value(Json::arrayValue);
+    paramsRequest[0u] = std::to_string(txBlock.GetHeader().GetBlockNum());
+
+    Json::Value response;
+
+    lookupServer.GetBlockTransactionCountByNumberI(paramsRequest, response);
+    BOOST_TEST_CHECK(response.asUInt64() == TRANSACTIONS_COUNT);
+  }
+
+  // Non Existing block by number
+  {
+    Json::Value paramsRequest = Json::Value(Json::arrayValue);
+    paramsRequest[0u] = "1234";
+
+    Json::Value response;
+
+    lookupServer.GetBlockTransactionCountByNumberI(paramsRequest, response);
+    BOOST_TEST_CHECK(response.asUInt64() == 0);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -972,7 +972,18 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_count_by_hash_or_num) {
 
     Json::Value response;
 
-    lookupServer.GetBlockTransactionCountByHashI(paramsRequest, response);
+    lookupServer.GetEthBlockTransactionCountByHashI(paramsRequest, response);
+    BOOST_TEST_CHECK(response.asUInt64() == TRANSACTIONS_COUNT);
+  }
+
+  // Existing block by Hash (with extra '0x' prefix)
+  {
+    Json::Value paramsRequest = Json::Value(Json::arrayValue);
+    paramsRequest[0u] = "0x" + txBlock.GetBlockHash().hex();
+
+    Json::Value response;
+
+    lookupServer.GetEthBlockTransactionCountByHashI(paramsRequest, response);
     BOOST_TEST_CHECK(response.asUInt64() == TRANSACTIONS_COUNT);
   }
 
@@ -983,7 +994,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_count_by_hash_or_num) {
 
     Json::Value response;
 
-    lookupServer.GetBlockTransactionCountByHashI(paramsRequest, response);
+    lookupServer.GetEthBlockTransactionCountByHashI(paramsRequest, response);
     BOOST_TEST_CHECK(response.asUInt64() == 0);
   }
 
@@ -994,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_count_by_hash_or_num) {
 
     Json::Value response;
 
-    lookupServer.GetBlockTransactionCountByNumberI(paramsRequest, response);
+    lookupServer.GetEthBlockTransactionCountByNumberI(paramsRequest, response);
     BOOST_TEST_CHECK(response.asUInt64() == TRANSACTIONS_COUNT);
   }
 
@@ -1005,7 +1016,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_count_by_hash_or_num) {
 
     Json::Value response;
 
-    lookupServer.GetBlockTransactionCountByNumberI(paramsRequest, response);
+    lookupServer.GetEthBlockTransactionCountByNumberI(paramsRequest, response);
     BOOST_TEST_CHECK(response.asUInt64() == 0);
   }
 }


### PR DESCRIPTION
## Description
The goal of this PR is to add new eth calls for getting transactions count in block (either retrieved by hash or num). PR has been tested locally with IsolatedServer and unit tests.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
[X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
[X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [X] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
