### PR TITLE
[master] Temporarily disable JS Integration tests until fixed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,9 +74,11 @@ timestamps {
                 stage('Integration test') {
                     sh "scripts/integration_test.sh --setup-env"
                 }
+                /*
                 stage('Integration test JS') {
-                    sh "scripts/integration_test_js.sh --setup-env"
+                   sh "scripts/integration_test_js.sh --setup-env"
                 }
+                */
                 stage('Report coverage') {
                     // Code coverage is currently only implemented for GCC builds, so OSX is currently excluded from reporting
                     sh "./scripts/ci_report_coverage.sh"


### PR DESCRIPTION
## Description
Need to make sure evm-ds is either found or built on Jenkins.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
