### PR TITLE
[master] Make the format of receipts similar to that of Eth testnets

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -24,6 +24,7 @@
 #include "AddressChecksum.h"
 #include "JSONConversion.h"
 #include "Server.h"
+#include "json/value.h"
 #include "libCrypto/EthCrypto.h"
 #include "libData/AccountData/Address.h"
 #include "libData/AccountData/Transaction.h"
@@ -693,7 +694,11 @@ const Json::Value JSONConversion::convertTxtoEthJson(
   retJson["data"] = inputField;
   retJson["nonce"] =
       (boost::format("0x%x") % txn.GetTransaction().GetNonce()).str();
-  retJson["to"] = "0x" + txn.GetTransaction().GetToAddr().hex();
+  if (IsNullAddress(txn.GetTransaction().GetToAddr())) {
+    retJson["to"] = Json::nullValue;  // special for contract creation transactions.
+  } else {
+    retJson["to"] = "0x" + txn.GetTransaction().GetToAddr().hex();
+  }
   retJson["value"] =
       (boost::format("0x%x") % txn.GetTransaction().GetAmountWei()).str();
   if (!txn.GetTransaction().GetCode().empty() &&
@@ -704,6 +709,7 @@ const Json::Value JSONConversion::convertTxtoEthJson(
                                        txn.GetTransaction().GetNonce() - 1)
             .hex();
   }
+  retJson["type"] = "0x0";
   return retJson;
 }
 


### PR DESCRIPTION
I tried Remix IDE with the Ropsten testnet, and it also works by just sending a txn and waiting for the receipt, and it works.

While with Zilliqa it takes forever.  Could be because of the to address mismatch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
