### PR TITLE
[master] revert block num start index as fails tests

### DIFF
--- a/src/cmd/isolated_server.cpp
+++ b/src/cmd/isolated_server.cpp
@@ -74,7 +74,7 @@ void help(const char* argv[]) {
 int main(int argc, const char* argv[]) {
   string accountJsonFilePath;
   uint port{5555};
-  string blocknum_str{"0"};
+  string blocknum_str{"1"};
   uint timeDelta{0};
   bool loadPersistence{false};
   bool nonisoload{false};


### PR DESCRIPTION
There is some error with starting the isolated server from block 0 that I see locally - this reverts @moboware change of starting it from 0. The behaviour is such that the tx receipt cannot be found via the regular zil api once the tx is submitted