### PR TITLE
[master] Fix revert test, add two new revert tests

### DIFF
--- a/tests/EvmAcceptanceTests/contracts/Revert.sol
+++ b/tests/EvmAcceptanceTests/contracts/Revert.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.9;
 
 import "hardhat/console.sol";
 
+error FakeError(uint256 value, address sender);
+
 contract Revert {
   address owner;
 
@@ -11,9 +13,16 @@ contract Revert {
     owner = msg.sender; // address that deploys contract will be the owner
   }
 
-  function revertCall() public view {
-    console.log("RevertCall from sender:", msg.sender, " to owner:", owner);
+  function revertCall() public pure {
     revert();
+  }
+
+  function revertCallWithMessage(string memory revertMessage) public pure {
+    revert(revertMessage);
+  }
+
+  function revertCallWithCustomError() public payable {
+    revert FakeError({value: msg.value, sender: msg.sender});
   }
 
   function value() public pure returns (int256) {


### PR DESCRIPTION
## Description
We have one disabled test in `ContractRevert.js` which is addressed in this PR as well as adding two more new tests to revert tests.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
