### PR TITLE
[master] ZIL-4987: Mention `SCILLA_LIB` in isolated server documentation

### DIFF
--- a/ISOLATED_SERVER_setup.md
+++ b/ISOLATED_SERVER_setup.md
@@ -37,6 +37,8 @@ Install the evm from the repo: https://github.com/Zilliqa/evm-ds
 <LOOKUP_NODE_MODE>true</LOOKUP_NODE_MODE>
 <ENABLE_SC>true</ENABLE_SC>
 <SCILLA_ROOT>scilla</SCILLA_ROOT>
+ # Make sure this, when appended to `SCILLA_ROOT`, points to a directory containing (e.g.) `BoolUtils.scillib`.
+<SCILLA_LIB>lib/scilla/stdlib</SCILLA_LIB>
 <ENABLE_SCILLA_MULTI_VERSION>false</ENABLE_SCILLA_MULTI_VERSION>
 
 ## Steps to Enable EVM for a run this temporarily replaces the Scilla Interpreter


### PR DESCRIPTION
I just spent a while trying to work out why Scilla contracts couldn't be created, until I eventually tracked it down to an error from the checker which said `BoolUtils` not found. That led me to seeing that my `SCILLA_LIB` constant was pointing at something non-existent.
