### PR TITLE
Correct constant for sha3Uncles

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -134,9 +134,9 @@ const Json::Value JSONConversion::convertTxBlocktoEthJson(
   retJson["number"] = (boost::format("0x%x") % txheader.GetBlockNum()).str();
   retJson["hash"] = std::string{"0x"} + txblock.GetBlockHash().hex();
   retJson["parentHash"] = std::string{"0x"} + txheader.GetPrevHash().hex();
-  // sha3Uncles is calculated as keccak("")
+  // sha3Uncles is calculated as Keccak256(RLP([]))
   retJson["sha3Uncles"] =
-      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+      "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
   // Todo: research and possibly implement logs bloom filter
   retJson["logsBloom"] =
       "0x0000000000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
## Description

I was reading https://blog.ethereum.org/2021/11/29/how-the-merge-impacts-app-layer, and realized that after the Merge, ethereum no longer has uncles, and also that hashing empty string is wrong, and it should be hasing of RLP([]).




## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
