### PR TITLE
[master] Clean-up around calling evm-ds: fail gently on logs config, not crash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -163,7 +163,7 @@ do
     ;;
     evm)
         echo "Build EVM"
-	evm_build_result=$(cd src/depends/evm; cargo build --release)
+	evm_build_result=$(cd evm-ds; cargo build --release)
 	exit $evm_build_result
     ;;
     *)

--- a/evm-ds/src/main.rs
+++ b/evm-ds/src/main.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use anyhow::Context;
 use clap::Parser;
 use evm::{
     backend::{Apply, Basic},
@@ -304,7 +305,8 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     match args.log4rs {
         Some(log_config) if log_config != "" => {
-            log4rs::init_file(log_config, Default::default()).unwrap();
+            log4rs::init_file(&log_config, Default::default())
+                .with_context(|| format!("cannot open file {}", log_config))?;
         }
         _ => {
             let config_str = include_str!("../log4rs-local.yml");

--- a/tests/EvmLookupServer/constants.xml
+++ b/tests/EvmLookupServer/constants.xml
@@ -193,7 +193,7 @@
         <ENABLE_EVM>true</ENABLE_EVM>
         <EVM_SERVER_BINARY>evm-ds</EVM_SERVER_BINARY>
         <EVM_SERVER_SOCKET_PATH>/tmp/evm-server.sock</EVM_SERVER_SOCKET_PATH>
-        <EVM_LOG_CONFIG>log4rs.yml</EVM_LOG_CONFIG>
+        <EVM_LOG_CONFIG></EVM_LOG_CONFIG>
         <!-- eth chain id : Test net = 0x814d, main net: 0x8001 -->
         <ETH_CHAINID>0x814d</ETH_CHAINID>
         <EVM_ZIL_SCALING_FACTOR>1000000</EVM_ZIL_SCALING_FACTOR>


### PR DESCRIPTION
A small cleanup of how evm-ds starts

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
