### PR TITLE
fix bug where contract map addresses did not work correctly

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -1020,6 +1020,9 @@ Json::Value EthRpcMethods::GetEthStorageAt(std::string const& address,
 
     zeroes.replace(zeroIter, zeroes.end(), positionIter, position.end());
 
+    // Must be uppercase
+    std::transform(zeroes.begin(), zeroes.end(), zeroes.begin(), ::toupper);
+
     auto res = root["_evm_storage"][zeroes];
     zbytes resAsStringBytes;
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getStorageAt.js
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getStorageAt.js
@@ -23,8 +23,7 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  // FIXME: In https://zilliqa-jira.atlassian.net/browse/ZIL-4953
-  xit("should return proper storage value when a value from a map is requested", async function () {
+  it("should return proper storage value when a value from a map is requested", async function () {
     const MAPPING_SLOT = "0000000000000000000000000000000000000000000000000000000000000001";
 
     // KEY that we want to read in the mapping


### PR DESCRIPTION
The key in the key value pair of storage to value is uppercase. This means if you queried a location in lowercase it would not work. Force uppercase on queries to the storage and enable the requisite test.

It looks like the map lookup code `keccack(LeftPad32(key, 0), LeftPad32(map position, 0))` is working correctly as the data is at a hashed address.