### PR TITLE
[master] ZIL-4805: don't compile jsonrpccpp with code coverage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.1)
+cmake_minimum_required(VERSION 3.19)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sudo apt-get install git \
     libcurl4-openssl-dev python3-dev \
     python3-setuptools python3-pip gawk
 ```
-Run the following to install latest version of cmake.We suggest to install cmake 3.19 or any version >=3.16:
+Run the following to install latest version of cmake. Please make sure you have cmake 3.19 or above:
 
 ```
 wget https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh

--- a/cmake/InstallJsonrpccpp.cmake
+++ b/cmake/InstallJsonrpccpp.cmake
@@ -21,6 +21,7 @@ set(CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_BUILD_TYPE=Release
                # Build static lib but suitable to be included in a shared lib.
                -DCMAKE_POSITION_INDEPENDENT_CODE=On
+               -DWITH_COVERAGE=Off
                -DBUILD_STATIC_LIBS=On
                -DBUILD_SHARED_LIBS=Off
                -DUNIX_DOMAIN_SOCKET_SERVER=On
@@ -66,10 +67,7 @@ file(MAKE_DIRECTORY ${JSONRPC_INCLUDE_DIR})  # Must exist.
 
 add_library(jsonrpc::common STATIC IMPORTED)
 set_property(TARGET jsonrpc::common PROPERTY IMPORTED_LOCATION ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsonrpccpp-common${CMAKE_STATIC_LIBRARY_SUFFIX})
-set_property(TARGET jsonrpc::common PROPERTY INTERFACE_LINK_LIBRARIES ${JSONCPP_LINK_TARGETS} gcov)
 set_property(TARGET jsonrpc::common PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${JSONRPC_INCLUDE_DIR} ${JSONCPP_INCLUDE_DIR})
-link_libraries(--coverage)
-link_libraries(-lgcov)
 add_dependencies(jsonrpc::common jsonrpc-project)
 
 add_library(jsonrpc::client STATIC IMPORTED)


### PR DESCRIPTION
  1. Stop compiling jsonrpccpp with code coverage.
  2. Update minimum CMake version in CMakeLists.txt & README.

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
