### PR TITLE
[master] Simplify local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,11 @@ isolated-server.logs
 
 *.pyc
 .husky/
+
+# Localdev's working directory
+_localdev/
+
+# Emacs backups
+*~
+\#*
+.\#*

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,16 @@
+# Annoyingly our build systems needs to invoke `git submodule update`, which means we need `.git` in the Docker build
+# context. Not unreasonably, Tilt doesn't let this happen: https://docs.tilt.dev/file_changes.html#git. Therefore, we
+# need to use a `custom_build` instead as advised.
+# What we want:
+#docker_build("zilliqa/zilliqa", ".", dockerfile="docker/Dockerfile")
+#custom_build("zilliqa/zilliqa", "DOCKER_BUILDKIT=1 docker build . -t $EXPECTED_REF -f docker/Dockerfile.all", ["docker/Dockerfile"])
+custom_build("zilliqa/zilliqa", "scripts/localdev.py build $EXPECTED_REF", [ "scripts/build_dev.py", "docker/Dockerfile.dev" ])
+
+# TODO: Deploy nginx ingress with Tilt, so the user doesn't need to do it manually.
+#k8s_yaml("infra/k8s/nginx-ingress.yaml")
+
+k8s_yaml("infra/k8s/localstack.yaml")
+k8s_resource("localstack", port_forwards="4566:4566")
+
+k8s_yaml(kustomize("infra/k8s/base"))
+k8s_resource("devnet-explorer", port_forwards="8110:80")

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,228 @@
+# Copyright (C) 2019 Zilliqa
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+ARG SCILLA_VERSION=a254436b
+
+# Common dependencies of the builder and runner stages.
+FROM ubuntu:22.04 AS deps
+# Format guideline: one package per line and keep them alphabetically sorted
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    autoconf \
+    bison \
+    build-essential \
+    ca-certificates \
+    ccache \
+    clang-format \
+    clang-tidy \
+    cron \
+    curl \
+    dnsutils \
+    gawk \
+    gdb \
+    git \
+    htop \
+    iproute2 \
+    lcov \
+    libcurl4-openssl-dev \
+    libgmp-dev \
+    libsecp256k1-dev \
+    libssl-dev \
+    libtool \
+    libxml2-utils \
+    logrotate \
+    net-tools \
+    ninja-build \
+    nload \
+    ocl-icd-opencl-dev \
+    openssh-client \
+    pkg-config \
+    python3-dev \
+    python3-pip \
+    rsync \
+    rsyslog \
+    tar \
+    trickle \
+    unzip \
+    vim \
+    wget \
+    zip \
+    && apt-get remove -y cmake python2  && apt-get autoremove -y
+
+FROM deps AS builder
+
+# Cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o install_script.sh && \
+    sh install_script.sh -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN cargo install sccache
+ENV SCCACHE_CACHE_SIZE="1G"
+ENV SCCACHE_DIR="/sccache"
+ENV RUSTC_WRAPPER="/root/.cargo/bin/sccache"
+
+# CMake 3.24
+ARG CMAKE_VERSION=3.24.2
+RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh \
+    && echo "739d372726cb23129d57a539ce1432453448816e345e1545f6127296926b6754 cmake-${CMAKE_VERSION}-Linux-x86_64.sh" | sha256sum -c \ 
+    && mkdir -p "${HOME}"/.local \
+    && bash ./cmake-${CMAKE_VERSION}-Linux-x86_64.sh --skip-license --prefix="${HOME}"/.local/ \
+    && "${HOME}"/.local/bin/cmake --version \
+    && rm cmake-${CMAKE_VERSION}-Linux-x86_64.sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Setup ccache
+RUN ln -s "$(which ccache)" /usr/local/bin/gcc \
+  && ln -s "$(which ccache)" /usr/local/bin/g++ \
+  && ln -s "$(which ccache)" /usr/local/bin/cc \
+  && ln -s "$(which ccache)" /usr/local/bin/c++
+
+# This tag must be equivalent to the hash specified by "builtin-baseline" in vcpkg.json
+ARG VCPKG_COMMIT_OR_TAG=2022.09.27
+ARG VCPKG_ROOT=/vcpkg
+
+RUN ccache -p && ccache -z
+
+# If COMMIT_OR_TAG is a branch name or a tag, clone a shallow copy which is
+# faster; if this fails, just clone the full repo and checkout the commit.
+RUN git clone https://github.com/microsoft/vcpkg ${VCPKG_ROOT} \
+  && git -C ${VCPKG_ROOT} checkout ${VCPKG_COMMIT_OR_TAG} \
+  && ${VCPKG_ROOT}/bootstrap-vcpkg.sh
+
+WORKDIR /zilliqa
+
+COPY vcpkg-registry/ vcpkg-registry
+COPY vcpkg-configuration.json .
+COPY vcpkg.json .
+
+RUN --mount=type=cache,target=/root/.cache/vcpkg/ ${VCPKG_ROOT}/vcpkg install --triplet=x64-linux-dynamic
+
+COPY src/ src
+COPY cmake/ cmake
+COPY daemon/ daemon
+COPY scripts/ scripts
+COPY constants.xml .
+COPY constants_local.xml .
+COPY build.sh .
+COPY CMakeLists.txt .
+
+ENV INSTALL_DIR=/usr/local
+ENV CCACHE_DIR="/ccache"
+
+# Build & install Zilliqa
+RUN --mount=type=cache,target=/ccache/ \
+    --mount=type=cache,target=/root/.cache/vcpkg/ \
+    CCACHE_BASEDIR="/zilliqa" ./build.sh ninja && cmake --build "/zilliqa/build" --target install
+
+COPY evm-ds/ evm-ds
+RUN --mount=type=cache,target=/sccache/ cd evm-ds && PATH=/zilliqa/vcpkg_installed/x64-linux-dynamic/tools/protobuf:$PATH cargo build --release --package evm-ds && sccache --show-stats
+
+RUN ls -l /zilliqa/evm-ds/target
+
+# Make sure all DLLs / shared libraries are installed
+RUN ldd /usr/local/bin/zilliqa | grep vcpkg_installed | gawk '{print $3}' | xargs -I{} cp {} /usr/local/lib \
+  && cp /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/libffi.so /usr/local/lib 
+RUN echo "built files:" && ls -lh /zilliqa/build && echo "installed libs:" && ls -lh /usr/local/lib
+
+ARG VCPKG_PYTHON_PATH=/zilliqa/build/vcpkg_installed/x64-linux-dynamic/tools/python3
+ARG VCPKG_PYTHON3=${VCPKG_PYTHON_PATH}/python3.10
+ARG PYTHON3_ENV_PATH=/usr/local
+RUN ${VCPKG_PYTHON3} -m ensurepip \
+  && ${VCPKG_PYTHON3} -m pip install --upgrade pip \
+  && mkdir -p ${PYTHON3_ENV_PATH}/bin \
+  && mkdir -p ${PYTHON3_ENV_PATH}/lib \
+  && cp ${VCPKG_PYTHON_PATH}/* ${PYTHON3_ENV_PATH}/bin/ \
+  && ldd ${VCPKG_PYTHON3} | grep vcpkg_installed | gawk '{print $3}' | xargs -I{} cp {} /usr/local/lib \
+  && cp -R /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/python3.10 ${PYTHON3_ENV_PATH}/lib/
+
+# strip all exes
+RUN strip /usr/local/bin/grepperf \
+   /usr/local/bin/zilliqad \
+   /usr/local/bin/genkeypair \
+   /usr/local/bin/signmultisig \
+   /usr/local/bin/verifymultisig \
+   /usr/local/bin/getpub \
+   /usr/local/bin/getaddr \
+   /usr/local/bin/genaccounts \
+   /usr/local/bin/sendcmd \
+   /usr/local/bin/gentxn \
+   /usr/local/bin/restore \
+   /usr/local/bin/gensigninitialds \
+   /usr/local/bin/validateDB \
+   /usr/local/bin/genTxnBodiesFromS3 \
+   /usr/local/bin/getnetworkhistory \
+   /usr/local/bin/isolatedServer \
+   /usr/local/bin/getrewardhistory \
+   /usr/local/bin/buildTxBlockHashesToNums \
+#    /usr/local/bin/zilliqa \
+   /usr/local/lib/libSchnorr.so \
+   /usr/local/lib/libCryptoUtils.so \
+   /usr/local/lib/libNAT.so \
+   /usr/local/lib/libCommon.so \
+   /usr/local/lib/libTrie.so
+
+FROM deps
+
+RUN apt-get update && apt-get install -y python3 python3-pip
+
+ARG PYTHON3_ENV_PATH=/usr/local
+COPY docker/requirements3.txt ./
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+#RUN  update-alternatives --install /usr/bin/python3 python3 ${PYTHON3_ENV_PATH}/bin/python3.10 10 # set python3 as default instead python3
+
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+RUN python3 -m pip install --upgrade pip setuptools wheel \
+  && python3 -m pip install --no-cache-dir -r requirements3.txt
+
+RUN echo '#!/bin/bash\npython3 -m pip "$@"' > /usr/bin/pip3 \
+  && chmod a+x /usr/bin/pip3 \
+  && rm /usr/bin/pip \
+  && ln -s /usr/bin/pip3 /usr/bin/pip
+
+RUN mkdir -p /scilla/0 /zilliqa/scripts
+
+COPY _localdev/scilla/bin /scilla/0/bin
+COPY _localdev/scilla/stdlib /scilla/0/src/stdlib
+
+# pour in zilliqa scripts
+COPY --from=builder /zilliqa/scripts         /zilliqa/scripts
+# pour in zilliqa binaries and dynnamic libs
+COPY --from=builder /usr/local/bin/*     /usr/local/bin/
+COPY --from=builder /usr/local/lib/*.so* /usr/local/lib/
+#COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
+COPY --from=builder /zilliqa/evm-ds/target/release/evm-ds /usr/local/bin/
+COPY --from=builder /zilliqa/evm-ds/log4rs.yml /usr/local/etc/
+
+# The above COPY doesn't preserve symlinks which causes gcc/g++/cc/c++
+# to hang as stand-alone binaries on Ubuntu 22.04.
+RUN rm -f /usr/local/bin/gcc \
+      /usr/local/bin/g++ \
+      /usr/local/bin/cc \
+    /usr/local/bin/c++ \
+    && ln -s "$(which ccache)" /usr/local/bin/gcc \
+    && ln -s "$(which ccache)" /usr/local/bin/g++ \
+    && ln -s "$(which ccache)" /usr/local/bin/cc \
+    && ln -s "$(which ccache)" /usr/local/bin/c++
+
+RUN rm -f /usr/local/bin/python3.10 \
+    /usr/local/bin/python3 /usr/local/bin/python /usr/local/bin/pip3
+
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
+
+
+ENTRYPOINT ["/bin/bash"]

--- a/docs/local-network.md
+++ b/docs/local-network.md
@@ -43,3 +43,15 @@ Note that it may take a while to download the container image and start up.
 
 Sadly our networks are not very resilient, so we can't rely on Kubernetes' automatic rollouts to restart nodes with a new image.
 Instead, the easiest thing to do at the moment is to tear down the network and re-create it by running `tilt down`, waiting for all the pods to be deleted and then `tilt up` again.
+
+# Localdev
+
+There is a script, `scripts/localdev.py` which helps automate some of these tasks - run it with no arguments for details.
+
+# Logging
+
+You can log from nodes with command lines like:
+
+```sh
+kubectl logs --tail=100 -f -l type=normal | tee /tmp/logs.txt 2>&1
+```

--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019 Zilliqa
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+This script supports development builds on Zilliqa.
+
+You can currently do a number of things, mostly just automating what's in docs/local-network.md
+
+setup       - create a kind cluster and set it up for development
+teardown    - destroy the cluster
+up          - bring the cluster up with the latest build (equiv to tilt up)
+down        - take the cluster down (equiv to tilt down)
+
+Explorer is at port 8110, HTTP proxy at 8080.
+
+build <tag> - this builds a quick & dirty Zilliqa container image for local development
+
+It's assumed that you have Scilla checked out as a sibling to Zilliqa.
+We:
+
+ - Create a temporary directory
+ - Copy some stuff from "Docker" into it
+ - Build Scilla
+ - Copy scilla into it.
+ - Build Zilliqa
+
+We use a magic dockerfile which does very bad things to Python, but is rather faster to build
+than the ordinary dockerfile.
+
+This is called by Tiltfile.dev, which uses it to build a (cached) container of your latest sources
+to run for localdev builds.
+"""
+
+import os
+import sys
+import shutil
+import re
+import tempfile
+import subprocess
+import time
+
+ZILLIQA_DIR=os.path.join(os.path.dirname(__file__), "..")
+SCILLA_DIR = os.path.join(ZILLIQA_DIR, "..", "scilla")
+KEEP_WORKSPACE = False
+
+class GiveUp(Exception):
+    pass
+
+def run_or_die(cmd, in_dir = None, env = None, in_background = False):
+    if in_background:
+        print(">&" + " ".join(cmd))
+        subprocess.Popen(cmd)
+        return None
+    else:
+        print("> " + " ".join(cmd))
+        data = subprocess.check_output(cmd, cwd = in_dir, env = env)
+        return data
+
+def setup():
+    run_or_die(["kind", "create", "cluster", "--name", "zqdev", "--config", "infra/kind-cluster.yaml"],
+               in_dir = ZILLIQA_DIR)
+    run_or_die(["kubectl", "config", "use-context", "kind-zqdev"])
+    run_or_die(["kubectl", "apply", "-f", "https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml"])
+    # we need to wait a bit for the resource to exist.
+    done = False
+    for i in range(0,5):
+        try:
+            run_or_die(["kubectl", "wait", "--namespace", "ingress-nginx", "--for=condition=ready","pod", "--selector=app.kubernetes.io/component=controller",
+                        "--timeout=300s"])
+            done = True
+            break
+        except:
+            time.sleep(2)
+    if not done:
+        raise GiveUp("Couldn't build ingress")
+
+def teardown():
+    run_or_die(["kind", "delete", "cluster", "-n", "kind-zqdev"])
+
+def run(which):
+    run_or_die(["kubectl", "config", "use-context", "kind-zqdev"])
+    kind_ip_addr = run_or_die(["docker", "container", "inspect", "zqdev-control-plane",
+                               "--format", "{{ .NetworkSettings.Networks.kind.IPAddress }}"]).decode('utf-8').strip()
+
+    # Oh, how I hate this .. but pidfiles are too easily corrupted.
+    try:
+        run_or_die(["killall", "mitmweb"])
+    except:
+        # Probably nothing was running.
+        pass
+    if which == "up":
+        mitm_cmd = ["mitmweb",
+                    "--mode",
+                    f"reverse:http://{kind_ip_addr}",
+                    "--modify-headers",
+                    "/~q/Host/l2api.local.z7a.xyz",
+                    "--no-web-open-browser"
+                    ]
+        run_or_die(mitm_cmd, in_dir = ZILLIQA_DIR, in_background = True)
+    tilt_cmd = ["tilt", "--context", "kind-zqdev", "-f", "Tiltfile.dev", which]
+    if which == "up":
+        print("*** Monitor http requests via mitmweb at http://localhost:8081 ****")
+        print("*** Monitor tilt at http://localhost/http requests via mitmweb at http://localhost:10350 ****")
+        os.execvp('tilt', tilt_cmd)
+    else:
+        run_or_die(tilt_cmd, in_dir = ZILLIQA_DIR)
+
+def build(args):
+    if len(args) != 1:
+        raise GiveUp("Need a single argument - the tag to build")
+    tag = args[0]
+    KEEP_WORKSACE = "KEEP_WORKSPACE" in os.environ
+    workspace = os.path.join(ZILLIQA_DIR, "_localdev")
+    print(f"> Using workspace {workspace}")
+    # Let's start off by building Scilla, in case it breaks.
+    run_or_die(["make"], in_dir = SCILLA_DIR)
+    # OK. That worked. Now copy the relevant bits to our workspace
+    os.makedirs(os.path.join(workspace, "scilla"), 0o755)
+    shutil.copytree(os.path.join(SCILLA_DIR, "bin"),
+                    os.path.join(workspace, "scilla", "bin"))
+    shutil.copytree(os.path.join(SCILLA_DIR, "_build", "install", "default", "lib", "scilla", "stdlib"),
+                    os.path.join(workspace, "scilla", "stdlib"))
+    new_env = os.environ.copy()
+    new_env["DOCKER_BUILDKIT"] = "1"
+    run_or_die(["docker", "build", ".", "-t", tag, "-f", os.path.join(ZILLIQA_DIR, "docker", "Dockerfile.dev")], in_dir = ZILLIQA_DIR, env = new_env)
+    print(f"> Built in workspace {workspace}")
+    if not KEEP_WORKSPACE:
+        print(f"> Removing workspace")
+        shutil.rmtree(workspace)
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if len(args) < 1:
+        print(__doc__, file=sys.stderr)
+        raise GiveUp("Syntax: localdev [cmd] <args..>")
+    cmd = args[0]
+    if cmd == "build":
+        build(args[1:])
+    elif cmd == "up":
+        run("up")
+    elif cmd == "down":
+        run("down")
+    elif cmd == "setup":
+        setup()
+    elif cmd == "teardown":
+        teardown()
+    else:
+        raise GiveUp(f"Invalid command {cmd}")


### PR DESCRIPTION
## Description

A script to build Zilliqa and Scilla together, and also to bodge python so that you don't need to download packages again every time you change the source. This is horribly unsafe for release, but works OK for local development and shortens the modify-compile-run cycle.

Note that you will want to merge https://github.com/Zilliqa/Zilliqa/pull/3367 before this, probably - it updates documentation and we rely on this here.

## Backward Compatibility
- [x] This is not a breaking change
- [  ] This is a breaking change

## Review Suggestion

Look at docs/local-network.md, run the localdev script and verify that it performs as advertised. Look at docker/Dockerfile.dev and check that, whilst unsafe, it caches properly.

