### PR TITLE
[master] AccountStore refactoring: Step 1

### DIFF
--- a/src/libData/AccountStore/AccountStore.h
+++ b/src/libData/AccountStore/AccountStore.h
@@ -223,6 +223,9 @@ class AccountStore  : public AccountStoreTrie {
   std::condition_variable_any& GetPrimaryWriteAccessCond() {
     return m_writeCond;
   }
+  bool EvmProcessMessageTemp(EvmProcessContext& params, evm::EvmResult& result) {
+    return m_accountStoreTemp.EvmProcessMessage(params, result);
+  }
 };
 
 #endif  // ZILLIQA_SRC_LIBDATA_ACCOUNTSTORE_ACCOUNTSTORE_H_

--- a/src/libData/AccountStore/AccountStoreTrie.cpp
+++ b/src/libData/AccountStore/AccountStoreTrie.cpp
@@ -24,7 +24,7 @@ AccountStoreTrie::AccountStoreTrie() : m_db("state"), m_state(&m_db) {}
 
 
 void AccountStoreTrie::Init() {
-  AccountStoreSC::Init();
+  AccountStoreBase::Init();
   InitTrie();
 }
 

--- a/src/libData/AccountStore/AccountStoreTrie.h
+++ b/src/libData/AccountStore/AccountStoreTrie.h
@@ -18,11 +18,11 @@
 #ifndef ZILLIQA_SRC_LIBDATA_ACCOUNTSTORE_ACCOUNTSTORETRIE_H_
 #define ZILLIQA_SRC_LIBDATA_ACCOUNTSTORE_ACCOUNTSTORETRIE_H_
 
-#include "AccountStoreSC.h"
+#include "AccountStoreBase.h"
 #include "depends/libTrie/TrieDB.h"
 #include "libData/DataStructures/TraceableDB.h"
 
-class AccountStoreTrie : public AccountStoreSC {
+class AccountStoreTrie : public AccountStoreBase {
  protected:
   TraceableDB m_db;
   dev::GenericTrieDB<TraceableDB> m_state;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -719,8 +719,8 @@ std::string EthRpcMethods::GetEthEstimateGas(const Json::Value& json) {
 
   evm::EvmResult result;
 
-  if (AccountStore::GetInstance().EvmProcessMessage(evmMessageContext,
-                                                    result) &&
+  if (AccountStore::GetInstance().EvmProcessMessageTemp(evmMessageContext,
+                                                        result) &&
       result.exit_reason().exit_reason_case() ==
           evm::ExitReason::ExitReasonCase::kSucceed) {
     const auto gasRemained = result.remaining_gas();
@@ -826,8 +826,8 @@ string EthRpcMethods::GetEthCallImpl(const Json::Value& _json,
                                         value, blockNum, txnExtras, "eth_call",
                                         false);
 
-    if (AccountStore::GetInstance().EvmProcessMessage(evmMessageContext,
-                                                      result) &&
+    if (AccountStore::GetInstance().EvmProcessMessageTemp(evmMessageContext,
+                                                          result) &&
         result.exit_reason().exit_reason_case() ==
             evm::ExitReason::ExitReasonCase::kSucceed) {
       success = true;


### PR DESCRIPTION
1. Remove the inheritance of `AccountStore` on `AccountStoreSC` - it doesn't have to, as all smart contract interactions are done via the `m_accountStoreTemp`.

Next steps planned are the following:

* Merge `AccountStore` with `AccountStoreTrie`, as there's no other accounts trie in the system - it is a real singleton.
* When the current AccountStore-like object is needed, get AccountStoreTrie instance, and wrap it into a caching AccountStoreTemp on demand.
* Remove AccountStoreSC from the hierarchy as it doesn't have anything related to account store itself, only transaction processing.