### PR TITLE
[master] Fix padding on R and S elements of the signature

### DIFF
--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -91,11 +91,15 @@ EthFields parseRawTxFields(std::string const& message) {
       case 6:  // V - only needed for pub sig recovery
         break;
       case 7:  // R
-        ret.signature.insert(ret.signature.end(), byteIt.begin(), byteIt.end());
-        break;
+      {
+        bytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
       case 8:  // S
-        ret.signature.insert(ret.signature.end(), byteIt.begin(), byteIt.end());
-        break;
+      {
+        bytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
       default:
         LOG_GENERAL(WARNING, "too many fields received in rlp!");
     }


### PR DESCRIPTION
## Description
Must handle R and S as numbers, and cast them to 256 bit arrays. Otherwise, bignums that start with at least 0 zeros would lose a byte in the encoding, making the signature invalid for the verifying code later.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
