### PR TITLE
[master] link to hashing libraries as it fails on mac

### DIFF
--- a/src/libNetwork/CMakeLists.txt
+++ b/src/libNetwork/CMakeLists.txt
@@ -16,4 +16,5 @@ target_link_libraries (Network PUBLIC
         libevent::core
         libevent::pthreads
         RumorSpreading
+        OpenSSL::Crypto
         Utils)


### PR DESCRIPTION
For me, the networking needs to use the hashing functions:

```Undefined symbols for architecture arm64:
  "_SHA256_Final", referenced from:
      P2PComm::ProcessBroadCastMsg(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&, Peer const&) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::vector<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::deque<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      SHA2<256u>::FromBytes(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(RumorManager.cpp.o)
  "_SHA256_Init", referenced from:
      P2PComm::ProcessBroadCastMsg(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&, Peer const&) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::vector<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::deque<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      SHA2<256u>::FromBytes(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(RumorManager.cpp.o)
  "_SHA256_Update", referenced from:
      SHA2<256u>::Update(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&, unsigned int, unsigned int) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::vector<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      P2PComm::SendBroadcastMessage(std::__1::deque<Peer, std::__1::allocator<Peer> > const&, std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(P2PComm.cpp.o)
      SHA2<256u>::FromBytes(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> > const&) in libNetwork.a(RumorManager.cpp.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```