### PR TITLE
[master] fix(): Specify the internal docker registry for the deps container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+ARG REGISTRY=
 
 ARG BASE=zilliqa/scilla:v0.11.0
 FROM ${BASE} AS scilla
@@ -20,7 +21,7 @@ FROM ${BASE} AS scilla
 RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*
 
 # start from a new ubuntu environment as builder for zilliqa, make sure the deps is consistent with those in the runner image
-FROM zilliqa:v8.2.0-deps AS builder
+FROM ${REGISTRY}zilliqa:v8.2.0-deps AS builder
 # Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update \
     && apt-get install -y software-properties-common \
@@ -69,7 +70,7 @@ RUN cmake --version \
 
 # Manually input tag or commit, can be overwritten by docker build-args
 ARG COMMIT_OR_TAG=master
-ARG REPO=https://github.com/Zilliqa.git
+ARG REPO=https://github.com/Zilliqa/Zilliqa.git
 ARG SOURCE_DIR=/zilliqa
 ARG BUILD_DIR=/build
 ARG INSTALL_DIR=/usr/local

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,6 +7,7 @@ all: release release-cuda
 len=$(shell echo $(COMMIT_OR_TAG) | wc -c)
 commit_or_tag=$(shell echo $(COMMIT_OR_TAG) | cut -c 1-7)
 cmake_extra_args=$(shell echo $(EXTRA_CMAKE_ARGS))
+registry=$(shell echo $(REGISTRY))
 
 major=$(shell tail -n +2 ../VERSION | head -n1)
 minor=$(shell tail -n +4 ../VERSION | head -n1)
@@ -26,7 +27,7 @@ check-commit:
 
 # build zilliqa docker image for Kubernetes usage
 dev: check-commit
-	docker build -t zilliqa:$(commit_or_tag) \
+	docker build -t zilliqa:$(commit_or_tag) --build-arg REGISTRY=$(registry) \
 		--build-arg COMMIT_OR_TAG=$(commit_or_tag) --build-arg EXTRA_CMAKE_ARGS="$(cmake_extra_args)" -f Dockerfile .
 
 # build the dependencies docker image for public usage

--- a/scripts/ci_make_image.sh
+++ b/scripts/ci_make_image.sh
@@ -49,7 +49,7 @@ target_image=${account_id}.dkr.ecr.${region_id}.amazonaws.com/zilliqa:${commit_o
 
 eval $(aws ecr get-login --no-include-email --region ${region_id})
 set +e
-make -C docker dev EXTRA_CMAKE_ARGS="${test_extra_cmake_args}" COMMIT_OR_TAG="${commit_or_tag}"  || exit 10
+make -C docker dev REGISTRY="${account_id}.dkr.ecr.${region_id}.amazonaws.com/" EXTRA_CMAKE_ARGS="${test_extra_cmake_args}" COMMIT_OR_TAG="${commit_or_tag}"  || exit 10
 set -e
 docker tag ${source_image} ${target_image}
 docker push ${target_image}


### PR DESCRIPTION
Add the REGISTRY argument to the Dockerfile and the Makefile to specify the internal ECR docker registry for the deps image.

## Description
Fix the image build issue affecting the Zilliqa Private Image Manual Trigger Jenkins Job.
The ci_make_image.sh script was failing pulling the Zilliqa dependency image as the
zilliqa:v8.2.0-deps is not available on the hub.docker.com and the FROM instruction of the Dockerfile wasn't specifying the full registry image URL.


## Backward Compatibility

- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
