### PR TITLE
[master] change evm-ds logging to fit in one line

### DIFF
--- a/evm-ds/src/convert.rs
+++ b/evm-ds/src/convert.rs
@@ -1,10 +1,10 @@
 use crate::protos::Evm as EvmProto;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
+use evm::backend::Log;
+use evm::Opcode;
 use primitive_types::*;
 use std::ops::Shr;
-use evm::backend::{Log};
-use evm::Opcode;
 
 impl From<H160> for EvmProto::Address {
     fn from(address: H160) -> Self {

--- a/evm-ds/src/main.rs
+++ b/evm-ds/src/main.rs
@@ -17,7 +17,11 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
 use clap::Parser;
-use evm::{backend::Apply, executor::stack::{MemoryStackState, StackSubstateMetadata}, tracing};
+use evm::{
+    backend::Apply,
+    executor::stack::{MemoryStackState, StackSubstateMetadata},
+    tracing,
+};
 use futures::FutureExt;
 
 use log::{debug, error, info};
@@ -104,6 +108,7 @@ impl EvmServer {
                     tracing,
                     gas_scaling_factor,
                     estimate,
+                    args.get_context().to_string(),
                 )
                 .boxed()
             }
@@ -123,14 +128,15 @@ async fn run_evm_impl(
     tracing: bool,
     gas_scaling_factor: u64,
     estimate: bool,
+    evm_context: String,
 ) -> Result<String> {
     // We must spawn a separate blocking task (on a blocking thread), because by default a JSONRPC
     // method runs as a non-blocking thread under a tokio runtime, and creating a new runtime
     // cannot be done. And we'll need a new runtime that we can safely drop on a handled
     // panic. (Using the parent runtime and dropping on stack unwind will mess up the parent runtime).
     tokio::task::spawn_blocking(move || {
-        info!(
-            "Executing EVM runtime: origin: {:?} address: {:?} gas: {:?} value: {:?} code: {:?} data: {:?}, extras: {:?}, estimate: {:?}",
+        debug!(
+            "Running EVM: origin: {:?} address: {:?} gas: {:?} value: {:?} code: {:?} data: {:?}, extras: {:?}, estimate: {:?}",
             backend.origin, address, gas_limit, apparent_value, hex::encode(&code), hex::encode(&data),
             backend.extras, estimate);
         let code = Rc::new(code);
@@ -142,7 +148,7 @@ async fn run_evm_impl(
             caller: backend.origin,
             apparent_value,
         };
-        let mut runtime = evm::Runtime::new(code, data, context, &config);
+        let mut runtime = evm::Runtime::new(code.clone(), data.clone(), context, &config);
         // Scale the gas limit.
         let gas_limit = gas_limit * gas_scaling_factor;
         let metadata = StackSubstateMetadata::new(gas_limit, &config);
@@ -222,7 +228,10 @@ async fn run_evm_impl(
                 result.set_trace(listener.traces.into_iter().map(Into::into).collect());
                 result.set_logs(logs.into_iter().map(Into::into).collect());
                 result.set_remaining_gas(remaining_gas);
-                debug!("Result: {:?}", result);
+                info!(
+                    "EVM execution summary: context: {:?}, origin: {:?} address: {:?} gas: {:?} value: {:?} code: {:?} data: {:?}, extras: {:?}, estimate: {:?}, result: {:?}", evm_context,
+                    backend.origin, address, gas_limit, apparent_value, hex::encode(code.as_ref()), hex::encode(data.as_ref()),
+                    backend.extras, estimate, result);
                 result
             },
             Err(panic) => {
@@ -358,4 +367,3 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-

--- a/evm-ds/src/precompiles/blake2.rs
+++ b/evm-ds/src/precompiles/blake2.rs
@@ -177,10 +177,13 @@ pub(crate) fn blake2(
     let finished = input[212] != 0;
 
     let output = f(h, m, t, finished, rounds);
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output,
-    }, cost))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output,
+        },
+        cost,
+    ))
 }
 
 pub(super) const F_ROUND: u64 = 1;

--- a/evm-ds/src/precompiles/ec.rs
+++ b/evm-ds/src/precompiles/ec.rs
@@ -49,10 +49,13 @@ pub(crate) fn ec_add(
     sum.x().to_big_endian(&mut output[0..32]).unwrap();
     sum.y().to_big_endian(&mut output[32..64]).unwrap();
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output: output.to_vec(),
-    }, ADD_COST))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output: output.to_vec(),
+        },
+        ADD_COST,
+    ))
 }
 
 pub(crate) fn ec_mul(
@@ -89,10 +92,13 @@ pub(crate) fn ec_mul(
     result.x().to_big_endian(&mut output[0..32]).unwrap();
     result.y().to_big_endian(&mut output[32..64]).unwrap();
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output: output.to_vec(),
-    }, MUL_COST))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output: output.to_vec(),
+        },
+        MUL_COST,
+    ))
 }
 
 pub(crate) fn ec_pairing(
@@ -135,10 +141,13 @@ pub(crate) fn ec_pairing(
     }
     // Otherwise, return 0.
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output: output.to_vec(),
-    }, cost))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output: output.to_vec(),
+        },
+        cost,
+    ))
 }
 
 fn pair_cost(num_points: usize) -> u64 {

--- a/evm-ds/src/precompiles/ecrecover.rs
+++ b/evm-ds/src/precompiles/ecrecover.rs
@@ -39,10 +39,13 @@ pub(crate) fn ecrecover(
     let v_bit = match v[31] {
         27 | 28 if v[..31] == [0; 31] => v[31] - 27,
         _ => {
-            return Ok((PrecompileOutput {
-                exit_status: ExitSucceed::Returned,
-                output: vec![],
-            }, cost))
+            return Ok((
+                PrecompileOutput {
+                    exit_status: ExitSucceed::Returned,
+                    output: vec![],
+                },
+                cost,
+            ))
         }
     };
     signature[64] = v_bit; // v
@@ -57,10 +60,13 @@ pub(crate) fn ecrecover(
         Err(_) => Vec::new(),
     };
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output,
-    }, cost))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output,
+        },
+        cost,
+    ))
 }
 
 fn ecrecover_impl(hash: H256, signature: &[u8]) -> Result<Address, ExitError> {

--- a/evm-ds/src/precompiles/identity.rs
+++ b/evm-ds/src/precompiles/identity.rs
@@ -26,10 +26,13 @@ pub(crate) fn identity(
         }
     }
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output: input.to_vec(),
-    }, gas_needed))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output: input.to_vec(),
+        },
+        gas_needed,
+    ))
 }
 
 fn required_gas(input: &[u8]) -> Result<u64, ExitError> {

--- a/evm-ds/src/precompiles/modexp.rs
+++ b/evm-ds/src/precompiles/modexp.rs
@@ -25,10 +25,13 @@ pub(crate) fn modexp(
     }
 
     match run_inner(input) {
-        Ok(out) => Ok((PrecompileOutput {
-            exit_status: ExitSucceed::Returned,
-            output: out,
-        }, cost)),
+        Ok(out) => Ok((
+            PrecompileOutput {
+                exit_status: ExitSucceed::Returned,
+                output: out,
+            },
+            cost,
+        )),
         Err(err) => Err(PrecompileFailure::Error { exit_status: err }),
     }
 }

--- a/evm-ds/src/precompiles/ripemd160.rs
+++ b/evm-ds/src/precompiles/ripemd160.rs
@@ -30,10 +30,13 @@ pub(crate) fn ripemd160(
     let mut output = vec![0u8; 32];
     output[12..].copy_from_slice(&hash);
 
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output,
-    }, cost))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output,
+        },
+        cost,
+    ))
 }
 
 fn internal_impl(input: &[u8]) -> [u8; 20] {

--- a/evm-ds/src/precompiles/sha2_256.rs
+++ b/evm-ds/src/precompiles/sha2_256.rs
@@ -28,10 +28,13 @@ pub(crate) fn sha2_256(
 
     use sha2::Digest;
     let output = sha2::Sha256::digest(input).to_vec();
-    Ok((PrecompileOutput {
-        exit_status: ExitSucceed::Returned,
-        output,
-    }, cost))
+    Ok((
+        PrecompileOutput {
+            exit_status: ExitSucceed::Returned,
+            output,
+        },
+        cost,
+    ))
 }
 
 fn required_gas(input: &[u8]) -> Result<u64, ExitError> {

--- a/evm-ds/src/scillabackend.rs
+++ b/evm-ds/src/scillabackend.rs
@@ -10,7 +10,7 @@ use jsonrpc_core::{Error, Result, Value};
 use jsonrpc_core_client::RawClient;
 use primitive_types::{H160, H256, U256};
 
-use log::{debug, info};
+use log::debug;
 
 use protobuf::Message;
 
@@ -95,7 +95,7 @@ impl ScillaBackend {
     }
 
     fn query_jsonrpc(&self, query_name: &str, query_args: Option<&str>) -> Value {
-        info!("query_jsonrpc: {}, {:?}", query_name, query_args);
+        debug!("query_jsonrpc: {}, {:?}", query_name, query_args);
         // Make a JSON Query for fetchBlockchaininfo
         let mut args = serde_json::Map::new();
         args.insert("query_name".into(), query_name.into());
@@ -122,7 +122,7 @@ impl ScillaBackend {
         key: Option<H256>,
         use_default: bool,
     ) -> Result<Option<ScillaMessage::ProtoScillaVal>> {
-        info!(
+        debug!(
             "query_state_value: {} {} {:?} {}",
             address, query_name, key, use_default
         );

--- a/src/libData/AccountData/AccountStoreSCEvm.cpp
+++ b/src/libData/AccountData/AccountStoreSCEvm.cpp
@@ -218,6 +218,12 @@ bool AccountStoreSC<MAP>::ViewAccounts(const evm::EvmArgs& args,
                                              result);
 }
 
+static std::string txnIdToString(const TxnHash& txn) {
+  std::ostringstream str;
+  str << "0x" << txn;
+  return str.str();
+}
+
 template <class MAP>
 bool AccountStoreSC<MAP>::UpdateAccountsEvm(
     const uint64_t& blockNum, const unsigned int& numShards, const bool& isDS,
@@ -357,6 +363,7 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(
       args.set_gas_limit(transaction.GetGasLimitEth());
       *args.mutable_apparent_value() =
           UIntToProto(transaction.GetAmountWei().convert_to<uint256_t>());
+      *args.mutable_context() = txnIdToString(transaction.GetTranID());
       if (!GetEvmEvalExtras(blockNum, txnExtras, *args.mutable_extras())) {
         LOG_GENERAL(WARNING, "Failed to get EVM call extras");
         error_code = TxnStatus::ERROR;
@@ -535,6 +542,8 @@ bool AccountStoreSC<MAP>::UpdateAccountsEvm(
       args.set_gas_limit(transaction.GetGasLimitEth());
       *args.mutable_apparent_value() =
           UIntToProto(transaction.GetAmountWei().convert_to<uint256_t>());
+      *args.mutable_context() = txnIdToString(transaction.GetTranID());
+
       if (!GetEvmEvalExtras(blockNum, txnExtras, *args.mutable_extras())) {
         LOG_GENERAL(WARNING, "Failed to get EVM call extras");
         error_code = TxnStatus::ERROR;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -704,6 +704,7 @@ std::string EthRpcMethods::GetEthEstimateGas(const Json::Value& json) {
                            "Failed to get EVM call extras");
   }
   args.set_estimate(true);
+  *args.mutable_context() = "eth_estimateGas";
 
   evm::EvmResult result;
   if (AccountStore::GetInstance().ViewAccounts(args, result) &&
@@ -809,6 +810,7 @@ string EthRpcMethods::GetEthCallImpl(const Json::Value& _json,
       throw JsonRpcException(ServerBase::RPC_INTERNAL_ERROR,
                              "Failed to get EVM call extras");
     }
+    *args.mutable_context() = "eth_call";
 
     if (AccountStore::GetInstance().ViewAccounts(args, result) &&
         result.exit_reason().exit_reason_case() ==

--- a/src/libUtils/Evm.proto
+++ b/src/libUtils/Evm.proto
@@ -68,6 +68,7 @@ message EvmArgs {
   uint64 gas_limit = 6;
   EvmEvalExtras extras = 7;
   bool estimate = 8;
+  string context = 9;
 }
 
 message EvmLog {


### PR DESCRIPTION
Change evm-ds logging to fit in one line, so we don't have to look for context
Additionally, provide context, whether this is TXN ID, or estimate or eth_call.


## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
