### PR TITLE
[master] Fix net_version call

### DIFF
--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -1779,11 +1779,6 @@ std::string LookupServer::GetEthCoinbase() {
   return "0x0000000000000000000000000000000000000000";
 }
 
-std::string LookupServer::GetNetVersion() {
-  LOG_MARKER();
-  return "0x8000";  // Like Ethereum, including test nets.
-}
-
 Json::Value LookupServer::GetNetListening() {
   LOG_MARKER();
   return Json::Value(false);

--- a/src/libServer/LookupServer.h
+++ b/src/libServer/LookupServer.h
@@ -504,7 +504,7 @@ class LookupServer : public Server,
    */
   virtual void GetNetVersionI(const Json::Value& /*request*/,
                               Json::Value& response) {
-    response = this->GetNetVersion();
+    response = this->GetEthChainId();
   }
 
   /**
@@ -701,7 +701,6 @@ class LookupServer : public Server,
   Json::Value GetEthUncleBlock();
   Json::Value GetEthMining();
   std::string GetEthCoinbase();
-  std::string GetNetVersion();
   Json::Value GetNetListening();
   std::string GetNetPeerCount();
   std::string GetProtocolVersion();


### PR DESCRIPTION
## Description
For most new networks in chainlist.org net_version is the same as eth_chainId, regardless of whether it is mainnet or testnet.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
