### PR TITLE
[master] force to lookup mode in isolated server

### DIFF
--- a/src/cmd/isolated_server.cpp
+++ b/src/cmd/isolated_server.cpp
@@ -79,6 +79,9 @@ int main(int argc, const char* argv[]) {
   bool loadPersistence{false};
   bool nonisoload{false};
   string uuid;
+
+  LOOKUP_NODE_MODE = true;
+
   try {
     po::options_description desc("Options");
 

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -114,7 +114,7 @@ bool SCILLA_PPLIT_FLAG = true;
 // General constants
 const unsigned int DEBUG_LEVEL{ReadConstantNumeric("DEBUG_LEVEL")};
 const bool ENABLE_DO_REJOIN{ReadConstantString("ENABLE_DO_REJOIN") == "true"};
-const bool LOOKUP_NODE_MODE{ReadConstantString("LOOKUP_NODE_MODE") == "true"};
+bool LOOKUP_NODE_MODE{ReadConstantString("LOOKUP_NODE_MODE") == "true"};
 const unsigned int MAX_ENTRIES_FOR_DIAGNOSTIC_DATA{
     ReadConstantNumeric("MAX_ENTRIES_FOR_DIAGNOSTIC_DATA")};
 const uint16_t CHAIN_ID{(uint16_t)ReadConstantNumeric("CHAIN_ID")};

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -147,7 +147,7 @@ constexpr uint16_t MAX_REPUTATION =
 // General constants
 extern const unsigned int DEBUG_LEVEL;
 extern const bool ENABLE_DO_REJOIN;
-extern const bool LOOKUP_NODE_MODE;
+extern bool LOOKUP_NODE_MODE;
 extern const unsigned int MAX_ENTRIES_FOR_DIAGNOSTIC_DATA;
 extern const uint16_t CHAIN_ID;
 extern const uint16_t NETWORK_ID;


### PR DESCRIPTION
You always want the isolated server to start in lookup mode and can forget to modify constants.xml every so often. Force it such that it is always true to avoid getting random segvs etc. 