### PR TITLE
Add --log-jsonrpc option for ethers.js [skip ci]

### DIFF
--- a/tests/EvmAcceptanceTests/README.md
+++ b/tests/EvmAcceptanceTests/README.md
@@ -95,7 +95,8 @@ npx hardhat test --network ganache
 
 # How to debug
 
-- Use `hre.logDebug` :smile:
+- Use `--log-jsonrpc` option to enable Json-RPC requests/responses logging. It only works with ethers.js currently.
+- Use `hre.logDebug`
 - Use vscode debugger
 - Use `--verbose` option to enable hardhat verbose logging.
 

--- a/tests/EvmAcceptanceTests/hardhat.config.js
+++ b/tests/EvmAcceptanceTests/hardhat.config.js
@@ -60,8 +60,20 @@ module.exports = {
 
 task("test")
   .addFlag("debug", "Print debugging logs")
+  .addFlag("logJsonrpc", "Log JSON RPC ")
   .setAction(async (taskArgs, hre, runSuper) => {
     hre.debugMode = taskArgs.debug ?? false;
     hre.logDebug = hre.debugMode ? console.log.bind(console) : function () {};
+    if (taskArgs.logJsonrpc) {
+      hre.ethers.provider.on("debug", (info) => {
+        if (info.request) {
+          console.log("Request:", info.request);
+        }
+        if (info.request) {
+          console.log("Response:", info.response);
+        }
+        console.log("=========================================================");
+      });
+    }
     return runSuper();
   });


### PR DESCRIPTION
## Description
This option allows you to log json-rpc requests/responses.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
