### PR TITLE
[master] ZIL-4921 account store scilla IPC server pointer fix

### DIFF
--- a/src/libData/AccountData/AccountStore.cpp
+++ b/src/libData/AccountData/AccountStore.cpp
@@ -48,23 +48,12 @@ AccountStore::AccountStore()
   bool ipcScillaInit = false;
 
   if ((ENABLE_SC && ENABLE_EVM) || ISOLATED_SERVER) {
-    /// Scilla IPC Server
-    /// clear path
-    boost::filesystem::remove_all(SCILLA_IPC_SOCKET_PATH);
-    m_scillaIPCServerConnector =
-        make_unique<jsonrpc::UnixDomainSocketServer>(SCILLA_IPC_SOCKET_PATH);
-    m_scillaIPCServerConnector->SetWaitTime(
-        SCILLA_SERVER_LOOP_WAIT_MICROSECONDS);
-
-    CreateScillaIPCServer(m_scillaIPCServerConnector);
-
     if (!LOOKUP_NODE_MODE || ISOLATED_SERVER) {
       ScillaClient::GetInstance().Init();
       ipcScillaInit = true;
     }
 
-    m_accountStoreTemp->SetScillaIPCServer(GetScillaIPCServer());
-    if (GetScillaIPCServer()->StartListening()) {
+    if (ScillaIPCServer::GetInstance().StartListening()) {
       LOG_GENERAL(INFO, "Scilla IPC Server started successfully");
     } else {
       LOG_GENERAL(WARNING, "Scilla IPC Server couldn't start");
@@ -82,9 +71,7 @@ AccountStore::AccountStore()
 }
 
 AccountStore::~AccountStore() {
-  if (GetScillaIPCServer() != nullptr) {
-    GetScillaIPCServer()->StopListening();
-  }
+  ScillaIPCServer::GetInstance().StopListening();
 }
 
 void AccountStore::Init() {

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -91,9 +91,6 @@ class AccountStore
   std::condition_variable_any m_writeCond;
   static constexpr int NUM_OF_WRITERS_IN_QUEUE = 1;
 
-  /// Scilla IPC server related
-  std::unique_ptr<jsonrpc::UnixDomainSocketServer> m_scillaIPCServerConnector;
-
   AccountStore();
   ~AccountStore();
 

--- a/src/libData/AccountData/AccountStore.h
+++ b/src/libData/AccountData/AccountStore.h
@@ -68,8 +68,7 @@ class AccountStoreTemp : public AccountStoreSC<std::map<Address, Account>> {
 
 // Singleton class for providing interface related Account System
 class AccountStore
-    : public AccountStoreTrie<std::unordered_map<Address, Account>>,
-      Singleton<AccountStore> {
+    : public AccountStoreTrie<std::unordered_map<Address, Account>> {
   /// instantiate of AccountStoreTemp, which is serving for the StateDelta
   /// generation
   std::unique_ptr<AccountStoreTemp> m_accountStoreTemp;
@@ -93,7 +92,6 @@ class AccountStore
   static constexpr int NUM_OF_WRITERS_IN_QUEUE = 1;
 
   /// Scilla IPC server related
-  std::shared_ptr<ScillaIPCServer> m_scillaIPCServer;
   std::unique_ptr<jsonrpc::UnixDomainSocketServer> m_scillaIPCServerConnector;
 
   AccountStore();

--- a/src/libData/AccountData/AccountStoreSC.cpp
+++ b/src/libData/AccountData/AccountStoreSC.cpp
@@ -319,16 +319,9 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       }
 
       // prepare IPC with current blockchain info provider.
-
-      if (m_scillaIPCServer) {
-        m_scillaIPCServer->setBCInfoProvider(
-            {m_curBlockNum, m_curDSBlockNum, m_originAddr, toAddr,
-             toAccount->GetStorageRoot(), scilla_version});
-      } else {
-        LOG_GENERAL(
-            WARNING,
-            "Scilla IPC server is not setup correctly - detected null object");
-      }
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
+          {m_curBlockNum, m_curDSBlockNum, m_originAddr, toAddr,
+           toAccount->GetStorageRoot(), scilla_version});
 
       // ************************************************************************
       // Undergo scilla checker
@@ -602,13 +595,9 @@ bool AccountStoreSC<MAP>::UpdateAccounts(const uint64_t& blockNum,
       }
 
       // prepare IPC with current blockchain info provider.
-      if (m_scillaIPCServer) {
-        m_scillaIPCServer->setBCInfoProvider(
-            {m_curBlockNum, m_curDSBlockNum, m_originAddr, m_curContractAddr,
-             toAccount->GetStorageRoot(), scilla_version});
-      } else {
-        LOG_GENERAL(WARNING, "m_scillaIPCServer not Initialised");
-      }
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
+          {m_curBlockNum, m_curDSBlockNum, m_originAddr, m_curContractAddr,
+           toAccount->GetStorageRoot(), scilla_version});
 
       Contract::ContractStorage::GetContractStorage().BufferCurrentState();
 
@@ -1453,7 +1442,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
       }
 
       // prepare IPC with current blockchain info provider.
-      m_scillaIPCServer->setBCInfoProvider(
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
           {m_curBlockNum, m_curDSBlockNum, m_originAddr, recipient,
            account->GetStorageRoot(), scilla_version});
 
@@ -1489,7 +1478,7 @@ bool AccountStoreSC<MAP>::ParseCallContractJsonOutput(
       }
 
       // prepare IPC with current blockchain info provider.
-      m_scillaIPCServer->setBCInfoProvider(
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
           {m_curBlockNum, m_curDSBlockNum, m_originAddr, recipient,
            account->GetStorageRoot(), scilla_version});
 
@@ -1557,7 +1546,6 @@ template <class MAP>
 bool AccountStoreSC<MAP>::TransferBalanceAtomic(const Address& from,
                                                 const Address& to,
                                                 const uint128_t& delta) {
-  // LOG_MARKER();
   return m_accountStoreAtomic->TransferBalance(from, to, delta);
 }
 
@@ -1595,29 +1583,12 @@ Account* AccountStoreSC<MAP>::GetAccountAtomic(const dev::h160& addr) {
 }
 
 template <class MAP>
-void AccountStoreSC<MAP>::SetScillaIPCServer(
-    const std::shared_ptr<ScillaIPCServer>& scillaIPCServer) {
-  LOG_MARKER();
-  m_scillaIPCServer = scillaIPCServer;
-}
-
-template <class MAP>
 void AccountStoreSC<MAP>::CleanNewLibrariesCache() {
   for (const auto& addr : m_newLibrariesCreated) {
     boost::filesystem::remove(addr.hex() + LIBRARY_CODE_EXTENSION);
     boost::filesystem::remove(addr.hex() + ".json");
   }
   m_newLibrariesCreated.clear();
-}
-
-template <class MAP>
-const std::shared_ptr<ScillaIPCServer>&
-AccountStoreSC<MAP>::CreateScillaIPCServer(
-    const std::unique_ptr<jsonrpc::UnixDomainSocketServer>&
-        scillaIPCServerConnector) {
-  m_scillaIPCServer =
-      std::make_shared<ScillaIPCServer>(*scillaIPCServerConnector);
-  return m_scillaIPCServer;
 }
 
 // Explicit template instantiations.

--- a/src/libData/AccountData/AccountStoreSC.cpp
+++ b/src/libData/AccountData/AccountStoreSC.cpp
@@ -1596,9 +1596,9 @@ Account* AccountStoreSC<MAP>::GetAccountAtomic(const dev::h160& addr) {
 
 template <class MAP>
 void AccountStoreSC<MAP>::SetScillaIPCServer(
-    std::shared_ptr<ScillaIPCServer> scillaIPCServer) {
+    const std::shared_ptr<ScillaIPCServer>& scillaIPCServer) {
   LOG_MARKER();
-  m_scillaIPCServer = std::move(scillaIPCServer);
+  m_scillaIPCServer = scillaIPCServer;
 }
 
 template <class MAP>
@@ -1608,6 +1608,16 @@ void AccountStoreSC<MAP>::CleanNewLibrariesCache() {
     boost::filesystem::remove(addr.hex() + ".json");
   }
   m_newLibrariesCreated.clear();
+}
+
+template <class MAP>
+const std::shared_ptr<ScillaIPCServer>&
+AccountStoreSC<MAP>::CreateScillaIPCServer(
+    const std::unique_ptr<jsonrpc::UnixDomainSocketServer>&
+        scillaIPCServerConnector) {
+  m_scillaIPCServer =
+      std::make_shared<ScillaIPCServer>(*scillaIPCServerConnector);
+  return m_scillaIPCServer;
 }
 
 // Explicit template instantiations.

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -104,9 +104,6 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   std::condition_variable m_CallContractConditionVariable;
   std::atomic<bool> m_txnProcessTimeout;
 
-  /// Scilla IPC server
-  std::shared_ptr<ScillaIPCServer> m_scillaIPCServer;
-
   /// A set of contract account address pending for storageroot updating
   std::set<Address> m_storageRootUpdateBuffer;
 
@@ -195,13 +192,6 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   const uint64_t& getCurBlockNum() const { return m_curBlockNum; }
 
   const uint64_t& getCurDSBlockNum() const { return m_curDSBlockNum; }
-
-  const std::shared_ptr<ScillaIPCServer>& CreateScillaIPCServer(
-      const std::unique_ptr<jsonrpc::UnixDomainSocketServer>& scillaIPCServerConnector);
-
-  const std::shared_ptr<ScillaIPCServer>& GetScillaIPCServer() const {
-    return m_scillaIPCServer;
-  }
 
   /// generate input files for interpreter to deploy contract
   bool ExportCreateContractFiles(

--- a/src/libData/AccountData/AccountStoreSC.h
+++ b/src/libData/AccountData/AccountStoreSC.h
@@ -196,6 +196,13 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
 
   const uint64_t& getCurDSBlockNum() const { return m_curDSBlockNum; }
 
+  const std::shared_ptr<ScillaIPCServer>& CreateScillaIPCServer(
+      const std::unique_ptr<jsonrpc::UnixDomainSocketServer>& scillaIPCServerConnector);
+
+  const std::shared_ptr<ScillaIPCServer>& GetScillaIPCServer() const {
+    return m_scillaIPCServer;
+  }
+
   /// generate input files for interpreter to deploy contract
   bool ExportCreateContractFiles(
       const Account& contract, bool is_library, uint32_t scilla_version,
@@ -248,7 +255,8 @@ class AccountStoreSC : public AccountStoreBase<MAP> {
   void NotifyTimeout();
 
   /// public interface to setup scilla ipc server
-  void SetScillaIPCServer(std::shared_ptr<ScillaIPCServer> scillaIPCServer);
+  void SetScillaIPCServer(
+      const std::shared_ptr<ScillaIPCServer>& scillaIPCServer);
 
   /// public interface to invoke processing of the buffered storage root
   /// updating tasks

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -239,6 +239,17 @@ bool AccountStoreSC<MAP>::ViewAccounts(const EvmCallParameters& params,
                                        evmproj::CallResponse& response) {
   uint32_t evm_version{0};
 
+  const Address contractAddr(params.m_contract);
+  const Address origin(params.m_caller);
+
+  //
+  // Get latest by setting tree to zeroes dev::h256()
+  //
+
+  ScillaIPCServer::GetInstance().setBCInfoProvider({m_curBlockNum, m_curDSBlockNum, origin,
+                                        Address(params.m_contract), dev::h256(),
+                                        evm_version});
+
   return EvmClient::GetInstance().CallRunner(
       evm_version, EvmUtils::GetEvmCallJson(params), response);
 }

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -246,9 +246,9 @@ bool AccountStoreSC<MAP>::ViewAccounts(const EvmCallParameters& params,
   // Get latest by setting tree to zeroes dev::h256()
   //
 
-  ScillaIPCServer::GetInstance().setBCInfoProvider({m_curBlockNum, m_curDSBlockNum, origin,
-                                        Address(params.m_contract), dev::h256(),
-                                        evm_version});
+  ScillaIPCServer::GetInstance().setBCInfoProvider(
+      {m_curBlockNum, m_curDSBlockNum, origin, Address(params.m_contract),
+       dev::h256(), evm_version});
 
   return EvmClient::GetInstance().CallRunner(
       evm_version, EvmUtils::GetEvmCallJson(params), response);

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -356,7 +356,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
 
       // prepare IPC with current blockchain info provider.
 
-      m_scillaIPCServer->setBCInfoProvider(
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
           {m_curBlockNum, m_curDSBlockNum, m_originAddr, contractAddress,
            contractAccount->GetStorageRoot(), scilla_version});
 
@@ -530,7 +530,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(const uint64_t& blockNum,
       }
 
       // prepare IPC with current blockchain info provider.
-      m_scillaIPCServer->setBCInfoProvider(
+      ScillaIPCServer::GetInstance().setBCInfoProvider(
           {m_curBlockNum, m_curDSBlockNum, m_originAddr, m_curContractAddr,
            contractAccount->GetStorageRoot(), scilla_version});
 

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -234,6 +234,10 @@ uint64_t AccountStoreSC<MAP>::InvokeEvmInterpreter(
   return gas;
 }
 
+//
+// Modified to set the bcInfo structure to a sensible value.
+//
+
 template <class MAP>
 bool AccountStoreSC<MAP>::ViewAccounts(const EvmCallParameters& params,
                                        evmproj::CallResponse& response) {

--- a/src/libData/AccountData/AccountStoreTemp.cpp
+++ b/src/libData/AccountData/AccountStoreTemp.cpp
@@ -21,7 +21,8 @@
 using namespace std;
 using namespace boost::multiprecision;
 
-AccountStoreTemp::AccountStoreTemp(AccountStore& parent) : m_parent(parent) {}
+AccountStoreTemp::AccountStoreTemp(AccountStore& parent)
+: m_parent(parent) {}
 
 Account* AccountStoreTemp::GetAccount(const Address& address) {
   Account* account =

--- a/src/libServer/ScillaIPCServer.h
+++ b/src/libServer/ScillaIPCServer.h
@@ -20,9 +20,7 @@
 #include <jsonrpccpp/server.h>
 #include <jsonrpccpp/server/abstractserver.h>
 #include <jsonrpccpp/server/connectors/unixdomainsocketserver.h>
-
 #include "depends/common/FixedHash.h"
-
 #include "libData/AccountData/Account.h"
 
 class ScillaBCInfo {
@@ -63,13 +61,13 @@ class ScillaBCInfo {
 class ScillaIPCServer : public jsonrpc::AbstractServer<ScillaIPCServer> {
  public:
   ScillaIPCServer(jsonrpc::AbstractServerConnector& conn);
-
   ~ScillaIPCServer() = default;
   ScillaIPCServer(const ScillaIPCServer&) = delete;
   ScillaIPCServer(ScillaIPCServer&&) = delete;
   ScillaIPCServer& operator=(const ScillaIPCServer&) = delete;
   ScillaIPCServer& operator=(ScillaIPCServer&) = delete;
 
+  static ScillaIPCServer& GetInstance();
   inline virtual void fetchStateValueI(const Json::Value& request,
                                        Json::Value& response);
   inline virtual void fetchExternalStateValueI(const Json::Value& request,
@@ -96,6 +94,7 @@ class ScillaIPCServer : public jsonrpc::AbstractServer<ScillaIPCServer> {
   // bool fetchExternalStateValue(const std::string& addr,
   //                              const std::string& query, std::string& value,
   //                              bool& found, std::string& type);
+
  private:
   ScillaBCInfo m_BCInfo;
 };


### PR DESCRIPTION
## Description
the scilla ipc svr pointer used in account store is shadowed by another scillaIPCSvr member and was due to that in the AccountStoreSc still a nullptr when ViewAccounts was called. The should one be one definition of the pointer that is shared over the users. This change encapsulate the scilla ipc pointer, and shares it over the users.
The scilla ipc pointer is shared with the AccountStoreTemp via a setter, but could be passed on at construction of the AccountStoreTemp instance, this is will be fixed in different PR and the SetScillaIPCServer method can be removed.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
