### PR TITLE
[master] Not allow lookup receipt non evm

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -1404,6 +1404,10 @@ Json::Value EthRpcMethods::GetEthTransactionReceipt(
       LOG_GENERAL(WARNING, "Unable to find transaction for given hash");
       return Json::nullValue;
     }
+    if (!transactionBodyPtr->GetTransaction().IsEth()) {
+      LOG_GENERAL(WARNING, "No tx receipts for zil txs");
+      return Json::nullValue;
+    }
 
     const TxBlock EMPTY_BLOCK;
     auto txBlock = GetBlockFromTransaction(*transactionBodyPtr);


### PR DESCRIPTION
Do not allow non-eth TXs to have get TX receipt called on them as this will fail when it tries to reparse the TX into a RLP. Found by @CSideSteve while running scilla tests on the node