### PR TITLE
[master] Saeed fix when contract deploy

### DIFF
--- a/src/libCrypto/EthCrypto.cpp
+++ b/src/libCrypto/EthCrypto.cpp
@@ -232,7 +232,8 @@ bytes RecoverECDSAPubSig(std::string const& message, int chain_id) {
   bytes asBytes;
   DataConversion::HexStrToUint8Vec(message, asBytes);
 
-  dev::RLP rlpStream1(asBytes, dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
+  dev::RLP rlpStream1(asBytes,
+                      dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
   dev::RLPStream rlpStreamRecreated(9);
 
   if (rlpStream1.isNull()) {

--- a/src/libCrypto/EthCrypto.cpp
+++ b/src/libCrypto/EthCrypto.cpp
@@ -232,10 +232,11 @@ bytes RecoverECDSAPubSig(std::string const& message, int chain_id) {
   bytes asBytes;
   DataConversion::HexStrToUint8Vec(message, asBytes);
 
-  dev::RLP rlpStream1(asBytes);
+  dev::RLP rlpStream1(asBytes, dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
   dev::RLPStream rlpStreamRecreated(9);
 
   if (rlpStream1.isNull()) {
+    LOG_GENERAL(WARNING, "Failed to parse raw TX RLP: " << message);
     return {};
   }
 

--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -59,7 +59,8 @@ EthFields parseRawTxFields(std::string const& message) {
   bytes asBytes;
   DataConversion::HexStrToUint8Vec(message, asBytes);
 
-  dev::RLP rlpStream1(asBytes, dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
+  dev::RLP rlpStream1(asBytes,
+                      dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
 
   if (rlpStream1.isNull()) {
     LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX! " << message);

--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -59,7 +59,13 @@ EthFields parseRawTxFields(std::string const& message) {
   bytes asBytes;
   DataConversion::HexStrToUint8Vec(message, asBytes);
 
-  dev::RLP rlpStream1(asBytes);
+  dev::RLP rlpStream1(asBytes, dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
+
+  if (rlpStream1.isNull()) {
+    LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX! " << message);
+    return {};
+  }
+
   int i = 0;
   // todo: checks on size of rlp stream etc.
 

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -730,8 +730,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_block_by_number) {
     paramsRequest[0u] = "earliest";
 
     lookupServer.GetEthBlockByNumberI(paramsRequest, response);
-    BOOST_CHECK_EQUAL(response,
-                      Json::nullValue);
+    BOOST_CHECK_EQUAL(response, Json::nullValue);
   }
 }
 


### PR DESCRIPTION
When testing, it was discovered that the RLP will throw if you feed it incorrect data (in this case, it was the bytecode rather than a raw TX). I had thought that throws were caught by the http framework, but perhaps it only catches the rpc exceptions. In any case, this switches the behaviour to a fail, and it is handled further down.