### PR TITLE
[master] Several fixes to support more recent versions of gcc & C++:

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -857,7 +857,7 @@ bool AccountStore::MigrateContractStates(
     for (auto const& type : types) {
       vector<string> fragments;
       boost::split(fragments, type.first,
-                   bind1st(std::equal_to<char>(), SCILLA_INDEX_SEPARATOR));
+                   [](char c) { return c == SCILLA_INDEX_SEPARATOR; });
       if (fragments.size() < 3) {
         LOG_GENERAL(WARNING,
                     "Error fetching (field_name, type): " << address.hex());

--- a/src/libPersistence/ContractStorage.cpp
+++ b/src/libPersistence/ContractStorage.cpp
@@ -362,7 +362,7 @@ bool ContractStorage::FetchStateValue(const dev::h160& addr,
       string key_non_prefix =
           entry.first.substr(key.size(), entry.first.size());
       boost::split(indices, key_non_prefix,
-                   bind1st(std::equal_to<char>(), SCILLA_INDEX_SEPARATOR));
+                   [](char c) { return c == SCILLA_INDEX_SEPARATOR; });
     }
     if (indices.size() > 0 && indices.back().empty()) indices.pop_back();
 
@@ -625,7 +625,7 @@ bool ContractStorage::FetchStateJsonForContract(Json::Value& _json,
   for (const auto& state : states) {
     vector<string> fragments;
     boost::split(fragments, state.first,
-                 bind1st(std::equal_to<char>(), SCILLA_INDEX_SEPARATOR));
+                 [](char c) { return c == SCILLA_INDEX_SEPARATOR; });
     if (fragments.at(0) != address.hex()) {
       LOG_GENERAL(WARNING, "wrong state fetched: " << state.first);
       return false;
@@ -907,7 +907,7 @@ bool ContractStorage::CleanEmptyMapPlaceholders(const string& key) {
   // key = 0xabc.vname.[index1.index2.[...].indexn.
   vector<string> indices;
   boost::split(indices, key,
-               bind1st(std::equal_to<char>(), SCILLA_INDEX_SEPARATOR));
+               [](char c) { return c == SCILLA_INDEX_SEPARATOR; });
   if (indices.size() < 2) {
     LOG_GENERAL(WARNING, "indices size too small: " << indices.size());
     return false;

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -451,7 +451,8 @@ bool IsolatedServer::ValidateTxn(const Transaction& tx, const Address& fromAddr,
 bool IsolatedServer::RetrieveHistory(const bool& nonisoload) {
   m_mediator.m_txBlockChain.Reset();
 
-  std::shared_ptr<Retriever> m_retriever;
+  std::shared_ptr<Retriever> m_retriever =
+      std::make_shared<Retriever>(m_mediator);
 
   bool st_result = m_retriever->RetrieveStates();
 

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -593,3 +593,11 @@ Validator::TxBlockValidationMsg Validator::CheckTxBlocks(
 
   return TxBlockValidationMsg::VALID;
 }
+
+template bool Validator::CheckBlockCosignature<
+    std::deque<std::pair<PubKey, Peer>,
+               std::allocator<std::pair<PubKey, Peer>>>,
+    TxBlock>(TxBlock const&,
+             std::deque<std::pair<PubKey, Peer>,
+                        std::allocator<std::pair<PubKey, Peer>>> const&,
+             bool);


### PR DESCRIPTION
  * Replace std::bind1st which is no longer supported in C++17 by
    an equivalent lambda.
  * Instantiate a Retriever in IsolatedServer to avoid a warning (and
    crash) on a null pointer.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **Ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
