### PR TITLE
[master] ZIL-4812: support compilation on Mac (M1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,18 @@ find_package(leveldb REQUIRED)
 find_package(g3log REQUIRED)
 #TODO: upgrade to OpenSSL 1.1.1a
 find_package(OpenSSL REQUIRED)
+
+# Temporary workarounds for Python3:
+#
+# 1. Make sure PATH points to the python3 in the vcpkg tools sub-directory; otherwise on some systems find_package 
+#    will fail (e.g. if libpython3-dev is installed on Ubuntu 20.04).
+# 2. For some reason it only finds debug library upon a second call to  find_package. Otherwise, the release
+#    library will be used and if it's a debug build linkage could fail.
+set(PREV_PATH $ENV{PATH})
+set(ENV{PATH} "${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/tools/python3:$ENV{PATH}")
 find_package(Python3 COMPONENTS Development REQUIRED)
-# Temporary workaround for Python3: for some reason it only finds debug library upon a second call to 
-# find_package. Otherwise, the release library will be used and if it's a debug build linkage could fail.
 find_package(Python3 COMPONENTS Development REQUIRED)
+set(ENV{PATH} "${PREV_PATH}")
 
 include(FindProtobuf)
 set(protobuf_MODULE_COMPATIBLE TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@ message(STATUS "We are on a ${CMAKE_SYSTEM_NAME} system")
 #             This is a simple workaround against this issue.
 if (APPLE)
   file(CREATE_LINK
-    ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-osx-dynamic/lib
-    ${CMAKE_BINARY_DIR}/vcpkg_installed/x64-osx-dynamic/tools/lib
+    ${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib
+    ${CMAKE_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/tools/lib
     SYMBOLIC)
 endif()
 

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -34,15 +34,34 @@ fi
 
 # set n_parallel to fully utilize the resources
 os=$(uname)
+arch=$(uname -m)
 case $os in
     'Linux')
         n_parallel=$(nproc)
+        case $arch in
+            'x86_64')
+                triplet=x64-linux-dynamic
+                ;;
+            'arm64')
+                triplet=armx64-linux-dynamic
+                ;;
+        esac
         ;;
     'Darwin')
         n_parallel=$(sysctl -n hw.ncpu)
+        case $arch in
+            'x86_64')
+                triplet=x64-osx-dynamic
+                ;;
+            'arm64')
+                triplet=arm64-osx-dynamic
+                ;;
+        esac
         ;;
     *)
         n_parallel=2
+        # Default is x64-linux-dynamic
+        triplet=x64-linux-dynamic
         ;;
 esac
 
@@ -66,7 +85,7 @@ then
 fi
 
 # assume that it is run from project root directory
-cmake -H. -B${dir} ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=Debug -DTESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux-dynamic
+cmake -H. -B${dir} ${CMAKE_EXTRA_OPTIONS} -DCMAKE_BUILD_TYPE=Debug -DTESTS=ON -DENABLE_COVERAGE=ON -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=${triplet}
 cmake --build ${dir} -- -j${n_parallel}
 
 # remember to append `|| exit` after the commands added in if-then-else

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
     {
       "kind": "filesystem",
       "path": "vcpkg-registry",
-      "packages": [ "python3", "g3log", "schnorr" ]
+      "packages": [ "python3", "g3log", "schnorr", "libmicrohttpd" ]
     }
   ]
 }

--- a/vcpkg-registry/ports/g3log/vcpkg.json
+++ b/vcpkg-registry/ports/g3log/vcpkg.json
@@ -4,5 +4,5 @@
   "port-version": 3,
   "description": "Asynchronous logger with Dynamic Sinks (with dynamic log levels)",
   "homepage": "https://github.com/KjellKod/g3log",
-  "supports": "!(arm | uwp)"
+  "supports": "!(uwp)"
 }

--- a/vcpkg-registry/ports/libmicrohttpd/fix-msvc-project.patch
+++ b/vcpkg-registry/ports/libmicrohttpd/fix-msvc-project.patch
@@ -1,0 +1,12 @@
+diff --git a/w32/common/libmicrohttpd-files.vcxproj b/w32/common/libmicrohttpd-files.vcxproj
+index 6f1e03b..c0ddea8 100644
+--- a/w32/common/libmicrohttpd-files.vcxproj
++++ b/w32/common/libmicrohttpd-files.vcxproj
+@@ -3,6 +3,7 @@
+   <ItemGroup>
+     <ClCompile Include="$(MhdSrc)microhttpd\base64.c" />
+     <ClCompile Include="$(MhdSrc)microhttpd\basicauth.c" />
++    <ClCompile Include="$(MhdSrc)microhttpd\sha256.c" />
+     <ClCompile Include="$(MhdSrc)microhttpd\connection.c" />
+     <ClCompile Include="$(MhdSrc)microhttpd\daemon.c" />
+     <ClCompile Include="$(MhdSrc)microhttpd\digestauth.c" />

--- a/vcpkg-registry/ports/libmicrohttpd/portfile.cmake
+++ b/vcpkg-registry/ports/libmicrohttpd/portfile.cmake
@@ -1,0 +1,55 @@
+vcpkg_fail_port_install(ON_TARGET "UWP")
+
+set(MICROHTTPD_VERSION 0.9.63)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+        "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+    FILENAME "libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz"
+    SHA512 cb99e7af84fb6d7c0fd3894a9dc0fbff14959b35347506bd3211a65bbfad36455007b9e67493e97c9d8394834408df10eeabdc7758573e6aae0ba6f5f87afe17
+)
+
+vcpkg_extract_source_archive_ex(
+    ARCHIVE "${ARCHIVE}"
+    OUT_SOURCE_PATH SOURCE_PATH
+    PATCHES fix-msvc-project.patch
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    if (VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(CFG_SUFFIX "dll")
+    else()
+        set(CFG_SUFFIX "static")
+    endif()
+
+    vcpkg_install_msbuild(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_SUBPATH w32/VS2015/libmicrohttpd.vcxproj
+        RELEASE_CONFIGURATION "Release-${CFG_SUFFIX}"
+        DEBUG_CONFIGURATION "Debug-${CFG_SUFFIX}"
+    )
+    
+    file(GLOB MICROHTTPD_HEADERS "${SOURCE_PATH}/src/include/microhttpd*.h")
+    file(COPY ${MICROHTTPD_HEADERS} DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+else()
+    if(VCPKG_TARGET_IS_OSX AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        set(ENV{LIBS} "$ENV{LIBS} -framework Foundation -framework AppKit") # TODO: Get this from the extracted cmake vars somehow
+    endif()
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        OPTIONS
+            --disable-doc
+            --disable-examples
+            --disable-curl
+            --disable-https
+            --with-gnutls=no
+    )
+
+    vcpkg_install_make()
+    vcpkg_fixup_pkgconfig()
+    
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+endif()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg-registry/ports/libmicrohttpd/vcpkg.json
+++ b/vcpkg-registry/ports/libmicrohttpd/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "libmicrohttpd",
+  "version": "0.9.63",
+  "port-version": 8,
+  "description": "GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application",
+  "homepage": "https://www.gnu.org/software/libmicrohttpd/",
+  "supports": "!(uwp)",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "platform": "!windows"
+    }
+  ]
+}

--- a/vcpkg-registry/ports/schnorr/portfile.cmake
+++ b/vcpkg-registry/ports/schnorr/portfile.cmake
@@ -6,12 +6,18 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-      -DCMAKE_CXX_FLAGS=-Wno-dev
-      -DCMAKE_C_FLAGS=-Wno-dev
-)
+if (UNIX AND NOT APPLE)
+  vcpkg_cmake_configure(
+      SOURCE_PATH ${SOURCE_PATH}
+      OPTIONS
+        -DCMAKE_CXX_FLAGS=-Wno-dev
+        -DCMAKE_C_FLAGS=-Wno-dev
+  )
+else()
+  vcpkg_cmake_configure(
+      SOURCE_PATH ${SOURCE_PATH}
+  )
+endif()
 
 vcpkg_cmake_install()
 

--- a/vcpkg-registry/versions/baseline.json
+++ b/vcpkg-registry/versions/baseline.json
@@ -2,6 +2,7 @@
   "default": {
     "python3": { "baseline": "3.10.5", "port-version": 6 },
     "g3log": { "baseline": "1.3.4", "port-version": 3 },
-    "schnorr": { "baseline": "8.2.0", "port-version": 0 }
+    "schnorr": { "baseline": "8.2.0", "port-version": 0 },
+    "libmicrohttpd": { "baseline": "0.9.63", "port-version": 8 }
   }
 }

--- a/vcpkg-registry/versions/l-/libmicrohttpd.json
+++ b/vcpkg-registry/versions/l-/libmicrohttpd.json
@@ -1,0 +1,10 @@
+{
+  "versions": [
+    {
+      "path": "$/ports/libmicrohttpd",
+      "version": "0.9.63",
+      "port-version": 8
+    }
+  ]
+}
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "zilliqa",
-  "version-string": "9.0.0",
+  "version-string": "8.3.0",
   "dependencies": [
     "jsoncpp",
     "openssl",
@@ -49,7 +49,7 @@
     },
     {
       "name": "libmicrohttpd",
-      "version-string": "0.9.63#7"
+      "version-string": "0.9.63#8"
     },
     {
       "name": "schnorr",


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This includes several changes to allow compilation on a M1 Mac:
* Updating the g3log & libmicrohttpd ports by simply removing the restriction that prevents compilation ARM machines.
* Forking libff to prevent unused parts from compiling on ARM. This necessitates updating the CryptoUtils submodule.

This requires invoking: `git submodule update --init --recursive`

**These changes are untested on ARM and are only meant as preliminary changes to start moving in this direction.**

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
