### PR TITLE
[master] Remove dependency on pyzil. Normalize amounts in tests

### DIFF
--- a/tests/evm_ds_test/evm_ds_test/api.py
+++ b/tests/evm_ds_test/evm_ds_test/api.py
@@ -13,4 +13,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-

--- a/tests/evm_ds_test/evm_ds_test/test_case.py
+++ b/tests/evm_ds_test/evm_ds_test/test_case.py
@@ -63,13 +63,6 @@ class EvmDsTestCase:
     eth_network_id = network_id + 0x8000
 
     def init(self, num_accounts=1):
-        # Set up Zilliqa blockchain - needed just for GetContractaddressfromtransactionid.
-        # version = int("0x%04x%04x" % (self.network_id, 1), 0)
-        # self.blockchain = BlockChain(
-        #     api_url=self.endpoint, version=version, network_id=self.network_id
-        # )
-        # set_active_chain(self.blockchain)
-
         self.w3 = Web3(Web3.HTTPProvider(self.endpoint))
         funded_account = EthAccount.from_key(
             private_key="d96e9eb5b782a80ea153c937fa83e5948485fbfc8b7e7c069d7b914dbc350aba"

--- a/tests/evm_ds_test/evm_ds_test/test_case.py
+++ b/tests/evm_ds_test/evm_ds_test/test_case.py
@@ -77,7 +77,7 @@ class EvmDsTestCase:
         ]
         self.account = self.accounts[0]
 
-        nonce = self.w3.eth.get_transaction_count(funded_account.address)
+        nonce = self.get_nonce(funded_account.address)
 
         logging.debug("Funding initial test accounts")
         # Fund all the accounts.
@@ -122,7 +122,7 @@ class EvmDsTestCase:
 
     def transfer_zil(self, source, dest, amount, nonce=None):
         if nonce is None:
-            nonce = self.w3.eth.get_transaction_count(source.address)
+            nonce = self.get_nonce(source.address)
         signed_txn = self.w3.eth.account.sign_transaction(
             {
                 "to": dest.address,
@@ -177,7 +177,7 @@ class EvmDsTestCase:
     def install_contract_bytes(self, account, data_bytes, *args, **kwargs):
         confirm = kwargs.get("confirm", True)
         value = kwargs.get("value", 0)
-        nonce = self.w3.eth.get_transaction_count(account.address)
+        nonce = self.get_nonce(account.address)
         txn = self.w3.eth.account.sign_transaction(
             {
                 "value": value,

--- a/tests/evm_ds_test/evm_ds_test/test_case.py
+++ b/tests/evm_ds_test/evm_ds_test/test_case.py
@@ -26,10 +26,6 @@ from hexbytes import HexBytes
 from fastecdsa import keys, curve
 import numpy as np
 
-from pyzil.zilliqa.api import APIError
-from pyzil.zilliqa.chain import BlockChain, set_active_chain, active_chain
-from pyzil.account import Account
-from pyzil.crypto.zilkey import to_checksum_address, ZilKey
 import solcx
 
 from web3 import Web3
@@ -54,7 +50,7 @@ def pad_uint256(value):
     padding = 32 - len(b)
     if padding < 0:
         padding = 0
-    return (b"\x00" * padding + b)
+    return b"\x00" * padding + b
 
 
 class EvmDsTestCase:
@@ -67,54 +63,54 @@ class EvmDsTestCase:
     eth_network_id = network_id + 0x8000
 
     def init(self, num_accounts=1):
-        version = int("0x%04x%04x" % (self.network_id, 1), 0)
-        self.blockchain = BlockChain(
-            api_url=self.endpoint, version=version, network_id=self.network_id
-        )
-        set_active_chain(self.blockchain)
-        funded_account = Account(
+        # Set up Zilliqa blockchain - needed just for GetContractaddressfromtransactionid.
+        # version = int("0x%04x%04x" % (self.network_id, 1), 0)
+        # self.blockchain = BlockChain(
+        #     api_url=self.endpoint, version=version, network_id=self.network_id
+        # )
+        # set_active_chain(self.blockchain)
+
+        self.w3 = Web3(Web3.HTTPProvider(self.endpoint))
+        funded_account = EthAccount.from_key(
             private_key="d96e9eb5b782a80ea153c937fa83e5948485fbfc8b7e7c069d7b914dbc350aba"
         )
         self.accounts = [
             EthAccount.from_key(
-                pad_uint256(keys.gen_private_key(curve.secp256k1, randfunc=np.random.bytes))
+                pad_uint256(
+                    keys.gen_private_key(curve.secp256k1, randfunc=np.random.bytes)
+                )
             )
             for _ in range(num_accounts)
         ]
         self.account = self.accounts[0]
 
-        nonce = funded_account.get_nonce() + 1
+        nonce = self.w3.eth.get_transaction_count(funded_account.address)
 
         logging.debug("Funding initial test accounts")
-        # Fund all three accounts.
+        # Fund all the accounts.
         pending_transactions = []
         for account in self.accounts:
-            txn_details = funded_account.transfer(
-                to_addr=to_checksum_address(account.address),
-                zils=1000,
-                gas_limit=100,
-                priority=True,
-                nonce=nonce,
-                confirm=False,
+            amount = 200_000_000_000_000
+            logging.info(
+                "Funding account {} with {} Qa".format(account.address, amount)
             )
-            logging.debug("TXN Details: '{}'".format(txn_details))
-            pending_transactions.append(txn_details["TranID"])
+            txn_id = self.transfer_zil(funded_account, account, amount, nonce)
+            pending_transactions.append(txn_id)
             nonce += 1
+
         # Wait for all initial funding transactions to complete.
         start = time.time()
-        time.sleep(1)
         while time.time() - start <= 240 and pending_transactions:
             txn_id = pending_transactions.pop(0)
             try:
-                active_chain.api.GetTransaction(txn_id)
-            except APIError as e:
-                logging.debug("Retry GetTransaction: {}".format(e))
+                txn = self.w3.eth.get_transaction(txn_id)
+                if txn and "hash" in txn:
+                    return txn["hash"]
+            except TransactionNotFound:
                 pending_transactions.append(txn_id)
                 time.sleep(1.0)
         if pending_transactions:
             raise RuntimeError("Failed to complete initial payment transactions")
-
-        self.w3 = Web3(Web3.HTTPProvider(self.endpoint))
 
     def compile_solidity(self, contract_string):
         result = solcx.compile_source(
@@ -131,6 +127,23 @@ class EvmDsTestCase:
         result = result.popitem()[1]
         return self.w3.eth.contract(abi=result["abi"], bytecode=result["bin"])
 
+    def transfer_zil(self, source, dest, amount, nonce=None):
+        if nonce is None:
+            nonce = self.w3.eth.get_transaction_count(source.address)
+        signed_txn = self.w3.eth.account.sign_transaction(
+            {
+                "to": dest.address,
+                "value": amount,
+                "gas": 5_000,
+                "gasPrice": 2_000_000_000,
+                "nonce": nonce,
+                "chainId": self.eth_network_id,
+                "data": b"",
+            },
+            source.key,
+        )
+        return self.w3.eth.send_raw_transaction(signed_txn.rawTransaction).hex()
+
     def install_contract(self, account, contract_class, *args, **kwargs):
         """
         Send a Zilliqa transaction that creates a given contract.
@@ -139,10 +152,13 @@ class EvmDsTestCase:
         """
         value = kwargs.get("value", 0)
         confirm = kwargs.get("confirm", True)
-        nonce = self.w3.eth.get_transaction_count(account.address)
+        balance = self.get_balance(account.address)
+        nonce = self.get_nonce(account.address)
+        logging.debug(
+            "Account {} balance {}, nonce {}".format(account.address, balance, nonce)
+        )
         txn = contract_class.constructor(*args).build_transaction(
             {
-                "from": account.address,
                 "gas": 30_000,
                 "gasPrice": 2_000_000_000,
                 "value": value,
@@ -151,17 +167,19 @@ class EvmDsTestCase:
             }
         )
         signed_txn = self.w3.eth.account.sign_transaction(txn, account.key)
+        logging.info(
+            "Balance of sending account is {}".format(self.get_balance(account.address))
+        )
+        logging.info("Installing contract from account {}".format(account.address))
         install_txn = self.w3.eth.send_raw_transaction(signed_txn.rawTransaction).hex()
         if confirm:
-            txn_id = self.wait_for_transaction_receipt(install_txn).hex()
-            logging.info("done waiting for txn_id {}".format(txn_id))
-            if txn_id:
-                txn_id = txn_id.replace("0x", "")
-                address = Web3.toChecksumAddress(
-                    # TODO: remove dependence on this Zilliqa API. Use TXN receipt instead.
-                    active_chain.api.GetContractAddressFromTransactionID(txn_id)
-                )
+            receipt = self.wait_for_transaction_receipt(install_txn)
+            if receipt:
+                address = receipt.get("contractAddress", None)
+                logging.debug("deployed contract at address: {}".format(address))
                 return contract_class(address=address)
+            else:
+                raise RuntimeError("Could not wait for txn ID {}".format(install_txn))
 
     def install_contract_bytes(self, account, data_bytes, *args, **kwargs):
         confirm = kwargs.get("confirm", True)
@@ -169,7 +187,6 @@ class EvmDsTestCase:
         nonce = self.w3.eth.get_transaction_count(account.address)
         txn = self.w3.eth.account.sign_transaction(
             {
-                "from": account.address,
                 "value": value,
                 "data": data_bytes,
                 "gas": 30_000,
@@ -183,22 +200,19 @@ class EvmDsTestCase:
             Web3.toHex(txn.rawTransaction)
         ).hex()
         if confirm:
-            txn_id = self.wait_for_transaction_receipt(install_txn).hex()
-            logging.info("done waiting for txn_id {}".format(txn_id))
-            if txn_id:
-                txn_id = txn_id.replace("0x", "")
-                address = Web3.toChecksumAddress(
-                    active_chain.api.GetContractAddressFromTransactionID(txn_id)
-                )
+            receipt = self.wait_for_transaction_receipt(install_txn)
+            if receipt:
+                address = receipt.get("contractAddress", None)
+                logging.debug("deployed contract at address: {}".format(address))
                 return self.w3.eth.contract(address=address)
+            else:
+                raise RuntimeError("Could not wait for txn ID {}".format(install_txn))
 
     def wait_for_transaction_receipt(self, txn_id, timeout=300):
         start = time.time()
         while time.time() - start <= timeout:
             try:
-                txn = self.w3.eth.get_transaction(txn_id)
-                if txn and "hash" in txn:
-                    return txn["hash"]
+                return self.w3.eth.get_transaction_receipt(txn_id)
             except TransactionNotFound:
                 pass
             logging.debug("Waiting for transaction: " + txn_id)
@@ -214,7 +228,11 @@ class EvmDsTestCase:
         if "confirm" in kwargs:
             del kwargs["confirm"]
         function = contract.get_function_by_name(method)
-        nonce = self.w3.eth.get_transaction_count(account.address)
+        nonce = self.get_nonce(account.address)
+        balance = self.get_balance(account.address)
+        logging.debug(
+            "Account {} balance {}, nonce {}".format(account.address, balance, nonce)
+        )
         txn = function(*args, **kwargs).build_transaction(
             {
                 "from": account.address,
@@ -229,12 +247,17 @@ class EvmDsTestCase:
         call_txn = self.w3.eth.send_raw_transaction(signed_txn.rawTransaction).hex()
         logging.info("call txn {}".format(call_txn))
         if confirm:
-            txn_id = self.wait_for_transaction_receipt(call_txn).hex()
-            return txn_id
+            txn_id = self.wait_for_transaction_receipt(call_txn)
+            if txn_id and "transactionHash" in txn_id:
+                return txn_id.get("transactionHash", None)
+            else:
+                return None
 
     def get_storage_at(self, address, position):
         ret = bytes(
-            self.w3.eth.get_storage_at(pad_address(address), pad_uint256(position).hex())
+            self.w3.eth.get_storage_at(
+                pad_address(address), pad_uint256(position).hex()
+            )
         )
         padding = 32 - len(ret)
         if padding < 0:

--- a/tests/evm_ds_test/run_test_loop.sh
+++ b/tests/evm_ds_test/run_test_loop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2019 Zilliqa
+# Copyright (C) 2022 Zilliqa
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/evm_ds_test/scripts/fund_accounts.py
+++ b/tests/evm_ds_test/scripts/fund_accounts.py
@@ -18,16 +18,29 @@ from pyzil.account import Account
 from pyzil.zilliqa.chain import BlockChain, set_active_chain, active_chain
 from pyzil.crypto.zilkey import to_checksum_address, ZilKey
 
+
 def fund(private_key, destination, amount):
     acc = Account(private_key=private_key)
-    blockchain = BlockChain(api_url="https://evmdev-l2api.dev.z7a.xyz", version=int("0x%04x%04x" % (333, 1), 0), network_id=333)
+    blockchain = BlockChain(
+        api_url="https://evmdev-l2api.dev.z7a.xyz",
+        version=int("0x%04x%04x" % (333, 1), 0),
+        network_id=333,
+    )
     set_active_chain(blockchain)
-    print ("Current balance: ", acc.get_balance())
+    print("Current balance: ", acc.get_balance())
     nonce = acc.get_nonce() + 1
     if amount > 0:
-        acc.transfer(to_addr=to_checksum_address(destination), zils=amount, gas_limit=100, priority=True, nonce=nonce, confirm=True)
+        acc.transfer(
+            to_addr=to_checksum_address(destination),
+            zils=amount,
+            gas_limit=100,
+            priority=True,
+            nonce=nonce,
+            confirm=True,
+        )
 
 
 if __name__ == "__main__":
     import sys
+
     fund(sys.argv[1], sys.argv[2], int(sys.argv[3], 0))

--- a/tests/evm_ds_test/tests/__init__.py
+++ b/tests/evm_ds_test/tests/__init__.py
@@ -13,4 +13,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-

--- a/tests/evm_ds_test/tests/conftest.py
+++ b/tests/evm_ds_test/tests/conftest.py
@@ -19,6 +19,7 @@ import os
 import numpy
 import random as rand
 
+
 @pytest.fixture(scope="session", autouse=True)
 def random():
     seed = int(os.environ.get("TESTSEED", "0"))

--- a/tests/evm_ds_test/tests/test_erc20.py
+++ b/tests/evm_ds_test/tests/test_erc20.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import time
 import pytest
 from eth_utils import decode_hex, to_checksum_address as eth_to_checksum_address
 

--- a/tests/evm_ds_test/tests/test_transfer.py
+++ b/tests/evm_ds_test/tests/test_transfer.py
@@ -17,11 +17,6 @@
 from evm_ds_test import test_case, from_zil
 from eth_account import Account as EthAccount
 
-from pyzil.zilliqa.units import Zil
-from pyzil.account import Account
-from pyzil.crypto.zilkey import to_checksum_address as zil_to_checksum_address
-
-
 import time
 
 
@@ -52,8 +47,8 @@ contract ForwardZil {
     function withdraw() public {
         // get the amount of Zil stored in this contract minus 10 zil.
         uint amount = address(this).balance;
-        if (amount > 10000 gwei) {  // 10 ZIL
-            amount -= 10000 gwei;
+        if (amount > 1000 gwei) {  // 1 ZIL
+            amount -= 1000 gwei;
         }
 
         // send all Ether to owner
@@ -85,19 +80,19 @@ contract ForwardZil {
         # and it is accepted. In EVM, the payment is accepted as long as there's
         # no revert.
         assert self.get_balance(contract.address) == 0
-        self.call_contract(self.account, contract, from_zil(300), "deposit")
-        assert self.get_balance(contract.address) == from_zil(300)
+        self.call_contract(self.account, contract, from_zil(2), "deposit")
+        assert self.get_balance(contract.address) == from_zil(2)
 
         # Check that we can pass apparent value to a non-payable method. It should revert
         # as the passed value is not zero, so the resulting balance should not change.
         try:
             self.call_contract(
-                self.account, contract, from_zil(200), "notPayable", confirm=False
+                self.account, contract, from_zil(1), "notPayable", confirm=False
             )
         except ValueError:
             pass  # For the isolated server
         self.wait_txn_timeout()
-        assert self.get_balance(contract.address) == from_zil(300)  # Should not change.
+        assert self.get_balance(contract.address) == from_zil(2)  # Should not change.
 
         # Check that we can have the contract itself send some value to some address.
         # We expect the resulting balance to be zero, as the contract sends all of
@@ -105,13 +100,10 @@ contract ForwardZil {
         self.call_contract(self.account, contract, 0, "withdraw")
         time.sleep(1)
 
-        zil_account = Account(address=zil_to_checksum_address(contract.address))
-        assert zil_account.get_balance() == Zil(10)
+        assert self.get_balance(contract.address) == from_zil(1)
 
-        assert self.get_balance(contract.address) == from_zil(10)
-
-        # Now we should get 290 Zil back to account. Minus the gas charges.
-        # But overall we should be down 10 Zil + any gas fees
+        # Now we should get 1 Zil back to account. Minus the gas charges.
+        # But overall we should be down 1 Zil + any gas fees
         account_diff = prev_balance - self.get_balance(self.account.address)
-        assert account_diff > from_zil(10)
-        assert account_diff < from_zil(100)  # Gas fees are not in tens of Zils even.
+        assert account_diff > from_zil(1)
+        assert account_diff < from_zil(2)  # Gas fees are not in tens of Zils even.


### PR DESCRIPTION
## Description
`evm_ds_test` now only depends on the web3 (eth compatible) APIs. No Zilliqa APIs should be used.

To make this work in your local environment,  replace the address `381f4008505e940ad7681ec3468a719060caf796` with `f0cb24ac66ba7375bf9b9c4fa91e208d9eaabd2e`. This is the address correspoding to the private key `d96e9eb5b782a80ea153c937fa83e5948485fbfc8b7e7c069d7b914dbc350aba`.

Correspondingly, the same address is replaced in the genesis accounts fed to the devnet deployment scripts with ` --genesis-address-file` argument:

`s/381F4008505E940AD7681EC3468A719060CAF796/F0CB24AC66BA7375BF9B9C4FA91E208D9EAABD2E/`

The same account in the Internal EVM Testnet has been generously funded.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
