### PR TITLE
[master] Fix Dockerfile due to ccache symlinks hanging on Ubuntu 22.04.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -200,6 +200,17 @@ COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /zilliqa/evm-ds/target/release/evm-ds /usr/local/bin/
 COPY --from=builder /zilliqa/evm-ds/log4rs.yml /usr/local/etc/
 
+# The above COPY doesn't preserve symlinks which causes gcc/g++/cc/c++
+# to hang as stand-alone binaries on Ubuntu 22.04.
+RUN rm -f /usr/local/bin/gcc \
+      /usr/local/bin/g++ \
+      /usr/local/bin/cc \
+      /usr/local/bin/c++ \
+    && ln -s "$(which ccache)" /usr/local/bin/gcc \
+    && ln -s "$(which ccache)" /usr/local/bin/g++ \
+    && ln -s "$(which ccache)" /usr/local/bin/cc \
+    && ln -s "$(which ccache)" /usr/local/bin/c++
+
 ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
 
 ARG PYTHON3_ENV_PATH=/usr/local


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Reinstates symlinks to ccache after COPY follows them to the binary.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
