### PR TITLE
[master] Scale transaction fields GasPrice and Amount

### DIFF
--- a/evm-ds/src/main.rs
+++ b/evm-ds/src/main.rs
@@ -188,7 +188,6 @@ async fn run_evm_impl(
         let config = evm::Config::london();
         let apparent_value = U256::from_dec_str(&apparent_value)
             .map_err(|e| Error::invalid_params(format!("apparent_value: {}", e)))?;
-        let apparent_value = backend.scale_zil_to_eth(apparent_value);
         let context = evm::Context {
             address: H160::from_str(&address)
                 .map_err(|e| Error::invalid_params(format!("address: {}", e)))?,

--- a/evm-ds/src/scillabackend.rs
+++ b/evm-ds/src/scillabackend.rs
@@ -293,7 +293,7 @@ impl<'config> Backend for ScillaBackend {
             .expect("query_state_value _nonce")
             .and_then(|x| x.as_uint256())
             .unwrap_or_default();
-        Basic { balance: balance * self.config.zil_scaling_factor, nonce }
+        Basic { balance: self.scale_zil_to_eth(balance), nonce }
     }
 
     fn code(&self, address: H160) -> Vec<u8> {

--- a/src/libCrypto/EthCrypto.cpp
+++ b/src/libCrypto/EthCrypto.cpp
@@ -28,6 +28,7 @@
 #include <openssl/ec.h>  // for EC_GROUP_new_by_curve_name, EC_GROUP_free, EC_KEY_new, EC_KEY_set_group, EC_KEY_generate_key, EC_KEY_free
 #include <openssl/obj_mac.h>  // for NID_secp192k1
 #include <openssl/sha.h>      //for SHA512_DIGEST_LENGTH
+#include <cstddef>
 #include <ethash/keccak.hpp>
 #include <iostream>
 #include <memory>
@@ -171,6 +172,32 @@ bool VerifyEcdsaSecp256k1(const bytes& sRandomNumber,
   return result;
 }
 
+bool SignEcdsaSecp256k1(const bytes& digest, const bytes& privKey,
+                        bytes& signature) {
+  std::unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
+      s_ctx{secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
+                                     SECP256K1_CONTEXT_VERIFY),
+            &secp256k1_context_destroy};
+
+  auto ctx = s_ctx.get();
+
+  secp256k1_ecdsa_signature sig;
+
+  int result =
+      secp256k1_ecdsa_sign(ctx, &sig, &digest[0], &privKey[0], NULL, NULL);
+  if (result != 1) {
+    LOG_GENERAL(WARNING, "Failed to sign ECDSA");
+    return false;
+  }
+
+  unsigned char str_signature[64];
+  secp256k1_ecdsa_signature_serialize_compact(ctx, str_signature, &sig);
+  signature.assign(&str_signature[0],
+                   &str_signature[0] + sizeof(str_signature));
+
+  return true;
+}
+
 // Given a hex string representing the pubkey (secp256k1), return the hex
 // representation of the pubkey in uncompressed format.
 // The input will have the '02' prefix, and the output will have the '04' prefix
@@ -180,8 +207,14 @@ std::string ToUncompressedPubKey(std::string const& pubKey) {
   std::unique_ptr<EC_KEY, decltype(ekFree)> zPublicKey(
       EC_KEY_new_by_curve_name(NID_secp256k1), ekFree);
 
+  size_t offset = 0;
+  if (pubKey.size() >= 2 && pubKey[0] == '0' &&
+      (pubKey[1] == 'x' || pubKey[1] == 'X')) {
+    offset = 2;
+  }
+
   // The +2 removes '0x' at the beginning of the string
-  if (!SetOpensslPublicKey(pubKey.c_str() + 2, zPublicKey.get())) {
+  if (!SetOpensslPublicKey(pubKey.c_str() + offset, zPublicKey.get())) {
     LOG_GENERAL(WARNING,
                 "Failed to get the public key from the hex input when getting "
                 "uncompressed form");
@@ -213,15 +246,6 @@ std::string ToUncompressedPubKey(std::string const& pubKey) {
   }
 
   return ret;
-}
-
-secp256k1_context const* getCtx() {
-  static std::unique_ptr<secp256k1_context,
-                         decltype(&secp256k1_context_destroy)>
-      s_ctx{secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
-                                     SECP256K1_CONTEXT_VERIFY),
-            &secp256k1_context_destroy};
-  return s_ctx.get();
 }
 
 // EIP-155 : assume the chain height is high enough that the signing scheme
@@ -307,7 +331,12 @@ bytes RecoverECDSAPubSig(std::string const& message, int chain_id) {
                                        messageRecreatedBytes.size());
 
   // Load the RS into the library
-  auto* ctx = getCtx();
+  std::unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
+      s_ctx{secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
+                                     SECP256K1_CONTEXT_VERIFY),
+            &secp256k1_context_destroy};
+  auto ctx = s_ctx.get();
+
   secp256k1_ecdsa_recoverable_signature rawSig;
   if (!secp256k1_ecdsa_recoverable_signature_parse_compact(
           ctx, &rawSig, rs.data(), vSelect)) {

--- a/src/libCrypto/EthCrypto.cpp
+++ b/src/libCrypto/EthCrypto.cpp
@@ -174,6 +174,16 @@ bool VerifyEcdsaSecp256k1(const bytes& sRandomNumber,
 
 bool SignEcdsaSecp256k1(const bytes& digest, const bytes& privKey,
                         bytes& signature) {
+  if (digest.size() != 32) {
+    LOG_GENERAL(WARNING, "Singing ECDSA: wrong digest length");
+    return false;
+  }
+
+  if (privKey.size() != 32) {
+    LOG_GENERAL(WARNING, "Singing ECDSA: wrong private key length");
+    return false;
+  }
+
   std::unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
       s_ctx{secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
                                      SECP256K1_CONTEXT_VERIFY),

--- a/src/libCrypto/EthCrypto.h
+++ b/src/libCrypto/EthCrypto.h
@@ -26,6 +26,9 @@
 
 constexpr unsigned int UNCOMPRESSED_SIGNATURE_SIZE = 65;
 
+bool SignEcdsaSecp256k1(const bytes& digest, const bytes& privKey,
+                        bytes& signature);
+
 bool VerifyEcdsaSecp256k1(const bytes& sRandomNumber,
                           const std::string& sSignature,
                           const std::string& sDevicePubKeyInHex);

--- a/src/libData/AccountData/AccountStoreBase.cpp
+++ b/src/libData/AccountData/AccountStoreBase.cpp
@@ -73,7 +73,7 @@ bool AccountStoreBase<MAP>::UpdateAccounts(const Transaction& transaction,
                                            TxnStatus& error_code) {
   const Address fromAddr = transaction.GetSenderAddr();
   Address toAddr = transaction.GetToAddr();
-  const uint128_t& amount = transaction.GetAmount();
+  const uint128_t& amount = transaction.GetAmountQa();
   error_code = TxnStatus::NOT_PRESENT;
 
   Account* fromAccount = this->GetAccount(fromAddr);
@@ -95,15 +95,15 @@ bool AccountStoreBase<MAP>::UpdateAccounts(const Transaction& transaction,
 
   uint128_t gasDeposit = 0;
   if (!SafeMath<uint128_t>::mul(transaction.GetGasLimit(),
-                                transaction.GetGasPrice(), gasDeposit)) {
+                                transaction.GetGasPriceQa(), gasDeposit)) {
     LOG_GENERAL(
         WARNING,
-        "transaction.GetGasLimit() * transaction.GetGasPrice() overflow!");
+        "transaction.GetGasLimit() * transaction.GetGasPriceQa() overflow!");
     error_code = TxnStatus::MATH_ERROR;
     return false;
   }
 
-  if (fromAccount->GetBalance() < transaction.GetAmount() + gasDeposit) {
+  if (fromAccount->GetBalance() < amount + gasDeposit) {
     LOG_GENERAL(WARNING,
                 "The account (balance: "
                     << fromAccount->GetBalance()
@@ -112,7 +112,7 @@ bool AccountStoreBase<MAP>::UpdateAccounts(const Transaction& transaction,
                     << gasDeposit
                     << ") "
                        "with amount ("
-                    << transaction.GetAmount() << ") in the transaction");
+                    << amount << ") in the transaction");
     error_code = TxnStatus::INSUFFICIENT_BALANCE;
     return false;
   }
@@ -132,7 +132,7 @@ bool AccountStoreBase<MAP>::UpdateAccounts(const Transaction& transaction,
 
   uint128_t gasRefund;
   if (!CalculateGasRefund(gasDeposit, NORMAL_TRAN_GAS,
-                          transaction.GetGasPrice(), gasRefund)) {
+                          transaction.GetGasPriceQa(), gasRefund)) {
     error_code = TxnStatus::MATH_ERROR;
     return false;
   }
@@ -161,7 +161,7 @@ bool AccountStoreBase<MAP>::CalculateGasRefund(const uint128_t& gasDeposit,
                                                uint128_t& gasRefund) {
   uint128_t gasFee;
   if (!SafeMath<uint128_t>::mul(gasUnit, gasPrice, gasFee)) {
-    LOG_GENERAL(WARNING, "gasUnit * transaction.GetGasPrice() overflow!");
+    LOG_GENERAL(WARNING, "gasUnit * gasPrice overflow!");
     return false;
   }
 

--- a/src/libData/AccountData/AccountStoreSC.cpp
+++ b/src/libData/AccountData/AccountStoreSC.cpp
@@ -146,14 +146,14 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
   const Address fromAddr = Account::GetAddressFromPublicKey(senderPubKey);
   Address toAddr = transaction.GetToAddr();
 
-  const uint128_t& amount = transaction.GetAmount();
+  const uint128_t& amount = transaction.GetAmountQa();
 
   // Initiate gasRemained
   uint64_t gasRemained = transaction.GetGasLimit();
 
   // Get the amount of deposit for running this txn
   uint128_t gasDeposit;
-  if (!SafeMath<uint128_t>::mul(gasRemained, transaction.GetGasPrice(),
+  if (!SafeMath<uint128_t>::mul(gasRemained, transaction.GetGasPriceQa(),
                                 gasDeposit)) {
     error_code = TxnStatus::MATH_ERROR;
     return false;
@@ -206,7 +206,7 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
             WARNING,
             "The account doesn't have enough gas to create a contract. Bal: "
                 << fromAccount->GetBalance()
-                << " required: " << gasDeposit + transaction.GetAmount());
+                << " required: " << gasDeposit + amount);
         error_code = TxnStatus::INSUFFICIENT_BALANCE;
         return false;
       }
@@ -399,7 +399,7 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       // Summary
       boost::multiprecision::uint128_t gasRefund;
       if (!SafeMath<boost::multiprecision::uint128_t>::mul(
-              gasRemained, transaction.GetGasPrice(), gasRefund)) {
+              gasRemained, transaction.GetGasPriceQa(), gasRefund)) {
         this->RemoveAccount(toAddr);
         error_code = TxnStatus::MATH_ERROR;
         return false;
@@ -590,7 +590,7 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       }
 
       m_curGasLimit = transaction.GetGasLimit();
-      m_curGasPrice = transaction.GetGasPrice();
+      m_curGasPrice = transaction.GetGasPriceQa();
       m_curContractAddr = toAddr;
       m_curAmount = amount;
       m_curNumShards = numShards;
@@ -640,7 +640,7 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       }
       boost::multiprecision::uint128_t gasRefund;
       if (!SafeMath<boost::multiprecision::uint128_t>::mul(
-              gasRemained, transaction.GetGasPrice(), gasRefund)) {
+              gasRemained, transaction.GetGasPriceQa(), gasRefund)) {
         error_code = TxnStatus::MATH_ERROR;
         return false;
       }
@@ -930,7 +930,7 @@ bool AccountStoreSC<MAP>::ExportCallContractFiles(
         prepend +
         Account::GetAddressFromPublicKey(transaction.GetSenderPubKey()).hex();
     msgObj["_origin"] = prepend + m_originAddr.hex();
-    msgObj["_amount"] = transaction.GetAmount().convert_to<std::string>();
+    msgObj["_amount"] = transaction.GetAmountQa().convert_to<std::string>();
 
     JSONUtils::GetInstance().writeJsontoFile(INPUT_MESSAGE_JSON, msgObj);
   } catch (const std::exception& e) {

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include "AccountStoreSC.h"
 #include "EvmClient.h"
+#include "common/Constants.h"
 #include "libPersistence/ContractStorage.h"
 #include "libUtils/EvmCallParameters.h"
 #include "libUtils/EvmJsonResponse.h"
@@ -286,7 +287,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
   // Get the amount of deposit for running this txn
   uint128_t gasDeposit;
-  if (!SafeMath<uint128_t>::mul(gasRemained, transaction.GetGasPrice(),
+  if (!SafeMath<uint128_t>::mul(gasRemained, transaction.GetGasPriceWei(),
                                 gasDeposit)) {
     error_code = TxnStatus::MATH_ERROR;
     return false;
@@ -318,7 +319,8 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       }
 
       // Check if the sender has enough balance to pay gasDeposit
-      if (fromAccount->GetBalance() < gasDeposit + transaction.GetAmount()) {
+      if (fromAccount->GetBalance() * EVM_ZIL_SCALING_FACTOR <
+          gasDeposit + transaction.GetAmountWei()) {
         LOG_GENERAL(WARNING,
                     "The account doesn't have enough gas to create a contract");
         error_code = TxnStatus::INSUFFICIENT_BALANCE;
@@ -390,11 +392,11 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
       LOG_GENERAL(INFO, "Invoking EVM with Cumulative Gas "
                             << gasRemained << " alleged "
-                            << transaction.GetAmount() << " limit "
+                            << transaction.GetAmountQa() << " limit "
                             << transaction.GetGasLimit());
 
       if (!TransferBalanceAtomic(fromAddr, contractAddress,
-                                 transaction.GetAmount())) {
+                                 transaction.GetAmountQa())) {
         error_code = TxnStatus::INSUFFICIENT_BALANCE;
         LOG_GENERAL(WARNING, "TransferBalance Atomic failed");
         return false;
@@ -406,7 +408,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
           DataConversion::CharArrayToString(transaction.GetCode()),
           DataConversion::CharArrayToString(transaction.GetData()),
           transaction.GetGasLimit(),
-          transaction.GetAmount()};
+          transaction.GetAmountWei()};
 
       std::map<std::string, bytes> t_newmetadata;
 
@@ -428,11 +430,12 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       // Summary
       boost::multiprecision::uint128_t gasRefund;
       if (!SafeMath<boost::multiprecision::uint128_t>::mul(
-              gasRemained, transaction.GetGasPrice(), gasRefund)) {
+              gasRemained, transaction.GetGasPriceWei(), gasRefund)) {
         error_code = TxnStatus::MATH_ERROR;
         return false;
       }
-      if (!this->IncreaseBalance(fromAddr, gasRefund)) {
+      if (!this->IncreaseBalance(fromAddr,
+                                 gasRefund / EVM_ZIL_SCALING_FACTOR)) {
         LOG_GENERAL(FATAL, "IncreaseBalance failed for gasRefund");
       }
       if (evm_call_run_succeeded) {
@@ -492,7 +495,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
       LOG_GENERAL(INFO, "Call contract");
 
-      if (fromAccount->GetBalance() < gasDeposit + transaction.GetAmount()) {
+      if (fromAccount->GetBalance() < gasDeposit + transaction.GetAmountQa()) {
         LOG_GENERAL(WARNING, "The account (balance: "
                                  << fromAccount->GetBalance()
                                  << ") "
@@ -501,7 +504,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
                                  << gasDeposit
                                  << ") "
                                     "and transfer the amount ("
-                                 << transaction.GetAmount()
+                                 << transaction.GetAmountQa()
                                  << ") in the txn, "
                                     "rejected");
         error_code = TxnStatus::INSUFFICIENT_BALANCE;
@@ -532,9 +535,9 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       }
 
       m_curGasLimit = transaction.GetGasLimit();
-      m_curGasPrice = transaction.GetGasPrice();
+      m_curGasPrice = transaction.GetGasPriceWei();
       m_curContractAddr = transaction.GetToAddr();
-      m_curAmount = transaction.GetAmount();
+      m_curAmount = transaction.GetAmountQa();
       m_curNumShards = numShards;
 
       std::chrono::system_clock::time_point tpStart;
@@ -555,7 +558,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       bool evm_call_succeeded{true};
 
       if (!TransferBalanceAtomic(fromAddr, m_curContractAddr,
-                                 transaction.GetAmount())) {
+                                 transaction.GetAmountQa())) {
         error_code = TxnStatus::INSUFFICIENT_BALANCE;
         LOG_GENERAL(WARNING, "TransferBalance Atomic failed");
         return false;
@@ -567,7 +570,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
           DataConversion::CharArrayToString(contractAccount->GetCode()),
           DataConversion::CharArrayToString(transaction.GetData()),
           transaction.GetGasLimit(),
-          transaction.GetAmount()};
+          transaction.GetAmountWei()};
 
       LOG_GENERAL(WARNING, "contract address is " << params.m_contract
                                                   << " caller account is "
@@ -590,12 +593,13 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       }
       boost::multiprecision::uint128_t gasRefund;
       if (!SafeMath<boost::multiprecision::uint128_t>::mul(
-              gasRemained, transaction.GetGasPrice(), gasRefund)) {
+              gasRemained, transaction.GetGasPriceWei(), gasRefund)) {
         error_code = TxnStatus::MATH_ERROR;
         return false;
       }
 
-      if (!this->IncreaseBalance(fromAddr, gasRefund)) {
+      if (!this->IncreaseBalance(fromAddr,
+                                 gasRefund / EVM_ZIL_SCALING_FACTOR)) {
         LOG_GENERAL(WARNING, "IncreaseBalance failed for gasRefund");
       }
 

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -361,7 +361,8 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       try {
         // TODO verify this line is needed, suspect it is a scilla thing
         m_curBlockNum = blockNum;
-        if (!this->DecreaseBalance(fromAddr, gasDepositWei / EVM_ZIL_SCALING_FACTOR)) {
+        if (!this->DecreaseBalance(fromAddr,
+                                   gasDepositWei / EVM_ZIL_SCALING_FACTOR)) {
           LOG_GENERAL(WARNING, "Evm Decrease Balance has failed");
           error_code = TxnStatus::FAIL_CONTRACT_INIT;
           return false;
@@ -495,8 +496,8 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
       LOG_GENERAL(INFO, "Call contract");
 
-      if (fromAccount->GetBalance() * EVM_ZIL_SCALING_FACTOR
-          < gasDepositWei + transaction.GetAmountWei()) {
+      if (fromAccount->GetBalance() * EVM_ZIL_SCALING_FACTOR <
+          gasDepositWei + transaction.GetAmountWei()) {
         LOG_GENERAL(WARNING, "The account (balance: "
                                  << fromAccount->GetBalance()
                                  << ") "
@@ -529,7 +530,8 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
       DiscardAtomics();
 
-      if (!this->DecreaseBalance(fromAddr, gasDepositWei / EVM_ZIL_SCALING_FACTOR)) {
+      if (!this->DecreaseBalance(fromAddr,
+                                 gasDepositWei / EVM_ZIL_SCALING_FACTOR)) {
         LOG_GENERAL(WARNING, "DecreaseBalance failed");
         error_code = TxnStatus::MATH_ERROR;
         return false;

--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -220,10 +220,10 @@ const uint128_t Transaction::GetGasPriceQa() const {
 
 const uint128_t Transaction::GetGasPriceWei() const {
   if (IsEth()) {
-    return m_coreInfo.amount;
+    return m_coreInfo.gasPrice;
   } else {
     // We know the amounts in transactions are capped, so it won't overlow.
-    return m_coreInfo.amount * EVM_ZIL_SCALING_FACTOR;
+    return m_coreInfo.gasPrice * EVM_ZIL_SCALING_FACTOR;
   }
 }
 

--- a/src/libData/AccountData/Transaction.cpp
+++ b/src/libData/AccountData/Transaction.cpp
@@ -165,7 +165,7 @@ const PubKey& Transaction::GetSenderPubKey() const {
 
 Address Transaction::GetSenderAddr() const {
   // If a V2 Tx
-  if ((GetVersion() & 0xffff) == 0x2) {
+  if (IsEth()) {
     LOG_GENERAL(WARNING, "Getting eth style address from pub key");
     return Account::GetAddressFromPublicKeyEth(GetSenderPubKey());
   }
@@ -173,10 +173,46 @@ Address Transaction::GetSenderAddr() const {
   return Account::GetAddressFromPublicKey(GetSenderPubKey());
 }
 
-const uint128_t& Transaction::GetAmount() const { return m_coreInfo.amount; }
+bool Transaction::IsEth() const { return (GetVersion() & 0xffff) == 0x2; }
 
-const uint128_t& Transaction::GetGasPrice() const {
+const uint128_t& Transaction::GetAmountRaw() const { return m_coreInfo.amount; }
+
+const uint128_t Transaction::GetAmountQa() const {
+  if (IsEth()) {
+    return m_coreInfo.amount / EVM_ZIL_SCALING_FACTOR;
+  } else {
+    return m_coreInfo.amount;
+  }
+}
+
+const uint128_t Transaction::GetAmountWei() const {
+  if (IsEth()) {
+    return m_coreInfo.amount;
+  } else {
+    // We know the amounts in transactions are capped, so it won't overlow.
+    return m_coreInfo.amount * EVM_ZIL_SCALING_FACTOR;
+  }
+}
+
+const uint128_t& Transaction::GetGasPriceRaw() const {
   return m_coreInfo.gasPrice;
+}
+
+const uint128_t Transaction::GetGasPriceQa() const {
+  if (IsEth()) {
+    return m_coreInfo.gasPrice / EVM_ZIL_SCALING_FACTOR;
+  } else {
+    return m_coreInfo.gasPrice;
+  }
+}
+
+const uint128_t Transaction::GetGasPriceWei() const {
+  if (IsEth()) {
+    return m_coreInfo.amount;
+  } else {
+    // We know the amounts in transactions are capped, so it won't overlow.
+    return m_coreInfo.amount * EVM_ZIL_SCALING_FACTOR;
+  }
 }
 
 const uint64_t& Transaction::GetGasLimit() const { return m_coreInfo.gasLimit; }

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -119,6 +119,8 @@ class Transaction : public SerializableDataBlock {
   /// Returns the current version.
   const uint32_t& GetVersion() const;
 
+  bool IsEth() const;
+
   /// Returns whether the current version is correct
   bool VersionCorrect() const;
 
@@ -134,11 +136,23 @@ class Transaction : public SerializableDataBlock {
   /// Returns the sender's Address
   Address GetSenderAddr() const;
 
-  /// Returns the transaction amount.
-  const uint128_t& GetAmount() const;
+  /// Returns the transaction amount in Qa.
+  const uint128_t GetAmountQa() const;
 
-  /// Returns the gas price.
-  const uint128_t& GetGasPrice() const;
+  /// Returns the transaction amount in Wei.
+  const uint128_t GetAmountWei() const;
+
+  /// Returns the transaction amount in raw units regardless of Qa or Wei.
+  const uint128_t& GetAmountRaw() const;
+
+  /// Returns the gas price in Qa.
+  const uint128_t GetGasPriceQa() const;
+
+  /// Returns the gas price in Wei.
+  const uint128_t GetGasPriceWei() const;
+
+  /// Returns the gas price in raw uints regadless of Qa or Wei.
+  const uint128_t& GetGasPriceRaw() const;
 
   /// Returns the gas limit.
   const uint64_t& GetGasLimit() const;

--- a/src/libData/AccountData/TxnPool.h
+++ b/src/libData/AccountData/TxnPool.h
@@ -74,8 +74,8 @@ struct TxnPool {
 
     auto searchNonce = NonceIndex.find({t.GetSenderPubKey(), t.GetNonce()});
     if (searchNonce != NonceIndex.end()) {
-      if ((t.GetGasPrice() > searchNonce->second.GetGasPrice()) ||
-          (t.GetGasPrice() == searchNonce->second.GetGasPrice() &&
+      if ((t.GetGasPriceQa() > searchNonce->second.GetGasPriceQa()) ||
+          (t.GetGasPriceQa() == searchNonce->second.GetGasPriceQa() &&
            t.GetTranID() < searchNonce->second.GetTranID())) {
         // erase from HashIdxTxns
         TxnHash hashToBeRemoved = searchNonce->second.GetTranID();
@@ -84,8 +84,8 @@ struct TxnPool {
           HashIndex.erase(searchHash);
         }
         // erase from GasIdxTxns
-        auto smallerGasPrice = searchNonce->second.GetGasPrice();
-        auto searchGas = GasIndex.find(searchNonce->second.GetGasPrice());
+        auto smallerGasPrice = searchNonce->second.GetGasPriceQa();
+        auto searchGas = GasIndex.find(searchNonce->second.GetGasPriceQa());
         if (searchGas != GasIndex.end()) {
           auto searchGasHash =
               searchGas->second.find(searchNonce->second.GetTranID());
@@ -97,7 +97,7 @@ struct TxnPool {
           }
         }
         HashIndex[t.GetTranID()] = t;
-        GasIndex[t.GetGasPrice()][t.GetTranID()] = t;
+        GasIndex[t.GetGasPriceQa()][t.GetTranID()] = t;
         searchNonce->second = t;
 
         status = {TxnStatus::MEMPOOL_SAME_NONCE_LOWER_GAS, hashToBeRemoved};
@@ -110,7 +110,7 @@ struct TxnPool {
       }
     } else {
       HashIndex[t.GetTranID()] = t;
-      GasIndex[t.GetGasPrice()][t.GetTranID()] = t;
+      GasIndex[t.GetGasPriceQa()][t.GetTranID()] = t;
       NonceIndex[{t.GetSenderPubKey(), t.GetNonce()}] = t;
     }
     status = {TxnStatus::NOT_PRESENT, t.GetTranID()};
@@ -120,15 +120,15 @@ struct TxnPool {
   void findSameNonceButHigherGas(Transaction& t) {
     auto searchNonce = NonceIndex.find({t.GetSenderPubKey(), t.GetNonce()});
     if (searchNonce != NonceIndex.end()) {
-      if (searchNonce->second.GetGasPrice() > t.GetGasPrice()) {
+      if (searchNonce->second.GetGasPriceQa() > t.GetGasPriceQa()) {
         t = std::move(searchNonce->second);
 
         // erase tx nonce map
         NonceIndex.erase(searchNonce);
         // erase tx gas map
-        GasIndex[t.GetGasPrice()].erase(t.GetTranID());
-        if (GasIndex[t.GetGasPrice()].empty()) {
-          GasIndex.erase(t.GetGasPrice());
+        GasIndex[t.GetGasPriceQa()].erase(t.GetTranID());
+        if (GasIndex[t.GetGasPriceQa()].empty()) {
+          GasIndex.erase(t.GetGasPriceQa());
         }
         // erase tx hash map
         HashIndex.erase(t.GetTranID());

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -452,7 +452,7 @@ void Node::ProcessTransactionWhenShardLeader(
           break;
         }
         uint128_t txnFee;
-        if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPrice(),
+        if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPriceQa(),
                                       txnFee)) {
           LOG_GENERAL(WARNING, "txnFee multiplication unsafe!");
           continue;
@@ -489,7 +489,7 @@ void Node::ProcessTransactionWhenShardLeader(
           if (it2 != it1->second.end()) {
             // found the txn with same addr and same nonce
             // then compare the gasprice and remains the higher one
-            if (t.GetGasPrice() > it2->second.GetGasPrice()) {
+            if (t.GetGasPriceQa() > it2->second.GetGasPriceQa()) {
               it2->second = t;
             }
             continue;
@@ -526,7 +526,7 @@ void Node::ProcessTransactionWhenShardLeader(
             break;
           }
           uint128_t txnFee;
-          if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPrice(),
+          if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPriceQa(),
                                         txnFee)) {
             LOG_GENERAL(WARNING, "txnFee multiplication unsafe!");
             continue;
@@ -624,17 +624,19 @@ bool Node::VerifyTxnsOrdering(const vector<TxnHash>& tranHashes,
     for (const auto& th : m_expectedTranOrdering) {
       Transaction t;
       if (m_createdTxns.get(th, t)) {
-        LOG_GENERAL(INFO, "Expected txn: "
-                              << t.GetTranID() << " " << t.GetSenderAddr()
-                              << " " << t.GetNonce() << " " << t.GetGasPrice());
+        LOG_GENERAL(INFO, "Expected txn: " << t.GetTranID() << " "
+                                           << t.GetSenderAddr() << " "
+                                           << t.GetNonce() << " "
+                                           << t.GetGasPriceQa());
       }
     }
     for (const auto& th : tranHashes) {
       Transaction t;
       if (m_createdTxns.get(th, t)) {
-        LOG_GENERAL(INFO, "Received txn: "
-                              << t.GetTranID() << " " << t.GetSenderAddr()
-                              << " " << t.GetNonce() << " " << t.GetGasPrice());
+        LOG_GENERAL(INFO, "Received txn: " << t.GetTranID() << " "
+                                           << t.GetSenderAddr() << " "
+                                           << t.GetNonce() << " "
+                                           << t.GetGasPriceQa());
       }
     }
 
@@ -770,7 +772,7 @@ void Node::ProcessTransactionWhenShardBackup(
           break;
         }
         uint128_t txnFee;
-        if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPrice(),
+        if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPriceQa(),
                                       txnFee)) {
           LOG_GENERAL(WARNING, "txnFee multiplication unsafe!");
           continue;
@@ -807,7 +809,7 @@ void Node::ProcessTransactionWhenShardBackup(
           if (it2 != it1->second.end()) {
             // found the txn with same addr and same nonce
             // then compare the gasprice and remains the higher one
-            if (t.GetGasPrice() > it2->second.GetGasPrice()) {
+            if (t.GetGasPriceQa() > it2->second.GetGasPriceQa()) {
               it2->second = t;
             }
             continue;
@@ -844,7 +846,7 @@ void Node::ProcessTransactionWhenShardBackup(
             break;
           }
           uint128_t txnFee;
-          if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPrice(),
+          if (!SafeMath<uint128_t>::mul(tr.GetCumGas(), t.GetGasPriceQa(),
                                         txnFee)) {
             LOG_GENERAL(WARNING, "txnFee multiplication overflow!");
             continue;

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -388,11 +388,11 @@ bool IsolatedServer::ValidateTxn(const Transaction& tx, const Address& fromAddr,
                            "Code size is too large");
   }
 
-  if (tx.GetGasPrice() < gasPrice) {
-    throw JsonRpcException(ServerBase::RPC_VERIFY_REJECTED,
-                           "GasPrice " + tx.GetGasPrice().convert_to<string>() +
-                               " lower than minimum allowable " +
-                               gasPrice.convert_to<string>());
+  if (tx.GetGasPriceQa() < gasPrice) {
+    throw JsonRpcException(
+        ServerBase::RPC_VERIFY_REJECTED,
+        "GasPrice " + tx.GetGasPriceQa().convert_to<string>() +
+            " lower than minimum allowable " + gasPrice.convert_to<string>());
   }
   if (!Validator::VerifyTransaction(tx)) {
     throw JsonRpcException(ServerBase::RPC_VERIFY_REJECTED,
@@ -530,12 +530,12 @@ Json::Value IsolatedServer::CreateTransaction(const Json::Value& _json) {
                              "Expected Nonce: " + to_string(senderNonce + 1));
     }
 
-    if (senderBalance < tx.GetAmount()) {
+    if (senderBalance < tx.GetAmountQa()) {
       throw JsonRpcException(RPC_INVALID_PARAMETER,
                              "Insufficient Balance: " + senderBalance.str());
     }
 
-    if (m_gasPrice > tx.GetGasPrice()) {
+    if (m_gasPrice > tx.GetGasPriceQa()) {
       throw JsonRpcException(RPC_INVALID_PARAMETER,
                              "Minimum gas price greater: " + m_gasPrice.str());
     }
@@ -682,8 +682,9 @@ Json::Value IsolatedServer::CreateTransactionEth(Eth::EthFields const& fields,
     uint64_t senderNonce;
     uint256_t senderBalance;
 
-    const uint128_t& gasPrice =
-        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetGasPrice();
+    const uint128_t gasPriceWei =
+        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetGasPrice() *
+        EVM_ZIL_SCALING_FACTOR;
 
     const Address fromAddr = tx.GetSenderAddr();
 
@@ -695,7 +696,7 @@ Json::Value IsolatedServer::CreateTransactionEth(Eth::EthFields const& fields,
 
       const Account* sender = AccountStore::GetInstance().GetAccount(fromAddr);
 
-      if (!Eth::ValidateEthTxn(tx, fromAddr, sender, gasPrice)) {
+      if (!Eth::ValidateEthTxn(tx, fromAddr, sender, gasPriceWei)) {
         return ret;
       }
 
@@ -706,14 +707,15 @@ Json::Value IsolatedServer::CreateTransactionEth(Eth::EthFields const& fields,
     // Sender's balance should be higher than value sent in the transaction +
     // max gas to be used by contract action
     const uint256_t requiredGas =
-        uint256_t{tx.GetGasPrice()} * uint256_t{tx.GetGasLimit()};
-    const uint256_t requiredBalance = uint256_t{tx.GetAmount()} + requiredGas;
+        uint256_t{tx.GetGasPriceWei()} * uint256_t{tx.GetGasLimit()};
+    const uint256_t requiredBalance =
+        uint256_t{tx.GetAmountWei()} + requiredGas;
 
     if (senderBalance < requiredBalance) {
       throw JsonRpcException(
           RPC_INVALID_PARAMETER,
           "Insufficient Balance: " + senderBalance.str() +
-              " with an attempt to send: " + tx.GetAmount().str() +
+              " with an attempt to send: " + tx.GetAmountQa().str() +
               " and use totalGas: " + requiredGas.str());
     }
 

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -715,7 +715,7 @@ Json::Value IsolatedServer::CreateTransactionEth(Eth::EthFields const& fields,
       throw JsonRpcException(
           RPC_INVALID_PARAMETER,
           "Insufficient Balance: " + senderBalance.str() +
-              " with an attempt to send: " + tx.GetAmountQa().str() +
+              " with an attempt to send: " + tx.GetAmountWei().str() +
               " and use totalGas: " + requiredGas.str());
     }
 

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -15,9 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <chrono>
 #include <string>
 #include <vector>
-#include <chrono>
 
 #include <boost/format.hpp>
 
@@ -603,10 +603,10 @@ const Json::Value JSONConversion::convertTxtoJson(const Transaction& txn) {
   _json["nonce"] = to_string(txn.GetNonce());
   _json["toAddr"] = txn.GetToAddr().hex();
   _json["senderAddr"] = txn.GetSenderAddr().hex();
-  _json["amount"] = txn.GetAmount().str();
+  _json["amount"] = txn.GetAmountQa().str();
   _json["signature"] = static_cast<string>(txn.GetSignature());
 
-  _json["gasPrice"] = txn.GetGasPrice().str();
+  _json["gasPrice"] = txn.GetGasPriceQa().str();
   _json["gasLimit"] = to_string(txn.GetGasLimit());
 
   if (!txn.GetCode().empty()) {
@@ -629,10 +629,10 @@ const Json::Value JSONConversion::convertTxtoJson(
   _json["toAddr"] = twr.GetTransaction().GetToAddr().hex();
   _json["senderPubKey"] =
       static_cast<string>(twr.GetTransaction().GetSenderPubKey());
-  _json["amount"] = twr.GetTransaction().GetAmount().str();
+  _json["amount"] = twr.GetTransaction().GetAmountQa().str();
   _json["signature"] = static_cast<string>(twr.GetTransaction().GetSignature());
   _json["receipt"] = twr.GetTransactionReceipt().GetJsonValue();
-  _json["gasPrice"] = twr.GetTransaction().GetGasPrice().str();
+  _json["gasPrice"] = twr.GetTransaction().GetGasPriceQa().str();
   _json["gasLimit"] = to_string(twr.GetTransaction().GetGasLimit());
 
   if (!twr.GetTransaction().GetCode().empty()) {
@@ -659,10 +659,10 @@ const Json::Value JSONConversion::convertTxtoEthJson(
       (boost::format("0x%x") % txn.GetTransactionReceipt().GetCumGas()).str();
   // ethers also expectes gasLimit and ChainId
   retJson["gasLimit"] =
-      (boost::format("0x%x") % txn.GetTransactionReceipt().GetCumGas()).str();
+      (boost::format("0x%x") % txn.GetTransaction().GetGasLimit()).str();
   retJson["chainId"] = (boost::format("0x%x") % ETH_CHAINID_INT).str();
   retJson["gasPrice"] =
-      (boost::format("0x%x") % txn.GetTransaction().GetGasPrice()).str();
+      (boost::format("0x%x") % txn.GetTransaction().GetGasPriceWei()).str();
   retJson["hash"] = "0x" + txn.GetTransaction().GetTranID().hex();
 
   // Concatenated Code and CallData form input entry in response json
@@ -690,7 +690,7 @@ const Json::Value JSONConversion::convertTxtoEthJson(
       (boost::format("0x%x") % txn.GetTransaction().GetNonce()).str();
   retJson["to"] = "0x" + txn.GetTransaction().GetToAddr().hex();
   retJson["value"] =
-      (boost::format("0x%x") % txn.GetTransaction().GetAmount()).str();
+      (boost::format("0x%x") % txn.GetTransaction().GetAmountWei()).str();
   if (!txn.GetTransaction().GetCode().empty() &&
       IsNullAddress(txn.GetTransaction().GetToAddr())) {
     retJson["contractAddress"] =

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1737,7 +1737,8 @@ std::string LookupServer::GetWeb3ClientVersion() {
 string LookupServer::GetWeb3Sha3(const Json::Value& _json) {
   LOG_MARKER();
   bytes input = DataConversion::HexStrToUint8VecRet(_json.asString());
-  return POW::BlockhashToHexString(ethash::keccak256(input.data(), input.size()));
+  return POW::BlockhashToHexString(
+      ethash::keccak256(input.data(), input.size()));
 }
 
 Json::Value LookupServer::GetEthUncleCount() {

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -509,7 +509,7 @@ LookupServer::LookupServer(Mediator& mediator,
       &LookupServer::GetNetListeningI);
 
   this->bindAndAddMethod(
-      jsonrpc::Procedure("eth_protocolVersion", jsonrpc::PARAMS_BY_POSITION,
+      jsonrpc::Procedure("protocol_version", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, NULL),
       &LookupServer::GetProtocolVersionI);
 
@@ -1182,23 +1182,16 @@ Json::Value LookupServer::GetEthBlockCommon(const TxBlock& txBlock,
                                                  includeFullTransactions);
 }
 
-Json::Value LookupServer::GetEthBalance(const std::string& address,
-                                        const std::string& tag) {
-  if (tag == "latest" || tag == "earliest" || tag == "pending") {
-    const auto balanceStr =
-        this->GetBalance(address, true)["balance"].asString();
+Json::Value LookupServer::GetEthBalance(const std::string& address) {
+  const auto balanceStr = this->GetBalance(address, true)["balance"].asString();
 
-    const uint256_t ethBalance =
-        std::strtoll(balanceStr.c_str(), nullptr, 16) * EVM_ZIL_SCALING_FACTOR;
+  const uint256_t ethBalance =
+      std::strtoll(balanceStr.c_str(), nullptr, 16) * EVM_ZIL_SCALING_FACTOR;
 
-    std::ostringstream strm;
-    strm << "0x" << std::hex << ethBalance << std::dec;
+  std::ostringstream strm;
+  strm << "0x" << std::hex << ethBalance << std::dec;
 
-    return strm.str();
-  }
-  throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process, invalid tag");
-
-  return "";
+  return strm.str();
 }
 
 Json::Value LookupServer::GetEthBlockTransactionCountByHash(
@@ -1730,21 +1723,17 @@ Json::Value LookupServer::GetBalance(const string& address, bool noThrow) {
 
 std::string LookupServer::GetWeb3ClientVersion() {
   LOG_MARKER();
-
-  return "Zilliqa/v8.2";
+  return "to do implement web3 version string";
 }
 
 string LookupServer::GetWeb3Sha3(const Json::Value& _json) {
   LOG_MARKER();
 
-  auto str{_json.asString()};
-  if (str.length() > 2 && (str[1] == 'x' || str[1] == 'X')) {
-    str = str.substr(2);
-  }
-
+  const auto str{_json.asString()};
   LOG_GENERAL(DEBUG, "GetWeb3Sha3 on:" << str);
 
-  return dev::sha3(str).hex();
+  return POW::BlockhashToHexString(ethash::keccak256(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size()));
 }
 
 Json::Value LookupServer::GetEthUncleCount() {
@@ -1775,12 +1764,12 @@ std::string LookupServer::GetEthCoinbase() {
 
 std::string LookupServer::GetNetVersion() {
   LOG_MARKER();
-  return std::to_string(NETWORK_ID);
+  return "0x8000";  // Like Ethereum, including test nets.
 }
 
 Json::Value LookupServer::GetNetListening() {
   LOG_MARKER();
-  return Json::Value(true);
+  return Json::Value(false);
 }
 
 std::string LookupServer::GetNetPeerCount() {
@@ -3132,7 +3121,7 @@ Json::Value LookupServer::GetMinerInfo(const std::string& blockNum) {
     throw JsonRpcException(RPC_INVALID_PARAMS, "String not numeric");
   } catch (invalid_argument& e) {
     LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
-    throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid argument");
+    throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid arugment");
   } catch (out_of_range& e) {
     LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << blockNum);
     throw JsonRpcException(RPC_INVALID_PARAMS, "Out of range");
@@ -3197,7 +3186,7 @@ Json::Value LookupServer::GetStateProof(const string& address,
     } catch (invalid_argument& e) {
       LOG_GENERAL(INFO,
                   "[Error]" << e.what() << " TxBlockNum: " << txBlockNumOrTag);
-      throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid argument");
+      throw JsonRpcException(RPC_INVALID_PARAMS, "Invalid arugment");
     } catch (out_of_range& e) {
       LOG_GENERAL(INFO,
                   "[Error]" << e.what() << " TxBlockNum: " << txBlockNumOrTag);

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -680,11 +680,11 @@ bool ValidateTxn(const Transaction& tx, const Address& fromAddr,
                            "Code size is too large");
   }
 
-  if (tx.GetGasPrice() < gasPrice) {
-    throw JsonRpcException(ServerBase::RPC_VERIFY_REJECTED,
-                           "GasPrice " + tx.GetGasPrice().convert_to<string>() +
-                               " lower than minimum allowable " +
-                               gasPrice.convert_to<string>());
+  if (tx.GetGasPriceQa() < gasPrice) {
+    throw JsonRpcException(
+        ServerBase::RPC_VERIFY_REJECTED,
+        "GasPrice " + tx.GetGasPriceQa().convert_to<string>() +
+            " lower than minimum allowable " + gasPrice.convert_to<string>());
   }
   if (!Validator::VerifyTransaction(tx)) {
     throw JsonRpcException(ServerBase::RPC_VERIFY_REJECTED,
@@ -741,17 +741,17 @@ bool ValidateTxn(const Transaction& tx, const Address& fromAddr,
 
   // Check if transaction amount is valid
   uint128_t gasDeposit = 0;
-  if (!SafeMath<uint128_t>::mul(tx.GetGasLimit(), tx.GetGasPrice(),
+  if (!SafeMath<uint128_t>::mul(tx.GetGasLimit(), tx.GetGasPriceQa(),
                                 gasDeposit)) {
     throw JsonRpcException(ServerBase::RPC_INVALID_PARAMETER,
-                           "tx.GetGasLimit() * tx.GetGasPrice() overflow!");
+                           "tx.GetGasLimit() * tx.GetGasPriceQa() overflow!");
   }
 
   uint128_t debt = 0;
-  if (!SafeMath<uint128_t>::add(gasDeposit, tx.GetAmount(), debt)) {
+  if (!SafeMath<uint128_t>::add(gasDeposit, tx.GetAmountQa(), debt)) {
     throw JsonRpcException(
         ServerBase::RPC_INVALID_PARAMETER,
-        "tx.GetGasLimit() * tx.GetGasPrice() + tx.GetAmount() overflow!");
+        "tx.GetGasLimit() * tx.GetGasPrice() + tx.GetAmountQa() overflow!");
   }
 
   if (sender->GetBalance() < debt) {

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -38,6 +38,7 @@
 #include "libPersistence/ContractStorage.h"
 #include "libRemoteStorageDB/RemoteStorageDB.h"
 #include "libUtils/AddressConversion.h"
+#include "libUtils/DataConversion.h"
 #include "libUtils/DetachedFunction.h"
 #include "libUtils/JsonUtils.h"
 #include "libUtils/Logger.h"
@@ -1735,12 +1736,8 @@ std::string LookupServer::GetWeb3ClientVersion() {
 
 string LookupServer::GetWeb3Sha3(const Json::Value& _json) {
   LOG_MARKER();
-
-  const auto str{_json.asString()};
-  LOG_GENERAL(DEBUG, "GetWeb3Sha3 on:" << str);
-
-  return POW::BlockhashToHexString(ethash::keccak256(
-      reinterpret_cast<const uint8_t*>(str.data()), str.size()));
+  bytes input = DataConversion::HexStrToUint8VecRet(_json.asString());
+  return POW::BlockhashToHexString(ethash::keccak256(input.data(), input.size()));
 }
 
 Json::Value LookupServer::GetEthUncleCount() {

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1182,16 +1182,23 @@ Json::Value LookupServer::GetEthBlockCommon(const TxBlock& txBlock,
                                                  includeFullTransactions);
 }
 
-Json::Value LookupServer::GetEthBalance(const std::string& address) {
-  const auto balanceStr = this->GetBalance(address, true)["balance"].asString();
+Json::Value LookupServer::GetEthBalance(const std::string& address,
+                                        const std::string& tag) {
+  if (tag == "latest" || tag == "earliest" || tag == "pending") {
+    const auto balanceStr =
+        this->GetBalance(address, true)["balance"].asString();
 
-  const uint256_t ethBalance =
-      std::strtoll(balanceStr.c_str(), nullptr, 16) * EVM_ZIL_SCALING_FACTOR;
+    const uint256_t ethBalance =
+        std::strtoll(balanceStr.c_str(), nullptr, 16) * EVM_ZIL_SCALING_FACTOR;
 
-  std::ostringstream strm;
-  strm << "0x" << std::hex << ethBalance << std::dec;
+    std::ostringstream strm;
+    strm << "0x" << std::hex << ethBalance << std::dec;
 
-  return strm.str();
+    return strm.str();
+  }
+  throw JsonRpcException(RPC_MISC_ERROR, "Unable To Process, invalid tag");
+
+  return "";
 }
 
 Json::Value LookupServer::GetEthBlockTransactionCountByHash(

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -591,9 +591,6 @@ class LookupServer : public Server,
     response = this->GetEthCode(request[0u].asString(), request[1u].asString());
   }
 
- 
- 
-
   inline virtual void GetEthFeeHistoryI(const Json::Value& /*request*/,
                                         Json::Value& response) {
     response = this->GetEmptyResponse();

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -392,11 +392,12 @@ class LookupServer : public Server,
 
     auto shards = m_mediator.m_lookup->GetShardPeers().size();
 
+    // For Eth transactions, pass gas Price in Wei
     auto resp = CreateTransactionEth(
         fields, pubKey, shards,
-        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetGasPrice(),
+        m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetGasPrice() *
+            EVM_ZIL_SCALING_FACTOR,
         m_createTransactionTarget);
-
     response = std::string{"0x"} + resp["TranID"].asString();
   }
 
@@ -740,7 +741,7 @@ class LookupServer : public Server,
 
   Json::Value CreateTransactionEth(
       Eth::EthFields const& fields, bytes const& pubKey,
-      const unsigned int num_shards, const uint128_t& gasPrice,
+      const unsigned int num_shards, const uint128_t& gasPriceWei,
       const CreateTransactionTargetFunc& targetFunc);
 
   Json::Value GetEthBlockTransactionCountByHash(const std::string& blockHash);

--- a/src/libServer/WebsocketServer.cpp
+++ b/src/libServer/WebsocketServer.cpp
@@ -387,7 +387,7 @@ Json::Value CreateReturnAddressJson(const TransactionWithReceipt& twr) {
 
   _json["toAddr"] = twr.GetTransaction().GetToAddr().hex();
   _json["fromAddr"] = twr.GetTransaction().GetSenderAddr().hex();
-  _json["amount"] = twr.GetTransaction().GetAmount().str();
+  _json["amount"] = twr.GetTransaction().GetAmountQa().str();
   _json["success"] = twr.GetTransactionReceipt().GetJsonValue()["success"];
   _json["ID"] = twr.GetTransaction().GetTranID().hex();
 

--- a/src/libUtils/DataConversion.cpp
+++ b/src/libUtils/DataConversion.cpp
@@ -20,9 +20,13 @@
 using namespace std;
 
 bool DataConversion::HexStrToUint8Vec(const string& hex_input, bytes& out) {
+  int offset = 0;
+  if (hex_input.size() >= 2 && hex_input[0] == '0' && hex_input[1] == 'x') {
+    offset = 2;
+  }
   try {
     out.clear();
-    boost::algorithm::unhex(hex_input.begin(), hex_input.end(),
+    boost::algorithm::unhex(hex_input.begin() + offset, hex_input.end(),
                             back_inserter(out));
   } catch (exception& e) {
     LOG_GENERAL(WARNING, "Failed HexStrToUint8Vec conversion with exception: "
@@ -34,9 +38,13 @@ bool DataConversion::HexStrToUint8Vec(const string& hex_input, bytes& out) {
 
 bytes DataConversion::HexStrToUint8VecRet(const string& hex_input) {
   bytes out;
+  int offset = 0;
+  if (hex_input.size() >= 2 && hex_input[0] == '0' && hex_input[1] == 'x') {
+    offset = 2;
+  }
   try {
     out.clear();
-    boost::algorithm::unhex(hex_input.begin(), hex_input.end(),
+    boost::algorithm::unhex(hex_input.begin() + offset, hex_input.end(),
                             back_inserter(out));
   } catch (exception& e) {
     LOG_GENERAL(WARNING, "Failed HexStrToUint8Vec conversion with exception: "

--- a/src/libUtils/EvmCallParameters.h
+++ b/src/libUtils/EvmCallParameters.h
@@ -30,7 +30,7 @@ struct EvmCallParameters {
   std::string m_code;
   std::string m_data;
   uint64_t m_available_gas = {0};
-  boost::multiprecision::uint128_t m_apparent_value = {0};
+  boost::multiprecision::uint256_t m_apparent_value = {0};
 };
 
 #endif  // ZILLIQA_SRC_LIBUTILS_EVMCALLPARAMETERS_H_

--- a/src/libValidator/Validator.cpp
+++ b/src/libValidator/Validator.cpp
@@ -94,12 +94,12 @@ bool Validator::CheckCreatedTransaction(const Transaction& tx,
   }
 
   // Check if transaction amount is valid
-  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
+  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmountQa()) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Insufficient funds in source account!"
                   << " From Account  = 0x" << fromAddr << " Balance = "
                   << AccountStore::GetInstance().GetBalance(fromAddr)
-                  << " Debit Amount = " << tx.GetAmount());
+                  << " Debit Amount = " << tx.GetAmountQa());
     error_code = TxnStatus::INSUFFICIENT_BALANCE;
     return false;
   }
@@ -202,10 +202,10 @@ bool Validator::CheckCreatedTransactionFromLookup(const Transaction& tx,
     return false;
   }
 
-  if (tx.GetGasPrice() <
+  if (tx.GetGasPriceQa() <
       m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetGasPrice()) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
-              "GasPrice " << tx.GetGasPrice()
+              "GasPrice " << tx.GetGasPriceQa()
                           << " lower than minimum allowable "
                           << m_mediator.m_dsBlockChain.GetLastBlock()
                                  .GetHeader()
@@ -237,12 +237,12 @@ bool Validator::CheckCreatedTransactionFromLookup(const Transaction& tx,
   }
 
   // Check if transaction amount is valid
-  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmount()) {
+  if (AccountStore::GetInstance().GetBalance(fromAddr) < tx.GetAmountQa()) {
     LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
               "Insufficient funds in source account!"
                   << " From Account  = 0x" << fromAddr << " Balance = "
                   << AccountStore::GetInstance().GetBalance(fromAddr)
-                  << " Debit Amount = " << tx.GetAmount());
+                  << " Debit Amount = " << tx.GetAmountQa());
     error_code = TxnStatus::INSUFFICIENT_BALANCE;
     return false;
   }

--- a/tests/Data/AccountData/Test_Transaction.cpp
+++ b/tests/Data/AccountData/Test_Transaction.cpp
@@ -107,8 +107,8 @@ BOOST_AUTO_TEST_CASE(test1) {
   const Address& toAddr2 = tx2.GetToAddr();
   const PubKey& senderPubKey = tx2.GetSenderPubKey();
   const Address& fromAddr2 = Account::GetAddressFromPublicKey(senderPubKey);
-  const uint128_t& amount2 = tx2.GetAmount();
-  const uint128_t& gasPrice2 = tx2.GetGasPrice();
+  const uint128_t& amount2 = tx2.GetAmountQa();
+  const uint128_t& gasPrice2 = tx2.GetGasPriceQa();
   const uint128_t& gasLimit2 = tx2.GetGasLimit();
   const bytes& code2 = tx2.GetCode();
   const bytes& data2 = tx2.GetData();
@@ -147,13 +147,13 @@ BOOST_AUTO_TEST_CASE(test1) {
 
   LOG_GENERAL(INFO, "Transaction2 amount: " << amount2);
   BOOST_CHECK_MESSAGE(
-      amount2 == tx1.GetAmount(),
-      "expected: " << tx1.GetAmount() << " actual: " << amount2 << "\n");
+      amount2 == tx1.GetAmountQa(),
+      "expected: " << tx1.GetAmountQa() << " actual: " << amount2 << "\n");
 
   LOG_GENERAL(INFO, "Transaction2 gasPrice: " << gasPrice2);
   BOOST_CHECK_MESSAGE(
-      gasPrice2 == tx1.GetGasPrice(),
-      "expected: " << tx1.GetGasPrice() << " actual: " << gasPrice2 << "\n");
+      gasPrice2 == tx1.GetGasPriceQa(),
+      "expected: " << tx1.GetGasPriceQa() << " actual: " << gasPrice2 << "\n");
 
   LOG_GENERAL(INFO, "Transaction2 gasLimit: " << gasLimit2);
   BOOST_CHECK_MESSAGE(

--- a/tests/Data/AccountData/Test_TxnPool.cpp
+++ b/tests/Data/AccountData/Test_TxnPool.cpp
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(txnpool) {
   // Find the existing Transaction with gasPrice < MAX (gasPrice)
   int i = 0;
   while (true) {
-    uint128_t gasprice = transaction_v[i].GetGasPrice();
+    uint128_t gasprice = transaction_v[i].GetGasPriceQa();
     if (gasprice < gasprice + 1) {
       transactionHigherGas =
           createTransaction(gasprice + 1, transaction_v[i].GetSenderPubKey(),
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(txnpool_status) {
   TxnPool tp;
 
   Transaction txn = generateUniqueTransaction();
-  const uint128_t& gasprice = txn.GetGasPrice();
+  const uint128_t& gasprice = txn.GetGasPriceQa();
 
   Transaction higherGasTxn =
       createTransaction(gasprice + 1, txn.GetSenderPubKey(), txn.GetNonce());

--- a/tests/EvmAcceptanceTests/helper/Web3Helper.js
+++ b/tests/EvmAcceptanceTests/helper/Web3Helper.js
@@ -12,7 +12,7 @@ var web3_helper = {
             .send({
                 from: this.primaryAccount.address,
                 ...(general_helper.isZilliqaNetworkSelected()) && { gas: 30_000 },
-                ...(general_helper.isZilliqaNetworkSelected()) && { gasPrice: 2_000_000_000 },
+                ...(general_helper.isZilliqaNetworkSelected()) && { gasPrice: 2_000_000_000_000_000 },
             })
             .on('error', function (error) { console.log(error) })
     }

--- a/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
+++ b/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
@@ -29,7 +29,7 @@ class ZilliqaHelper {
         const constructorArgs = (options.constructorArgs || []);
 
         // Give our Eth address some monies
-        await this.moveFunds(200000000000000, senderAccount.address)
+        await this.moveFunds("0x3635c9adc5dea00000", senderAccount.address)
 
         // Deploy a SC using web3 API ONLY
         const nonce = await web3.eth.getTransactionCount(senderAccount.address, 'latest'); // nonce starts counting from 0
@@ -39,7 +39,7 @@ class ZilliqaHelper {
             'value': options.value ?? 0,
             'data': Contract.getDeployTransaction(...constructorArgs).data,
             'gas': 300000,
-            'gasPrice': 2000000000,
+            'gasPrice': 2000000000000000,
             'chainId': general_helper.getEthChainId(),
             'nonce': nonce,
         };
@@ -67,7 +67,7 @@ class ZilliqaHelper {
             'value': 0,
             'data': abi,
             'gas': 300000,
-            'gasPrice': 2000000000,
+            'gasPrice': 2000000000000000,
             'chainId': general_helper.getEthChainId(),
             'nonce': nonce,
         };
@@ -87,7 +87,7 @@ class ZilliqaHelper {
             from: senderAccount.address,
             to: contract._address,
             data: abi,
-            gasPrice: 2000000000,
+            gasPrice: 2000000000000000,
         };
 
         return web3.eth.call(transaction)
@@ -105,7 +105,7 @@ class ZilliqaHelper {
                 'to': toAddr,
                 'value': amount,
                 'gas': 300000,
-                'gasPrice': 2000000000,
+                'gasPrice': 2000000000000000,
                 'nonce': nonce,
                 'chainId': general_helper.getEthChainId(),
                 'data': ""

--- a/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
@@ -14,7 +14,7 @@ describe("Calling " + METHOD, function () {
         assert.match(result.result, /^0x/, 'should be HEX starting with 0x');
         assert.isNumber(+result.result, 'can be converted to a number');
 
-        const expectedGasPrice = 2000000000 // default ganache gas price in wei
+        const expectedGasPrice = 2000000000000000 // default Zilliqa gas price in wei
         assert.equal(+result.result, expectedGasPrice, 'should have a gas price ' + expectedGasPrice);
       })
   })

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
@@ -5,7 +5,7 @@ const METHOD = 'eth_getBalance';
 
 describe("Calling " + METHOD, function () {
     it("should return the balance as specified in the ethereum protocol", async function () {
-        const expectedBalance = 1 * (10 ** 18) // should be 1 eth in wei
+        const expectedBalance = 1000000 * (10 ** 12) // should be 1,000,000 ZIL in wei
 
         await helper.callEthMethod(METHOD, 1, [
             "0xF0C05464f12cB2a011d21dE851108a090C95c755", // public address

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -15,14 +15,15 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "libData/AccountData/TransactionReceipt.h"
 #define BOOST_TEST_MODULE EvmLookupServer
 #define BOOST_TEST_DYN_LINK
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/format.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/test/unit_test.hpp>
 #include "libData/AccountData/EvmClient.h"
+#include "libData/AccountData/TransactionReceipt.h"
 #include "libMediator/Mediator.h"
 #include "libServer/LookupServer.h"
 #include "libUtils/EvmJsonResponse.h"
@@ -349,7 +350,7 @@ BOOST_AUTO_TEST_CASE(test_web3_sha3) {
 
   BOOST_CHECK_EQUAL(
       response.asString(),
-      "0xb1e9ddd229f9a21ef978f6fcd178e74e37a4fa3d87f453bc34e772ec91328181");
+      "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad");
 
   // test with empty string
   paramsRequest[0u] = "";
@@ -645,7 +646,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_balance) {
   lookupServer->GetEthBalanceI(paramsRequest, response);
   LOG_GENERAL(INFO, "Got balance: " << response);
   // expected return value should be 1.000.000 times greater
-  BOOST_CHECK_EQUAL(response.asString(), "0xe8d4a51000");
+  BOOST_CHECK_EQUAL(boost::algorithm::to_lower_copy(response.asString()), "0xe8d4a51000");
 }
 
 BOOST_AUTO_TEST_CASE(test_eth_get_block_by_number) {

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -1021,7 +1021,7 @@ BOOST_AUTO_TEST_CASE(test_eth_get_transaction_by_hash) {
             .str());
     BOOST_TEST_CHECK(
         response["value"] ==
-        (boost::format("0x%x") % transactions[i].GetTransaction().GetAmount())
+        (boost::format("0x%x") % transactions[i].GetTransaction().GetAmountQa())
             .str());
   }
 

--- a/tests/EvmLookupServer/Test_EvmLookupServer.cpp
+++ b/tests/EvmLookupServer/Test_EvmLookupServer.cpp
@@ -646,7 +646,8 @@ BOOST_AUTO_TEST_CASE(test_eth_get_balance) {
   lookupServer->GetEthBalanceI(paramsRequest, response);
   LOG_GENERAL(INFO, "Got balance: " << response);
   // expected return value should be 1.000.000 times greater
-  BOOST_CHECK_EQUAL(boost::algorithm::to_lower_copy(response.asString()), "0xe8d4a51000");
+  BOOST_CHECK_EQUAL(boost::algorithm::to_lower_copy(response.asString()),
+                    "0xe8d4a51000");
 }
 
 BOOST_AUTO_TEST_CASE(test_eth_get_block_by_number) {

--- a/tests/Persistence/ReadTransactions.cpp
+++ b/tests/Persistence/ReadTransactions.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(testTransaction) {
 
   BlockStorage::GetBlockStorage().GetTxBody(hash, tx);
 
-  LOG_GENERAL(INFO, "Transaction amount: " << tx->GetAmount());
+  LOG_GENERAL(INFO, "Transaction amount: " << tx->GetAmountQa());
   LOG_GENERAL(INFO, "Transaction from address: " << tx->GetFromAddr());
   LOG_GENERAL(INFO, "Transaction to address: " << tx->GetToAddr());
   LOG_GENERAL(INFO, "Transaction nonce: " << tx->GetNonce());

--- a/tests/evm_ds_test/evm_ds_test/test_case.py
+++ b/tests/evm_ds_test/evm_ds_test/test_case.py
@@ -32,7 +32,7 @@ from web3 import Web3
 from web3._utils.abi import get_constructor_abi, get_abi_output_types
 from web3._utils.contracts import encode_abi, get_function_info
 from web3.exceptions import TransactionNotFound
-from .utils import int_from_bytes
+from .utils import int_from_bytes, from_zil
 
 
 def pad_address(address):
@@ -83,7 +83,7 @@ class EvmDsTestCase:
         # Fund all the accounts.
         pending_transactions = []
         for account in self.accounts:
-            amount = 200_000_000_000_000
+            amount = from_zil(200)
             logging.info(
                 "Funding account {} with {} Qa".format(account.address, amount)
             )
@@ -128,7 +128,7 @@ class EvmDsTestCase:
                 "to": dest.address,
                 "value": amount,
                 "gas": 21_000,
-                "gasPrice": 2_000_000_000,
+                "gasPrice": from_zil(0.002),
                 "nonce": nonce,
                 "chainId": self.eth_network_id,
                 "data": b"",
@@ -153,7 +153,7 @@ class EvmDsTestCase:
         txn = contract_class.constructor(*args).build_transaction(
             {
                 "gas": 30_000,
-                "gasPrice": 2_000_000_000,
+                "gasPrice": from_zil(0.002),
                 "value": value,
                 "nonce": nonce,
                 "chainId": self.eth_network_id,
@@ -183,7 +183,7 @@ class EvmDsTestCase:
                 "value": value,
                 "data": data_bytes,
                 "gas": 30_000,
-                "gasPrice": 2_000_000_000,
+                "gasPrice": from_zil(0.002),
                 "nonce": nonce,
                 "chainId": self.eth_network_id,
             },
@@ -231,7 +231,7 @@ class EvmDsTestCase:
                 "from": account.address,
                 "value": value,
                 "gas": 30_000,
-                "gasPrice": 2_000_000_000,
+                "gasPrice": from_zil(0.002),
                 "nonce": nonce,
                 "chainId": self.eth_network_id,
             }
@@ -263,7 +263,7 @@ class EvmDsTestCase:
             {
                 "from": self.account.address,
                 # "gas": 30_000,
-                "gasPrice": 2_000_000_000,
+                "gasPrice": from_zil(0.002),
                 "chainId": self.eth_network_id,
             }
         )

--- a/tests/evm_ds_test/evm_ds_test/utils.py
+++ b/tests/evm_ds_test/evm_ds_test/utils.py
@@ -57,5 +57,5 @@ def process_log(arg, index, id, epoch_num):
 
 
 def from_zil(zil):
-    """Returns Zil converted to QA"""
-    return zil * 1_000_000_000_000
+    """Returns Zil converted to Wei"""
+    return int(zil * 1_000_000_000_000_000_000)

--- a/tests/evm_ds_test/tests/test_parent_child.py
+++ b/tests/evm_ds_test/tests/test_parent_child.py
@@ -95,7 +95,7 @@ contract ParentContract {
 
         # Check that the parent contract account is 1 zil as initially requested.
         set_value = self.call_view(contract, "getPaidValue")
-        assert set_value == 1_000_000_000_000
+        assert set_value == from_zil(1)
 
         assert self.get_balance(contract.address) == from_zil(1)
 

--- a/tests/evm_ds_test/tests/test_parent_child.py
+++ b/tests/evm_ds_test/tests/test_parent_child.py
@@ -61,7 +61,7 @@ contract ParentContract {
     }
 
     function installChild(uint256 initial_data) public returns (address payable) {
-      child = new ChildContract{value: 1000 gwei}(initial_data);
+      child = new ChildContract{value: 1 ether}(initial_data);
       return payable(address(child));
     }
 

--- a/tests/evm_ds_test/tests/test_transfer.py
+++ b/tests/evm_ds_test/tests/test_transfer.py
@@ -47,8 +47,8 @@ contract ForwardZil {
     function withdraw() public {
         // get the amount of Zil stored in this contract minus 10 zil.
         uint amount = address(this).balance;
-        if (amount > 1000 gwei) {  // 1 ZIL
-            amount -= 1000 gwei;
+        if (amount > 1 ether) {  // 1 ZIL
+            amount -= 1 ether;
         }
 
         // send all Ether to owner


### PR DESCRIPTION
## Description
The goal of this PR is to scale values from Qa to Wei where necessary in transactions.
We cannot just do it at the transaction creation time, as later on we need the original transaction values for verifying the signatures.

Therefore we store the original transaction value and gasprice, and have to modify all the places where it is used to specify whether it needs value in Qa or in Wei.

It is a large PR primarily because there are quite many such places.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
