### PR TITLE
[master] ZIL-5000: patch websocketpp 0.8.2 to compile on gcc in C++20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ $ cd /path/to/vcpkg && git checkout 2022.09.27 && ./bootstrap-vcpkg.sh
 $ cd /path/to/zilliqa
 $ export VCPKG_ROOT=/path/to/vcpkg
 ```
-
+As part of building our source code, we patch websocketpp 0.8.2 to compile on C++20; please
+see the license: https://github.com/zaphoyd/websocketpp/blob/master/COPYING.
 
 Build Zilliqa from the source:
 

--- a/tests/Server/CMakeLists.txt
+++ b/tests/Server/CMakeLists.txt
@@ -3,7 +3,7 @@ configure_file(${CMAKE_SOURCE_DIR}/constants.xml constants.xml COPYONLY)
 
 add_executable(Test_ScillaIPCServer Test_ScillaIPCServer.cpp)
 target_include_directories(Test_ScillaIPCServer PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(Test_ScillaIPCServer PUBLIC  AccountData Message Server jsonrpc::client)
+target_link_libraries(Test_ScillaIPCServer PUBLIC  AccountData Message Node jsonrpc::client)
 add_test(NAME Test_ScillaIPCServer COMMAND Test_ScillaIPCServer)
 
 # To be tested with a live network

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,7 +3,7 @@
     {
       "kind": "filesystem",
       "path": "vcpkg-registry",
-      "packages": [ "python3", "g3log", "g3sinks", "schnorr", "libmicrohttpd" ]
+      "packages": [ "python3", "g3log", "g3sinks", "schnorr", "libmicrohttpd", "websocketpp" ]
     }
   ]
 }

--- a/vcpkg-registry/ports/websocketpp/cxx20.patch
+++ b/vcpkg-registry/ports/websocketpp/cxx20.patch
@@ -1,0 +1,99 @@
+diff --git "a/websocketpp/endpoint.hpp" "b/websocketpp/endpoint.hpp"
+index c124b1d..9ce8a62 100644
+--- "a/websocketpp/endpoint.hpp"
++++ "b/websocketpp/endpoint.hpp"
+@@ -109,7 +109,7 @@ public:
+ 
+ 
+     /// Destructor
+-    ~endpoint<connection,config>() {}
++    ~endpoint() {}
+ 
+     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+         // no copy constructor because endpoints are not copyable
+diff --git "a/websocketpp/logger/basic.hpp" "b/websocketpp/logger/basic.hpp"
+index 8451413..4c9d836 100644
+--- "a/websocketpp/logger/basic.hpp"
++++ "b/websocketpp/logger/basic.hpp"
+@@ -58,33 +58,33 @@ namespace log {
+ template <typename concurrency, typename names>
+ class basic {
+ public:
+-    basic<concurrency,names>(channel_type_hint::value h =
++    basic(channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(std::ostream * out)
++    basic(std::ostream * out)
+       : m_static_channels(0xffffffff)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+ 
+-    basic<concurrency,names>(level c, channel_type_hint::value h =
++    basic(level c, channel_type_hint::value h =
+         channel_type_hint::access)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
+ 
+-    basic<concurrency,names>(level c, std::ostream * out)
++    basic(level c, std::ostream * out)
+       : m_static_channels(c)
+       , m_dynamic_channels(0)
+       , m_out(out) {}
+ 
+     /// Destructor
+-    ~basic<concurrency,names>() {}
++    ~basic() {}
+ 
+     /// Copy constructor
+-    basic<concurrency,names>(basic<concurrency,names> const & other)
++    basic(basic<concurrency,names> const & other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+@@ -97,7 +97,7 @@ public:
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    basic<concurrency,names>(basic<concurrency,names> && other)
++    basic(basic<concurrency,names> && other)
+      : m_static_channels(other.m_static_channels)
+      , m_dynamic_channels(other.m_dynamic_channels)
+      , m_out(other.m_out)
+diff --git a/websocketpp/roles/server_endpoint.hpp b/websocketpp/roles/server_endpoint.hpp
+index 9cc652f..35af834 100644
+--- a/websocketpp/roles/server_endpoint.hpp
++++ b/websocketpp/roles/server_endpoint.hpp
+@@ -72,23 +72,23 @@ public:
+     }
+ 
+     /// Destructor
+-    ~server<config>() {}
++    ~server() {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no copy constructor because endpoints are not copyable
+-    server<config>(server<config> &) = delete;
++    server(server<config> &) = delete;
+ 
+     // no copy assignment operator because endpoints are not copyable
+-    server<config> & operator=(server<config> const &) = delete;
++    server & operator=(server const &) = delete;
+ #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+ 
+ #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
+     /// Move constructor
+-    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
++    server(server && o) : endpoint<connection<config>,config>(std::move(o)) {}
+ 
+ #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+     // no move assignment operator because of const member variables
+-    server<config> & operator=(server<config> &&) = delete;
++    server & operator=(server &&) = delete;
+ #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
+ 
+ #endif // _WEBSOCKETPP_MOVE_SEMANTICS_

--- a/vcpkg-registry/ports/websocketpp/portfile.cmake
+++ b/vcpkg-registry/ports/websocketpp/portfile.cmake
@@ -1,0 +1,26 @@
+#header-only library
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zaphoyd/websocketpp
+    REF 56123c87598f8b1dd471be83ca841ceae07f95ba # 0.8.2
+    SHA512 f185a66e5a7c783254352a6ef87e2e559f681032b7368765d08393ed12bcae76825abed7dcaea73de09df644320409dad46279701f5f469520542a2c9b6a6163
+    HEAD_REF master
+    PATCHES
+      cxx20.patch
+)
+
+file(MAKE_DIRECTORY ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+# Copy the header files
+file(COPY "${SOURCE_PATH}/websocketpp" DESTINATION "${CURRENT_PACKAGES_DIR}/include" FILES_MATCHING PATTERN "*.hpp")
+
+set(PACKAGE_INSTALL_INCLUDE_DIR "\${CMAKE_CURRENT_LIST_DIR}/../../include")
+set(WEBSOCKETPP_VERSION 0.8.2)
+set(PACKAGE_INIT "
+macro(set_and_check)
+  set(\${ARGV})
+endmacro()
+")
+configure_file(${SOURCE_PATH}/websocketpp-config.cmake.in "${CURRENT_PACKAGES_DIR}/share/${PORT}/websocketpp-config.cmake" @ONLY)
+configure_file(${SOURCE_PATH}/COPYING ${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright COPYONLY)

--- a/vcpkg-registry/ports/websocketpp/vcpkg.json
+++ b/vcpkg-registry/ports/websocketpp/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "name": "websocketpp",
+  "version": "0.8.2",
+  "port-version": 3,
+  "description": "Library that implements RFC6455 The WebSocket Protocol",
+  "homepage": "https://github.com/zaphoyd/websocketpp",
+  "documentation": "http://docs.websocketpp.org/",
+  "default-features": [
+    "recommended"
+  ],
+  "features": {
+    "recommended": {
+      "description": "Use recommended dependencies",
+      "dependencies": [
+        "boost-asio",
+        "openssl",
+        "zlib"
+      ]
+    }
+  }
+}

--- a/vcpkg-registry/versions/baseline.json
+++ b/vcpkg-registry/versions/baseline.json
@@ -4,6 +4,7 @@
     "g3log": { "baseline": "1.3.4", "port-version": 4 },
     "g3sinks": { "baseline": "2.0.1", "port-version": 0 },
     "schnorr": { "baseline": "8.2.0", "port-version": 0 },
-    "libmicrohttpd": { "baseline": "0.9.63", "port-version": 8 }
+    "libmicrohttpd": { "baseline": "0.9.63", "port-version": 8 },
+    "websocketpp": { "baseline": "0.8.2", "port-version": 3 }
   }
 }

--- a/vcpkg-registry/versions/w-/websocketpp.json
+++ b/vcpkg-registry/versions/w-/websocketpp.json
@@ -1,0 +1,11 @@
+{
+  "versions": [
+    {
+      "path": "$/ports/websocketpp",
+      "version": "0.8.2",
+      "port-version": 3
+    }
+  ]
+}
+
+

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -62,6 +62,10 @@
     {
       "name": "g3sinks",
       "version": "2.0.1"
+    },
+    {
+      "name": "websocketpp",
+      "version": "0.8.2#3"
     }
   ]
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

* Add a vcpkg port to patch websocketpp for higher gcc versions with C++20.
* Add a link to the license in README.md (are we required to include the full copy?)
* This might be a temporary solution as there's already a PR in the websocketpp repo for this but for master (and not 0.8.2).

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
