### PR TITLE
[master] Reimplement ORIGIN instruction by passing the argument without a callback

### DIFF
--- a/evm-ds/src/main.rs
+++ b/evm-ds/src/main.rs
@@ -115,7 +115,7 @@ pub trait Rpc: Send + 'static {
     fn run(
         &self,
         address: String,
-        caller: String,
+        origin: String,
         code: String,
         data: String,
         apparent_value: String,
@@ -133,36 +133,43 @@ impl Rpc for EvmServer {
     fn run(
         &self,
         address: String,
-        caller: String,
+        origin: String,
         code_hex: String,
         data_hex: String,
         apparent_value: String,
         gas_limit: u64,
     ) -> BoxFuture<Result<EvmResult>> {
-        let backend = ScillaBackend::new(self.backend_config.clone());
-        let tracing = self.tracing;
-        let gas_scaling_factor = self.gas_scaling_factor;
-        Box::pin(async move {
-            run_evm_impl(
-                address,
-                caller,
-                code_hex,
-                data_hex,
-                apparent_value,
-                gas_limit,
-                backend,
-                tracing,
-                gas_scaling_factor,
-            )
-            .await
-        })
+        let origin = H160::from_str(&origin);
+        match origin {
+            Ok(origin) => {
+                let backend = ScillaBackend::new(self.backend_config.clone(), origin);
+                let tracing = self.tracing;
+                let gas_scaling_factor = self.gas_scaling_factor;
+                Box::pin(async move {
+                    run_evm_impl(
+                        address,
+                        code_hex,
+                        data_hex,
+                        apparent_value,
+                        gas_limit,
+                        backend,
+                        tracing,
+                        gas_scaling_factor,
+                    )
+                    .await
+                })
+            }
+            Err(e) => Box::pin(futures::future::err(Error::invalid_params(format!(
+                "origin: {}",
+                e
+            )))),
+        }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
 async fn run_evm_impl(
     address: String,
-    caller: String,
     code_hex: String,
     data_hex: String,
     apparent_value: String,
@@ -192,8 +199,7 @@ async fn run_evm_impl(
         let context = evm::Context {
             address: H160::from_str(&address)
                 .map_err(|e| Error::invalid_params(format!("address: {}", e)))?,
-            caller: H160::from_str(&caller)
-                .map_err(|e| Error::invalid_params(format!("caller: {}", e)))?,
+            caller: backend.origin,
             apparent_value,
         };
         let mut runtime = evm::Runtime::new(code, data, context, &config);

--- a/evm-ds/src/scillabackend.rs
+++ b/evm-ds/src/scillabackend.rs
@@ -32,6 +32,7 @@ pub struct ScillaBackendConfig {
 // Backend relying on Scilla variables and Scilla JSONRPC interface.
 pub struct ScillaBackend {
     config: ScillaBackendConfig,
+    pub origin: H160,
 }
 
 // Adding some convenience to ProtoScillaVal to convert to U256 and bytes.
@@ -56,8 +57,8 @@ impl ScillaMessage::ProtoScillaVal {
 }
 
 impl ScillaBackend {
-    pub fn new(config: ScillaBackendConfig) -> Self {
-        Self { config }
+    pub fn new(config: ScillaBackendConfig, origin: H160) -> Self {
+        Self { config, origin }
     }
 
     // Call the Scilla IPC Server API.
@@ -235,8 +236,7 @@ impl<'config> Backend for ScillaBackend {
     }
 
     fn origin(&self) -> H160 {
-        let result = self.query_jsonrpc("ORIGIN", None);
-        H160::from_str(result.as_str().expect("origin")).expect("origin hex")
+        self.origin
     }
 
     fn block_hash(&self, number: U256) -> H256 {

--- a/src/libServer/ScillaIPCServer.cpp
+++ b/src/libServer/ScillaIPCServer.cpp
@@ -195,9 +195,6 @@ bool ScillaIPCServer::fetchBlockchainInfo(const std::string &query_name,
   } else if (query_name == "CHAINID") {
     value = std::to_string(CHAIN_ID);
     return true;
-  } else if (query_name == "ORIGIN") {
-    value = m_BCInfo->getOriginAddr().hex();
-    return true;
   }
 
   // For queries that include the block number.
@@ -235,7 +232,7 @@ bool ScillaIPCServer::fetchBlockchainInfo(const std::string &query_name,
     }
   }
 
-  if (query_name == "BLOCHKASH") {
+  if (query_name == "BLOCKHASH") {
     value = txBlockSharedPtr->GetBlockHash().hex();
   } else if (query_name == "BLOCKNUMBER") {
     value = std::to_string(blockNum);


### PR DESCRIPTION
## Description
We pass the original caller of the transaction to evm-ds anyways, no need for a callback.

Maybe other instructions shall be re-implemented in a similar way in the following PRs.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
