### PR TITLE
Add debug flag to tests so that log messages will be printed only if this flag is set. [skip ci]

### DIFF
--- a/tests/EvmAcceptanceTests/README.md
+++ b/tests/EvmAcceptanceTests/README.md
@@ -3,6 +3,11 @@
 ```bash
     npm install
     npx hardhat test    # to run tests
+    npx hardhat test --debug    # to run tests and print log messages
+    npx hardhat test --grep something    # to run tests containing `something` in the description
+    npx hardhat test --network net1    # to run tests with `net1` network
+    npx hardhat test filename    # to run tests of `filename`
+    npx hardhat test folder/*    # to run tests of `folder`
 ```
 
 # Setup github pre-commit hook
@@ -87,9 +92,10 @@ npx hardhat test --network ganache
 
 # How to debug
 
-1. Use `console.log` :smile:
-2. Use vscode debugger
-3. Use `--verbose` option to enable hardhat verbose logging
+* Use `console.log` but pay attention to best practices Below :smile:
+* Use vscode debugger
+* Use `--verbose` option to enable hardhat verbose logging.
+* Use `--debug` to print out log messages. 
 
 ```bash
 npx hardhat --verbose test
@@ -98,6 +104,12 @@ npx hardhat --verbose test
 # Testing conventions and best practices
 
 - File names tries to tell us the scenario we're testing.
+- We don't pollute test results with logs. So if you want to add them for debugging, please consider using `--debug` flag and wrap logs with this block:
+```javascript
+if (hre.debugMode) {
+  console.log(result);
+}
+```
 - Every `it` block should have one assertion, readable and easy to understand.
 - Follow `GIVEN`, `WHEN` and, `THEN` BDD style
   - Top level `describe` for `GIVEN`

--- a/tests/EvmAcceptanceTests/README.md
+++ b/tests/EvmAcceptanceTests/README.md
@@ -95,20 +95,21 @@ npx hardhat test --network ganache
 * Use `console.log` but pay attention to best practices Below :smile:
 * Use vscode debugger
 * Use `--verbose` option to enable hardhat verbose logging.
-* Use `--debug` to print out log messages. 
 
 ```bash
 npx hardhat --verbose test
+```
+* Use `--debug` to print out log messages. 
+```bash
+npx hardhat --debug test
 ```
 
 # Testing conventions and best practices
 
 - File names tries to tell us the scenario we're testing.
-- We don't pollute test results with logs. So if you want to add them for debugging, please consider using `--debug` flag and wrap logs with this block:
+- We don't pollute test results with logs. So if you want to add them for debugging, please consider using `--debug` flag and use `hre.logDebug` function:
 ```javascript
-if (hre.debugMode) {
-  console.log(result);
-}
+hre.logDebug(result);
 ```
 - Every `it` block should have one assertion, readable and easy to understand.
 - Follow `GIVEN`, `WHEN` and, `THEN` BDD style

--- a/tests/EvmAcceptanceTests/README.md
+++ b/tests/EvmAcceptanceTests/README.md
@@ -92,7 +92,7 @@ npx hardhat test --network ganache
 
 # How to debug
 
-* Use `console.log` but pay attention to best practices Below :smile:
+* Use `hre.logDebug` :smile:
 * Use vscode debugger
 * Use `--verbose` option to enable hardhat verbose logging.
 

--- a/tests/EvmAcceptanceTests/hardhat.config.js
+++ b/tests/EvmAcceptanceTests/hardhat.config.js
@@ -47,5 +47,6 @@ task("test")
   .addFlag("debug", "Print debugging logs")
   .setAction(async (taskArgs, hre, runSuper) => {
     hre.debugMode = taskArgs.debug ?? false;
+    hre.logDebug = hre.debugMode ? console.log.bind(console) : function () {};
     return runSuper();
   });

--- a/tests/EvmAcceptanceTests/hardhat.config.js
+++ b/tests/EvmAcceptanceTests/hardhat.config.js
@@ -42,3 +42,10 @@ module.exports = {
     }
   }
 };
+
+task("test")
+  .addFlag("debug", "Print debugging logs")
+  .setAction(async (taskArgs, hre, runSuper) => {
+    hre.debugMode = taskArgs.debug ?? false;
+    return runSuper();
+  });

--- a/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
+++ b/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
@@ -1,4 +1,4 @@
-const { ethers, web3 } = require("hardhat");
+const {ethers, web3} = require("hardhat");
 const hre = require("hardhat");
 const general_helper = require("../helper/GeneralHelper");
 
@@ -100,7 +100,9 @@ var zilliqa_helper = {
   sendTransaction: async function (tx, senderAccount) {
     const signedTx = await senderAccount.signTransaction(tx);
 
-    console.log("Send transaction from sender:", senderAccount.address, " to:", tx.to);
+    if (hre.debugMode) {
+      console.log("Send transaction from sender:", senderAccount.address, " to:", tx.to);
+    }
 
     return web3.eth.sendSignedTransaction(signedTx.rawTransaction);
   },

--- a/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
+++ b/tests/EvmAcceptanceTests/helper/ZilliqaHelper.js
@@ -100,9 +100,7 @@ var zilliqa_helper = {
   sendTransaction: async function (tx, senderAccount) {
     const signedTx = await senderAccount.signTransaction(tx);
 
-    if (hre.debugMode) {
-      console.log("Send transaction from sender:", senderAccount.address, " to:", tx.to);
-    }
+    hre.logDebug("Send transaction from sender:", senderAccount.address, " to:", tx.to);
 
     return web3.eth.sendSignedTransaction(signedTx.rawTransaction);
   },

--- a/tests/EvmAcceptanceTests/test/rpc/eth_blockNumber.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_blockNumber.js
@@ -6,7 +6,10 @@ const METHOD = "eth_blockNumber";
 describe("Calling " + METHOD, function () {
   it("should return the block number", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
+
       // block number changes at every call, so check only the response format
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_blockNumber.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_blockNumber.js
@@ -6,9 +6,7 @@ const METHOD = "eth_blockNumber";
 describe("Calling " + METHOD, function () {
   it("should return the block number", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       // block number changes at every call, so check only the response format
       assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_call.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_call.js
@@ -1,28 +1,36 @@
-const helper = require('../../helper/GeneralHelper');
+const helper = require("../../helper/GeneralHelper");
 const zilliqa_helper = require("../../helper/ZilliqaHelper");
-const { hardhat } = require("hardhat");
-assert = require('chai').assert;
+assert = require("chai").assert;
 
-const METHOD = 'eth_call';
+const METHOD = "eth_call";
 
 describe("Calling " + METHOD, function () {
   it("should return the from eth call", async function () {
-
     const contractFactory = await hre.ethers.getContractFactory("SimpleContract");
 
-    await helper.callEthMethod(METHOD, 2, [{
-      "to": zilliqa_helper.getPrimaryAccountAddress(),
-      "data": contractFactory.bytecode,
-      "gas": 1000000
-    }, "latest"],
+    await helper.callEthMethod(
+      METHOD,
+      2,
+      [
+        {
+          to: zilliqa_helper.getPrimaryAccountAddress(),
+          data: contractFactory.bytecode,
+          gas: 1000000
+        },
+        "latest"
+      ],
       (result, status) => {
-        console.log(result);
-        assert.equal(status, 200, 'has status code');
-        assert.property(result, 'result', (result.error) ? result.error.message : 'error');
-        assert.isString(result.result, 'is string');
-        assert.match(result.result, /^0x/, 'should be HEX starting with 0x');
-        assert.isNumber(+result.result, 'can be converted to a number');
+        if (hre.debugMode) {
+          console.log(result);
+        }
+
+        assert.equal(status, 200, "has status code");
+        assert.property(result, "result", result.error ? result.error.message : "error");
+        assert.isString(result.result, "is string");
+        assert.match(result.result, /^0x/, "should be HEX starting with 0x");
+        assert.isNumber(+result.result, "can be converted to a number");
         assert.equal(result.result, "0x");
-      })
-  })
-})
+      }
+    );
+  });
+});

--- a/tests/EvmAcceptanceTests/test/rpc/eth_call.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_call.js
@@ -20,9 +20,7 @@ describe("Calling " + METHOD, function () {
         "latest"
       ],
       (result, status) => {
-        if (hre.debugMode) {
-          console.log(result);
-        }
+        hre.logDebug(result);
 
         assert.equal(status, 200, "has status code");
         assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_coinbase.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_coinbase.js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_coinbase";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -13,7 +13,10 @@ describe("Calling " + METHOD, function () {
 
     it("should return the coin base", async function () {
       await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-        console.log(result);
+        if (hre.debugMode) {
+          console.log(result);
+        }
+
         assert.equal(status, 200, "has status code");
         assert.property(result, "result", result.error ? result.error.message : "error");
         assert.isString(result.result, "is string");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_coinbase.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_coinbase.js
@@ -13,9 +13,7 @@ describe("Calling " + METHOD, function () {
 
     it("should return the coin base", async function () {
       await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-        if (hre.debugMode) {
-          console.log(result);
-        }
+        hre.logDebug(result);
 
         assert.equal(status, 200, "has status code");
         assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
@@ -6,7 +6,10 @@ const METHOD = "eth_gasPrice";
 describe("Calling " + METHOD, function () {
   it("should return the gasPrice as specified in the ethereum protocol", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
+
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is not a string");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_gasPrice.js
@@ -6,9 +6,7 @@ const METHOD = "eth_gasPrice";
 describe("Calling " + METHOD, function () {
   it("should return the gasPrice as specified in the ethereum protocol", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
@@ -8,7 +8,9 @@ describe("Calling " + METHOD, function () {
   describe("When tag is 'latest'", function () {
     it("should return the latest balance from the specified account", async function () {
       await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "latest"], (result, status) => {
-        console.log("Result:", result);
+        if (hre.debugMode) {
+          console.log("Result:", result);
+        }
 
         assert.equal(status, 200, "has status code");
         assert.property(result, "result", result.error ? result.error.message : "error");
@@ -40,7 +42,9 @@ describe("Calling " + METHOD, function () {
           1,
           [zilliqa_helper.getPrimaryAccountAddress(), "earliest"],
           (result, status) => {
-            console.log("Result:", result);
+            if (hre.debugMode) {
+              console.log("Result:", result);
+            }
 
             assert.equal(status, 200, "has status code");
             assert.property(result, "result", result.error ? result.error.message : "error");
@@ -74,7 +78,9 @@ describe("Calling " + METHOD, function () {
           1,
           [zilliqa_helper.getPrimaryAccountAddress(), "pending"],
           (result, status) => {
-            console.log("Result:", result);
+            if (hre.debugMode) {
+              console.log("Result:", result);
+            }
 
             assert.equal(status, 200, "has status code");
             assert.property(result, "result", result.error ? result.error.message : "error");
@@ -114,7 +120,10 @@ describe("Calling " + METHOD, function () {
         1,
         [zilliqa_helper.getPrimaryAccountAddress(), "unknown tag"], // not supported tag should give an error
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
+
           assert.equal(status, 200, "has status code");
           assert.equal(result.error.code, errorCode);
           assert.equal(result.error.message, expectedErrorMessage);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.js
@@ -8,9 +8,7 @@ describe("Calling " + METHOD, function () {
   describe("When tag is 'latest'", function () {
     it("should return the latest balance from the specified account", async function () {
       await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "latest"], (result, status) => {
-        if (hre.debugMode) {
-          console.log("Result:", result);
-        }
+        hre.logDebug("Result:", result);
 
         assert.equal(status, 200, "has status code");
         assert.property(result, "result", result.error ? result.error.message : "error");
@@ -42,9 +40,7 @@ describe("Calling " + METHOD, function () {
           1,
           [zilliqa_helper.getPrimaryAccountAddress(), "earliest"],
           (result, status) => {
-            if (hre.debugMode) {
-              console.log("Result:", result);
-            }
+            hre.logDebug("Result:", result);
 
             assert.equal(status, 200, "has status code");
             assert.property(result, "result", result.error ? result.error.message : "error");
@@ -78,9 +74,7 @@ describe("Calling " + METHOD, function () {
           1,
           [zilliqa_helper.getPrimaryAccountAddress(), "pending"],
           (result, status) => {
-            if (hre.debugMode) {
-              console.log("Result:", result);
-            }
+            hre.logDebug("Result:", result);
 
             assert.equal(status, 200, "has status code");
             assert.property(result, "result", result.error ? result.error.message : "error");
@@ -120,9 +114,7 @@ describe("Calling " + METHOD, function () {
         1,
         [zilliqa_helper.getPrimaryAccountAddress(), "unknown tag"], // not supported tag should give an error
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
 
           assert.equal(status, 200, "has status code");
           assert.equal(result.error.code, errorCode);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.js
@@ -69,9 +69,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return an error when called with no parameters", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
 
@@ -87,9 +85,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return an error when called with only first parameter", async function () {
     await helper.callEthMethod(METHOD, 1, ["latest"], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
       assert.equal(status, 200, "has status code");
 
       assert.isNumber(result.error.code, "Is not a number");
@@ -104,9 +100,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get full transactions objects by 'unknown tag' tag", async function () {
     await helper.callEthMethod(METHOD, 2, ["unknown tag", true], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.equal(result.result, null, "should be null");
@@ -115,9 +109,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get full transactions objects by 'latest' tag", async function () {
     await helper.callEthMethod(METHOD, 2, ["latest", true], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -127,9 +119,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get only the hashes of the transactions by 'latest' tag", async function () {
     await helper.callEthMethod(METHOD, 2, ["latest", false], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -139,9 +129,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get full transactions objects by 'earliest' tag", async function () {
     await helper.callEthMethod(METHOD, 2, ["earliest", true], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -152,9 +140,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get only the hashes of the transactions objects by 'earliest' tag", async function () {
     await helper.callEthMethod(METHOD, 2, ["earliest", false], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -165,9 +151,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get full transactions objects by its block number '0'", async function () {
     await helper.callEthMethod(METHOD, 2, ["0x0", true], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -179,9 +163,7 @@ describe("Calling " + METHOD, function () {
 
   it("should return get only the hashes of transactions objects by its block number '0'", async function () {
     await helper.callEthMethod(METHOD, 2, ["0x0", false], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       // validate all returned fields
@@ -199,9 +181,7 @@ describe("Calling " + METHOD, function () {
     });
     it("should return get full transactions objects by 'pending' tag", async function () {
       await helper.callEthMethod(METHOD, 2, ["pending", true], (result, status) => {
-        if (hre.debugMode) {
-          console.log(result);
-        }
+        hre.logDebug(result);
 
         assert.equal(status, 200, "has status code");
         // validate all returned fields

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.js
@@ -1,202 +1,214 @@
-const helper = require('../../helper/GeneralHelper');
-assert = require('chai').assert;
+const helper = require("../../helper/GeneralHelper");
+assert = require("chai").assert;
 
-const METHOD = 'eth_getBlockByNumber';
+const METHOD = "eth_getBlockByNumber";
 
 describe("Calling " + METHOD, function () {
-
   function TestResponse(response) {
-
     // validate all returned fields
 
-    assert.property(response, 'result', (response.error) ? response.error.message : 'error');
-    assert.isObject(response.result, 'is not an object');
+    assert.property(response, "result", response.error ? response.error.message : "error");
+    assert.isObject(response.result, "is not an object");
 
     // difficulty
-    assert.match(response.result.difficulty, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.difficulty, 'Is not a number');
+    assert.match(response.result.difficulty, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.difficulty, "Is not a number");
     // totalDifficulty
-    assert.match(response.result.totalDifficulty, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.totalDifficulty, 'Is not a number');
+    assert.match(response.result.totalDifficulty, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.totalDifficulty, "Is not a number");
     // extraData
-    assert.match(response.result.extraData, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.extraData, 'Is not a number');
+    assert.match(response.result.extraData, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.extraData, "Is not a number");
     // gasLimit
-    assert.match(response.result.gasLimit, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.gasLimit, 'Is not a number');
+    assert.match(response.result.gasLimit, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.gasLimit, "Is not a number");
     // gasUsed
-    assert.match(response.result.gasUsed, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.gasUsed, 'Is not a number');
+    assert.match(response.result.gasUsed, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.gasUsed, "Is not a number");
     // hash
-    assert.match(response.result.hash, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.hash, 'Is not a number');
+    assert.match(response.result.hash, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.hash, "Is not a number");
     // parentHash
-    assert.match(response.result.parentHash, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.parentHash, 'Is not a number');
+    assert.match(response.result.parentHash, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.parentHash, "Is not a number");
     // logsBloom
-    assert.match(response.result.logsBloom, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.logsBloom, 'Is not a number');
+    assert.match(response.result.logsBloom, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.logsBloom, "Is not a number");
     // miner
-    assert.match(response.result.miner, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.miner, 'Is not a number');
+    assert.match(response.result.miner, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.miner, "Is not a number");
     // number
-    assert.match(response.result.number, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.number, 'Is not a number');
+    assert.match(response.result.number, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.number, "Is not a number");
     // sha3Uncles
-    assert.match(response.result.sha3Uncles, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.sha3Uncles, 'Is not a number');
+    assert.match(response.result.sha3Uncles, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.sha3Uncles, "Is not a number");
     // size
-    assert.match(response.result.size, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.size, 'Is not a number');
+    assert.match(response.result.size, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.size, "Is not a number");
     // stateRoot
-    assert.match(response.result.stateRoot, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.stateRoot, 'Is not a number');
+    assert.match(response.result.stateRoot, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.stateRoot, "Is not a number");
     // timestamp
-    assert.match(response.result.timestamp, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.timestamp, 'Is not a number');
+    assert.match(response.result.timestamp, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.timestamp, "Is not a number");
     // nonce
-    assert.match(response.result.nonce, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.nonce, 'Is not a number');
+    assert.match(response.result.nonce, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.nonce, "Is not a number");
     // receiptsRoot
-    assert.match(response.result.receiptsRoot, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.receiptsRoot, 'Is not a number');
+    assert.match(response.result.receiptsRoot, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.receiptsRoot, "Is not a number");
     // transactionsRoot
-    assert.match(response.result.transactionsRoot, /^0x/, 'Should be HEX starting with 0x');
-    assert.isNumber(+response.result.transactionsRoot, 'Is not a number');
+    assert.match(response.result.transactionsRoot, /^0x/, "Should be HEX starting with 0x");
+    assert.isNumber(+response.result.transactionsRoot, "Is not a number");
     // transactions
-    assert.isArray(response.result.transactions, 'Is not an array');
+    assert.isArray(response.result.transactions, "Is not an array");
     // uncles
-    assert.isArray(response.result.uncles, 'Is not an array');
+    assert.isArray(response.result.uncles, "Is not an array");
   }
 
   it("should return an error when called with no parameters", async function () {
-    await helper.callEthMethod(METHOD, 1, [],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 1, [], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
-        assert.equal(status, 200, 'has status code');
+      }
 
-        assert.isNumber(result.error.code, "Is not a number");
-        assert.equal(+result.error.code, -32602);
-        assert.isString(result.error.message, 'is string');
-        assert.equal(result.error.message, 'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised');
-      })
-  })
+      assert.equal(status, 200, "has status code");
+
+      assert.isNumber(result.error.code, "Is not a number");
+      assert.equal(+result.error.code, -32602);
+      assert.isString(result.error.message, "is string");
+      assert.equal(
+        result.error.message,
+        "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+      );
+    });
+  });
 
   it("should return an error when called with only first parameter", async function () {
-    await helper.callEthMethod(METHOD, 1, ["latest"],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 1, ["latest"], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
-        assert.equal(status, 200, 'has status code');
+      }
+      assert.equal(status, 200, "has status code");
 
-        assert.isNumber(result.error.code, "Is not a number");
-        assert.equal(+result.error.code, -32602);
-        assert.isString(result.error.message, 'is string');
-        assert.equal(result.error.message, 'INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised');
-      })
-  })
+      assert.isNumber(result.error.code, "Is not a number");
+      assert.equal(+result.error.code, -32602);
+      assert.isString(result.error.message, "is string");
+      assert.equal(
+        result.error.message,
+        "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+      );
+    });
+  });
 
   it("should return get full transactions objects by 'unknown tag' tag", async function () {
-    await helper.callEthMethod(METHOD, 2, ["unknown tag", true],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["unknown tag", true], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        assert.equal(result.result, null, 'should be null');
-      })
-  })
+      assert.equal(status, 200, "has status code");
+      assert.equal(result.result, null, "should be null");
+    });
+  });
 
   it("should return get full transactions objects by 'latest' tag", async function () {
-    await helper.callEthMethod(METHOD, 2, ["latest", true],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["latest", true], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        // validate all returned fields
-        TestResponse(result);
-      })
-  })
-
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+    });
+  });
 
   it("should return get only the hashes of the transactions by 'latest' tag", async function () {
-    await helper.callEthMethod(METHOD, 2, ["latest", false],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["latest", false], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        // validate all returned fields
-        TestResponse(result);
-      })
-  })
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+    });
+  });
 
   it("should return get full transactions objects by 'earliest' tag", async function () {
-    await helper.callEthMethod(METHOD, 2, ["earliest", true],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["earliest", true], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        // validate all returned fields
-        TestResponse(result);
-        assert.equal(+result.result.number, 0, 'Block number is not "0"');
-      })
-  })
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(+result.result.number, 0, "Block number is not '0'");
+    });
+  });
 
   it("should return get only the hashes of the transactions objects by 'earliest' tag", async function () {
-    await helper.callEthMethod(METHOD, 2, ["earliest", false],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["earliest", false], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        // validate all returned fields
-        TestResponse(result);
-        assert.equal(+result.result.number, 0, 'Block number is not "0"');
-      })
-  })
-
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(+result.result.number, 0, "Block number is not '0'");
+    });
+  });
 
   it("should return get full transactions objects by its block number '0'", async function () {
-    await helper.callEthMethod(METHOD, 2, ["0x0", true],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["0x0", true], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
-        // validate all returned fields
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
 
-        TestResponse(result);
-        assert.equal(+result.result.number, 0, 'Block number is not "0"');
-      })
-  })
+      TestResponse(result);
+      assert.equal(+result.result.number, 0, "Block number is not '0'");
+    });
+  });
 
   it("should return get only the hashes of transactions objects by its block number '0'", async function () {
-    await helper.callEthMethod(METHOD, 2, ["0x0", false],
-      (result, status) => {
+    await helper.callEthMethod(METHOD, 2, ["0x0", false], (result, status) => {
+      if (hre.debugMode) {
         console.log(result);
+      }
 
-        assert.equal(status, 200, 'has status code');
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+
+      TestResponse(result);
+      assert.equal(+result.result.number, 0, "Block number is not '0'");
+    });
+  });
+
+  describe("When on Zilliqa network", function () {
+    before(function () {
+      if (!helper.isZilliqaNetworkSelected()) {
+        this.skip();
+      }
+    });
+    it("should return get full transactions objects by 'pending' tag", async function () {
+      await helper.callEthMethod(METHOD, 2, ["pending", true], (result, status) => {
+        if (hre.debugMode) {
+          console.log(result);
+        }
+
+        assert.equal(status, 200, "has status code");
         // validate all returned fields
 
-        TestResponse(result);
-        assert.equal(+result.result.number, 0, 'Block number is not "0"');
-      })
-  })
-
-  it("should return get full transactions objects by 'pending' tag", async function () {
-    describe("When on Zilliqa network", async function () {
-      before(async function () {
-        if (!helper.isZilliqaNetworkSelected()) {
-          this.skip();
-        }
-      })
-
-      await helper.callEthMethod(METHOD, 2, ["pending", true],
-        (result, status) => {
-          console.log(result);
-
-          assert.equal(status, 200, 'has status code');
-          // validate all returned fields
-
-          assert.property(result, 'result', (result.error) ? result.error.message : 'error');
-          assert.equal(result.result, null, 'should be null');
-        })
-    })
-  })
-})
+        assert.property(result, "result", result.error ? result.error.message : "error");
+        assert.equal(result.result, null, "should be null");
+      });
+    });
+  });
+});

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionCount.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionCount.js
@@ -8,9 +8,7 @@ describe("Calling " + METHOD, function () {
   // Test that we get no error and that the api call returns a transaction count >= 0.
   it("Should return the latest transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "latest"], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");
@@ -28,9 +26,7 @@ describe("Calling " + METHOD, function () {
 
   it("Should return the pending transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "pending"], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");
@@ -48,9 +44,7 @@ describe("Calling " + METHOD, function () {
 
   it("Should return the earliest transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "earliest"], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionCount.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionCount.js
@@ -8,7 +8,9 @@ describe("Calling " + METHOD, function () {
   // Test that we get no error and that the api call returns a transaction count >= 0.
   it("Should return the latest transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "latest"], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");
@@ -26,7 +28,9 @@ describe("Calling " + METHOD, function () {
 
   it("Should return the pending transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "pending"], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");
@@ -44,7 +48,9 @@ describe("Calling " + METHOD, function () {
 
   it("Should return the earliest transaction count >= 0", async function () {
     await helper.callEthMethod(METHOD, 1, [zilliqa_helper.getPrimaryAccountAddress(), "earliest"], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionReceipt.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionReceipt.js
@@ -15,16 +15,12 @@ describe("Calling " + METHOD, function () {
     var transactionHash;
 
     function onMoveFundsFinished(receipt) {
-      if (hre.debugMode) {
-        console.log("Moved funds successfully, receipt:", receipt);
-      }
+      hre.logDebug("Moved funds successfully, receipt:", receipt);
       transactionHash = receipt.transactionHash;
     }
 
     function onMoveFundsError(error) {
-      if (hre.debugMode) {
-        console.log("Then with Error:", error);
-      }
+      hre.logDebug("Then with Error:", error);
       assert.fail("Failure: Unexpected return ", error);
     }
 
@@ -35,9 +31,7 @@ describe("Calling " + METHOD, function () {
       .then(onMoveFundsFinished, onMoveFundsError);
 
     await helper.callEthMethod(METHOD, 1, [transactionHash], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionReceipt.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionReceipt.js
@@ -15,12 +15,16 @@ describe("Calling " + METHOD, function () {
     var transactionHash;
 
     function onMoveFundsFinished(receipt) {
-      console.log("Moved funds successfully, receipt:", receipt);
+      if (hre.debugMode) {
+        console.log("Moved funds successfully, receipt:", receipt);
+      }
       transactionHash = receipt.transactionHash;
     }
 
     function onMoveFundsError(error) {
-      console.log("Then with Error:", error);
+      if (hre.debugMode) {
+        console.log("Then with Error:", error);
+      }
       assert.fail("Failure: Unexpected return ", error);
     }
 
@@ -31,7 +35,9 @@ describe("Calling " + METHOD, function () {
       .then(onMoveFundsFinished, onMoveFundsError);
 
     await helper.callEthMethod(METHOD, 1, [transactionHash], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.js
@@ -17,9 +17,7 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
           assert.equal(status, 200, "has status code");
           assert.property(result, "result", result.error ? result.error.message : "error");
           assert.isNumber(+result.result, "can be converted to a number");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_getUncleByBlockHashAndIndex";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -17,7 +17,9 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
           assert.equal(status, 200, "has status code");
           assert.property(result, "result", result.error ? result.error.message : "error");
           assert.isNumber(+result.result, "can be converted to a number");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex .js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex .js
@@ -17,9 +17,7 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
           assert.equal(status, 200, "has status code");
           assert.property(result, "result", result.error ? result.error.message : "error");
           assert.isNumber(+result.result, "can be converted to a number");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex .js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex .js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_getUncleByBlockNumberAndIndex";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -17,7 +17,9 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b", "0x0"],
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
           assert.equal(status, 200, "has status code");
           assert.property(result, "result", result.error ? result.error.message : "error");
           assert.isNumber(+result.result, "can be converted to a number");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_mining.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_mining.js
@@ -6,9 +6,7 @@ const METHOD = "eth_mining";
 describe("Calling " + METHOD, function () {
   it("should return the mining state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_mining.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_mining.js
@@ -6,7 +6,9 @@ const METHOD = "eth_mining";
 describe("Calling " + METHOD, function () {
   it("should return the mining state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_protocolVersion.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_protocolVersion.js
@@ -6,9 +6,7 @@ const METHOD = "eth_protocolVersion";
 describe("Calling " + METHOD, function () {
   it("should return the protocol version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_protocolVersion.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_protocolVersion.js
@@ -6,7 +6,9 @@ const METHOD = "eth_protocolVersion";
 describe("Calling " + METHOD, function () {
   it("should return the protocol version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sendRawTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sendRawTransaction.js
@@ -25,9 +25,7 @@ describe("Calling " + METHOD, function () {
       const signedTx = await fromAccount.signTransaction(tx);
 
       await gHelper.callEthMethod(METHOD, 1, [signedTx.rawTransaction], (result, status) => {
-        if (hre.debugMode) {
-          console.log("Result:", result);
-        }
+        hre.logDebug("Result:", result);
 
         // The result contains a transaction hash that is every time different and should match the hash returned in the result
         assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sendRawTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sendRawTransaction.js
@@ -25,7 +25,9 @@ describe("Calling " + METHOD, function () {
       const signedTx = await fromAccount.signTransaction(tx);
 
       await gHelper.callEthMethod(METHOD, 1, [signedTx.rawTransaction], (result, status) => {
-        console.log("Result:", result);
+        if (hre.debugMode) {
+          console.log("Result:", result);
+        }
 
         // The result contains a transaction hash that is every time different and should match the hash returned in the result
         assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.js
@@ -26,9 +26,7 @@ describe("Calling " + METHOD, function () {
           }
         ],
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
 
           assert.equal(status, 200, "has status code");
           assert.isNumber(result.error.code, -32601);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_sendTransaction";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -26,7 +26,9 @@ describe("Calling " + METHOD, function () {
           }
         ],
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
 
           assert.equal(status, 200, "has status code");
           assert.isNumber(result.error.code, -32601);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sign.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sign.js
@@ -17,9 +17,7 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xF0C05464f12cB2a011d21dE851108a090C95c755", "0xdeadbeaf"],
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
 
           // eth_sign not supported on Zilliqa
           assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sign.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sign.js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_sign";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -17,7 +17,9 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xF0C05464f12cB2a011d21dE851108a090C95c755", "0xdeadbeaf"],
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
 
           // eth_sign not supported on Zilliqa
           assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_signTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_signTransaction.js
@@ -4,7 +4,7 @@ assert = require("chai").assert;
 const METHOD = "eth_signTransaction";
 
 describe("Calling " + METHOD, function () {
-  describe("When on Zilliqa network", async function () {
+  describe("When on Zilliqa network", function () {
     before(async function () {
       if (!helper.isZilliqaNetworkSelected()) {
         this.skip();
@@ -17,7 +17,9 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xF0C05464f12cB2a011d21dE851108a090C95c755", "0xdeadbeaf"],
         (result, status) => {
-          console.log(result);
+          if (hre.debugMode) {
+            console.log(result);
+          }
 
           assert.equal(status, 200, "has status code");
           assert.isNumber(result.error.code, -32601);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_signTransaction.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_signTransaction.js
@@ -17,9 +17,7 @@ describe("Calling " + METHOD, function () {
         2,
         ["0xF0C05464f12cB2a011d21dE851108a090C95c755", "0xdeadbeaf"],
         (result, status) => {
-          if (hre.debugMode) {
-            console.log(result);
-          }
+          hre.logDebug(result);
 
           assert.equal(status, 200, "has status code");
           assert.isNumber(result.error.code, -32601);

--- a/tests/EvmAcceptanceTests/test/rpc/eth_syncing.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_syncing.js
@@ -6,7 +6,9 @@ const METHOD = "eth_syncing";
 describe("Calling " + METHOD, function () {
   it("should return the syncing state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_syncing.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_syncing.js
@@ -6,9 +6,7 @@ const METHOD = "eth_syncing";
 describe("Calling " + METHOD, function () {
   it("should return the syncing state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_listening.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_listening.js
@@ -6,7 +6,9 @@ const METHOD = "net_listening";
 describe("Calling " + METHOD, function () {
   it("should return the network listening state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_listening.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_listening.js
@@ -6,9 +6,7 @@ const METHOD = "net_listening";
 describe("Calling " + METHOD, function () {
   it("should return the network listening state", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_peerCount.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_peerCount.js
@@ -6,7 +6,9 @@ const METHOD = "net_peerCount";
 describe("Calling " + METHOD, function () {
   it("should return the number of peers connected to the network", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_peerCount.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_peerCount.js
@@ -6,9 +6,7 @@ const METHOD = "net_peerCount";
 describe("Calling " + METHOD, function () {
   it("should return the number of peers connected to the network", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_version.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_version.js
@@ -6,7 +6,9 @@ const METHOD = "net_version";
 describe("Calling " + METHOD, function () {
   it("should return the current network version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/net_version.js
+++ b/tests/EvmAcceptanceTests/test/rpc/net_version.js
@@ -6,9 +6,7 @@ const METHOD = "net_version";
 describe("Calling " + METHOD, function () {
   it("should return the current network version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/web3_clientVersion.js
+++ b/tests/EvmAcceptanceTests/test/rpc/web3_clientVersion.js
@@ -6,7 +6,9 @@ const METHOD = "web3_clientVersion";
 describe("Calling " + METHOD, function () {
   it("should return the web3 client version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");

--- a/tests/EvmAcceptanceTests/test/rpc/web3_clientVersion.js
+++ b/tests/EvmAcceptanceTests/test/rpc/web3_clientVersion.js
@@ -6,9 +6,7 @@ const METHOD = "web3_clientVersion";
 describe("Calling " + METHOD, function () {
   it("should return the web3 client version", async function () {
     await helper.callEthMethod(METHOD, 1, [], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");
       assert.isString(result.result, "is string");

--- a/tests/EvmAcceptanceTests/test/rpc/web3_sha3.js
+++ b/tests/EvmAcceptanceTests/test/rpc/web3_sha3.js
@@ -6,9 +6,7 @@ const METHOD = "web3_sha3";
 describe("Calling " + METHOD, function () {
   it("should return a sha3 of the provided hex string", async function () {
     await helper.callEthMethod(METHOD, 1, ["0x68656c6c6f20776f726c64"], (result, status) => {
-      if (hre.debugMode) {
-        console.log(result);
-      }
+      hre.logDebug(result);
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");

--- a/tests/EvmAcceptanceTests/test/rpc/web3_sha3.js
+++ b/tests/EvmAcceptanceTests/test/rpc/web3_sha3.js
@@ -6,7 +6,9 @@ const METHOD = "web3_sha3";
 describe("Calling " + METHOD, function () {
   it("should return a sha3 of the provided hex string", async function () {
     await helper.callEthMethod(METHOD, 1, ["0x68656c6c6f20776f726c64"], (result, status) => {
-      console.log(result);
+      if (hre.debugMode) {
+        console.log(result);
+      }
 
       assert.equal(status, 200, "has status code");
       assert.property(result, "result", result.error ? result.error.message : "error");


### PR DESCRIPTION
## Description
Test results should be as cleanest as we can. just failure or success of tests. I added `--debug` flag so that if it's passed to `npx hardhat test` then logs will be appeared on the screen.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
