### PR TITLE
[master] disable warning so mac build passes

### DIFF
--- a/src/depends/jsonrpccpp/common/procedure.cpp
+++ b/src/depends/jsonrpccpp/common/procedure.cpp
@@ -13,8 +13,10 @@
 #include <cstdarg>
 #include <vector>
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvarargs"
+#endif
 using namespace std;
 using namespace jsonrpc;
 
@@ -160,4 +162,6 @@ bool Procedure::ValidateSingleParameter(jsontype_t expectedType,
   return ok;
 }
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif

--- a/src/depends/jsonrpccpp/common/procedure.cpp
+++ b/src/depends/jsonrpccpp/common/procedure.cpp
@@ -13,6 +13,8 @@
 #include <cstdarg>
 #include <vector>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvarargs"
 using namespace std;
 using namespace jsonrpc;
 
@@ -157,3 +159,5 @@ bool Procedure::ValidateSingleParameter(jsontype_t expectedType,
   }
   return ok;
 }
+
+#pragma clang diagnostic pop

--- a/src/libNetwork/Executable.h
+++ b/src/libNetwork/Executable.h
@@ -20,7 +20,7 @@
 
 #include "common/BaseType.h"
 
-class Peer;
+struct Peer;
 
 /// Specifies the interface required for classes that process messages.
 class Executable {

--- a/vcpkg-registry/ports/opentelemetry-cpp/mac-fix.patch
+++ b/vcpkg-registry/ports/opentelemetry-cpp/mac-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/exporters/ostream/CMakeLists.txt b/exporters/ostream/CMakeLists.txt
+index 1d1c20a6..d9e2412d 100644
+--- a/exporters/ostream/CMakeLists.txt
++++ b/exporters/ostream/CMakeLists.txt
+@@ -41,7 +41,7 @@ target_include_directories(
+   opentelemetry_exporter_ostream_metrics
+   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>")
+ target_link_libraries(opentelemetry_exporter_ostream_metrics
+-                      PUBLIC opentelemetry_metrics)
++                      PUBLIC opentelemetry_metrics opentelemetry_resources)
+ install(
+   TARGETS opentelemetry_exporter_ostream_metrics
+   EXPORT "${PROJECT_NAME}-target"
+

--- a/vcpkg-registry/ports/opentelemetry-cpp/portfile.cmake
+++ b/vcpkg-registry/ports/opentelemetry-cpp/portfile.cmake
@@ -10,6 +10,7 @@ vcpkg_from_github(
     HEAD_REF main
     PATCHES
         support_absl_cxx17.patch
+        mac-fix.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS

--- a/vcpkg-registry/ports/opentelemetry-cpp/vcpkg.json
+++ b/vcpkg-registry/ports/opentelemetry-cpp/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
   "name": "opentelemetry-cpp",
   "version-semver": "1.8.0",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "OpenTelemetry is a collection of tools, APIs, and SDKs.",
     "You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior."

--- a/vcpkg-registry/versions/baseline.json
+++ b/vcpkg-registry/versions/baseline.json
@@ -7,6 +7,6 @@
     "cryptoutils": { "baseline": "8.3.0", "port-version": 1 },
     "libmicrohttpd": { "baseline": "0.9.63", "port-version": 8 },
     "websocketpp": { "baseline": "0.8.2", "port-version": 3 },
-    "opentelemetry-cpp": { "baseline": "1.8.0", "port-version": 1 }
+    "opentelemetry-cpp": { "baseline": "1.8.0", "port-version": 2 }
   }
 }

--- a/vcpkg-registry/versions/o-/opentelemetry-cpp.json
+++ b/vcpkg-registry/versions/o-/opentelemetry-cpp.json
@@ -3,7 +3,7 @@
     {
       "path": "$/ports/opentelemetry-cpp",
       "version": "1.8.0",
-      "port-version": 1
+      "port-version": 2
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -72,7 +72,7 @@
     },
     {
       "name": "opentelemetry-cpp",
-      "version": "1.8.0#1"
+      "version": "1.8.0#2"
     }
   ]
 }


### PR DESCRIPTION
We see this warning:

```
/Users/nhutton/repos/Zilliqa/src/depends/jsonrpccpp/common/procedure.cpp:27:24: error: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Werror,-Wvarargs]
  va_start(parameters, returntype);
                       ^
/Users/nhutton/repos/Zilliqa/src/depends/jsonrpccpp/common/procedure.cpp:25:33: note: parameter of type 'jsonrpc::jsontype_t' is declared here
                     jsontype_t returntype, ...) {
```                     