### PR TITLE
[master] Fix get balance

### DIFF
--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -401,12 +401,11 @@ class LookupServer : public Server,
 
     const auto resp = this->GetBalance(address, true)["balance"].asString();
 
-    if (res == "0x") {
+    if (resp == "0x") {
       response = resp;
     } else {
       response = "0x" + resp;
     }
-    return response;
   }
 
   /**

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -401,7 +401,7 @@ class LookupServer : public Server,
 
     const auto resp = this->GetBalance(address, true)["balance"].asString();
 
-    if (resp == "0x") {
+    if (resp == "0x0") {
       response = resp;
     } else {
       response = "0x" + resp;

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -396,17 +396,17 @@ class LookupServer : public Server,
 
   inline virtual void GetEthBalanceI(const Json::Value& request,
                                      Json::Value& response) {
-    (void)request;
     std::string address = request[0u].asString();
     DataConversion::NormalizeHexString(address);
 
-    auto resp = this->GetBalance(address, true)["balance"];
+    const auto resp = this->GetBalance(address, true)["balance"].asString();
 
-    auto balanceStr = resp.asString();
-
-    resp = balanceStr;
-
-    response = resp;
+    if (res == "0x") {
+      response = resp;
+    } else {
+      response = "0x" + resp;
+    }
+    return response;
   }
 
   /**


### PR DESCRIPTION
## Description
This PR fixes `eth_getBalance` call which unnecessarily prepends `0x` to a balance of non-existing account (ultimately returning `0x0x0` string). Tested locally with isolated server.

<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [X] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
