### PR TITLE
EM-39: retrieve txn pool from DS leader

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@
 ARG SCILLA_VERSION=v0.13.1
 
 # Common dependencies of the builder and runner stages.
-FROM ubuntu:22.04 AS deps
+FROM ubuntu:22.04 AS base
 # Format guideline: one package per line and keep them alphabetically sorted
 RUN apt-get update \
     && apt-get install -y software-properties-common \
@@ -40,7 +40,6 @@ RUN apt-get update \
     lcov \
     libcurl4-openssl-dev \
     libgmp-dev \
-    libsecp256k1-dev \
     libssl-dev \
     libtool \
     libxml2-utils \
@@ -51,8 +50,6 @@ RUN apt-get update \
     ocl-icd-opencl-dev \
     openssh-client \
     pkg-config \
-    python3-dev \
-    python3-pip \
     rsync \
     rsyslog \
     tar \
@@ -61,9 +58,9 @@ RUN apt-get update \
     vim \
     wget \
     zip \
-    && apt-get remove -y cmake python2  && apt-get autoremove -y
+    && apt-get remove -y cmake python2 python3 && apt-get autoremove -y
 
-FROM deps AS builder
+FROM base AS builder
 
 # Cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o install_script.sh && \
@@ -103,7 +100,7 @@ RUN git clone https://github.com/microsoft/vcpkg ${VCPKG_ROOT} \
   && git -C ${VCPKG_ROOT} checkout ${VCPKG_COMMIT_OR_TAG} \
   && ${VCPKG_ROOT}/bootstrap-vcpkg.sh
 
-WORKDIR /zilliqa
+WORKDIR /zilliqa/build
 
 COPY vcpkg-registry/ vcpkg-registry
 COPY vcpkg-configuration.json .
@@ -111,32 +108,17 @@ COPY vcpkg.json .
 
 RUN --mount=type=cache,target=/root/.cache/vcpkg/ ${VCPKG_ROOT}/vcpkg install --triplet=x64-linux-dynamic
 
-COPY src/ src
-COPY cmake/ cmake
-COPY daemon/ daemon
-COPY scripts/ scripts
-COPY constants.xml .
-COPY constants_local.xml .
-COPY build.sh .
-COPY CMakeLists.txt .
-
 ENV INSTALL_DIR=/usr/local
 ENV CCACHE_DIR="/ccache"
 
-# Build & install Zilliqa
-RUN --mount=type=cache,target=/ccache/ \
-    --mount=type=cache,target=/root/.cache/vcpkg/ \
-    CCACHE_BASEDIR="/zilliqa" ./build.sh ninja && cmake --build "/zilliqa/build" --target install
+WORKDIR /zilliqa
 
+COPY src/libPersistence/*.proto src/libPersistence/
+COPY src/libUtils/*.proto src/libUtils/
 COPY evm-ds/ evm-ds
-RUN --mount=type=cache,target=/sccache/ cd evm-ds && PATH=/zilliqa/vcpkg_installed/x64-linux-dynamic/tools/protobuf:$PATH cargo build --release --package evm-ds && sccache --show-stats
+RUN --mount=type=cache,target=/sccache/ cd evm-ds && PATH=/zilliqa/build/vcpkg_installed/x64-linux-dynamic/tools/protobuf:$PATH cargo build --release --package evm-ds && sccache --show-stats
 
 RUN ls -l /zilliqa/evm-ds/target
-
-# Make sure all DLLs / shared libraries are installed
-RUN ldd /usr/local/bin/zilliqa | grep vcpkg_installed | gawk '{print $3}' | xargs -I{} cp {} /usr/local/lib \
-  && cp /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/libffi.so /usr/local/lib 
-RUN echo "built files:" && ls -lh /zilliqa/build && echo "installed libs:" && ls -lh /usr/local/lib
 
 ARG VCPKG_PYTHON_PATH=/zilliqa/build/vcpkg_installed/x64-linux-dynamic/tools/python3
 ARG VCPKG_PYTHON3=${VCPKG_PYTHON_PATH}/python3.10
@@ -146,8 +128,44 @@ RUN ${VCPKG_PYTHON3} -m ensurepip \
   && mkdir -p ${PYTHON3_ENV_PATH}/bin \
   && mkdir -p ${PYTHON3_ENV_PATH}/lib \
   && cp ${VCPKG_PYTHON_PATH}/* ${PYTHON3_ENV_PATH}/bin/ \
+  && cp /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/libffi.so /usr/local/lib  \
+  && cp /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/libssl.so* /usr/local/lib  \
+  && cp /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/libcrypto.so* /usr/local/lib  \
   && ldd ${VCPKG_PYTHON3} | grep vcpkg_installed | gawk '{print $3}' | xargs -I{} cp {} /usr/local/lib \
   && cp -R /zilliqa/build/vcpkg_installed/x64-linux-dynamic/lib/python3.10 ${PYTHON3_ENV_PATH}/lib/
+
+RUN update-alternatives --install /usr/bin/python python ${PYTHON3_ENV_PATH}/bin/python3.10 10 \ 
+  && update-alternatives --install /usr/bin/python3 python3 ${PYTHON3_ENV_PATH}/bin/python3.10 10 # set python3 as default instead python3
+
+COPY docker/requirements3.txt ./
+RUN python3 -m pip install --upgrade pip setuptools wheel \
+  && python3 -m pip install --no-cache-dir -r requirements3.txt
+
+RUN echo '#!/bin/bash\npython3 -m pip "$@"' > /usr/bin/pip3 \
+  && chmod a+x /usr/bin/pip3 \
+  && rm -f /usr/bin/pip \
+  && ln -s /usr/bin/pip3 /usr/bin/pip
+
+COPY vcpkg-registry/ vcpkg-registry
+COPY vcpkg-configuration.json .
+COPY vcpkg.json .
+COPY src/ src
+COPY cmake/ cmake
+COPY daemon/ daemon
+COPY scripts/ scripts
+COPY constants.xml .
+COPY constants_local.xml .
+COPY build.sh .
+COPY CMakeLists.txt .
+
+# Build & install Zilliqa
+RUN --mount=type=cache,target=/ccache/ \
+    --mount=type=cache,target=/root/.cache/vcpkg/ \
+    CCACHE_BASEDIR="/zilliqa" ./build.sh ninja && cmake --build "/zilliqa/build" --target install
+
+# Make sure all DLLs / shared libraries are installed
+RUN ldd /usr/local/bin/zilliqa | grep vcpkg_installed | gawk '{print $3}' | xargs -I{} cp {} /usr/local/lib
+RUN echo "built files:" && ls -lh /zilliqa/build && echo "installed libs:" && ls -lh /usr/local/lib
 
 # strip all exes
 RUN strip /usr/local/bin/zilliqad \
@@ -177,7 +195,7 @@ FROM zilliqa/scilla:${SCILLA_VERSION} AS scilla
 # run a copy -L to unfold the symlinkes, and strip all exes
 RUN mkdir -p /scilla/0/bin2/ && cp -L /scilla/0/bin/* /scilla/0/bin2/ && strip /scilla/0/bin2/*
 
-FROM deps
+FROM base
 
 # make dirs for scilla and zilliqa
 RUN mkdir -p \
@@ -197,6 +215,8 @@ COPY --from=builder /usr/local/lib/python3.10 /usr/local/lib/python3.10
 COPY --from=builder /zilliqa/evm-ds/target/release/evm-ds /usr/local/bin/
 COPY --from=builder /zilliqa/evm-ds/log4rs.yml /usr/local/etc/
 
+ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
+
 # The above COPY doesn't preserve symlinks which causes gcc/g++/cc/c++
 # to hang as stand-alone binaries on Ubuntu 22.04.
 RUN rm -f /usr/local/bin/gcc \
@@ -208,21 +228,10 @@ RUN rm -f /usr/local/bin/gcc \
     && ln -s "$(which ccache)" /usr/local/bin/cc \
     && ln -s "$(which ccache)" /usr/local/bin/c++
 
-ADD https://github.com/krallin/tini/releases/latest/download/tini /tini
-
 ARG PYTHON3_ENV_PATH=/usr/local
-COPY docker/requirements3.txt ./
 RUN update-alternatives --install /usr/bin/python python ${PYTHON3_ENV_PATH}/bin/python3.10 10 \ 
   && update-alternatives --install /usr/bin/python3 python3 ${PYTHON3_ENV_PATH}/bin/python3.10 10 # set python3 as default instead python3
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
-
-RUN python3 -m pip install --upgrade pip setuptools wheel \
-  && python3 -m pip install --no-cache-dir -r requirements3.txt
-
-RUN echo '#!/bin/bash\npython3 -m pip "$@"' > /usr/bin/pip3 \
-  && chmod a+x /usr/bin/pip3 \
-  && rm /usr/bin/pip \
-  && ln -s /usr/bin/pip3 /usr/bin/pip
 
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     lcov \
     libcurl4-openssl-dev \
     libgmp-dev \
+    libsecp256k1-dev \
     libssl-dev \
     libtool \
     libxml2-utils \
@@ -106,7 +107,11 @@ COPY vcpkg-registry/ vcpkg-registry
 COPY vcpkg-configuration.json .
 COPY vcpkg.json .
 
+# python3 is unfortunately needed for upb which has a problem finding the
+# vcpkg compiled python.
+RUN apt-get install -y python3-dev
 RUN --mount=type=cache,target=/root/.cache/vcpkg/ ${VCPKG_ROOT}/vcpkg install --triplet=x64-linux-dynamic
+RUN apt-get remove -y python3-dev && apt-get autoremove -y
 
 ENV INSTALL_DIR=/usr/local
 ENV CCACHE_DIR="/ccache"
@@ -231,6 +236,11 @@ RUN rm -f /usr/local/bin/gcc \
 ARG PYTHON3_ENV_PATH=/usr/local
 RUN update-alternatives --install /usr/bin/python python ${PYTHON3_ENV_PATH}/bin/python3.10 10 \ 
   && update-alternatives --install /usr/bin/python3 python3 ${PYTHON3_ENV_PATH}/bin/python3.10 10 # set python3 as default instead python3
+
+RUN echo '#!/bin/bash\npython3 -m pip "$@"' > /usr/bin/pip3 \
+  && chmod a+x /usr/bin/pip3 \
+  && rm -f /usr/bin/pip \
+  && ln -s /usr/bin/pip3 /usr/bin/pip
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 

--- a/src/common/MessageNames.h
+++ b/src/common/MessageNames.h
@@ -23,7 +23,9 @@
 #include "Messages.h"
 
 #define MAKE_LITERAL_STRING(s) \
-  { #s }
+  {                            \
+#s                         \
+  }
 #define ARRAY_SIZE(s) (sizeof(s) / sizeof(s[0]))
 
 static const std::string DSInstructionStrings[]{
@@ -95,10 +97,10 @@ static const std::string LookupInstructionStrings[]{
     MAKE_LITERAL_STRING(GETMBNFWDTXNFROML2LDATAPROVIDER),
     MAKE_LITERAL_STRING(GETPENDINGTXNFROML2LDATAPROVIDER),  // UNUSED
     MAKE_LITERAL_STRING(GETMICROBLOCKFROML2LDATAPROVIDER),
-    MAKE_LITERAL_STRING(GETTXNSFROML2LDATAPROVIDER)};
+    MAKE_LITERAL_STRING(GETTXNSFROML2LDATAPROVIDER),
+    MAKE_LITERAL_STRING(SETDSLEADERTXNPOOL)};
 
-static_assert(ARRAY_SIZE(LookupInstructionStrings) ==
-                  GETTXNSFROML2LDATAPROVIDER + 1,
+static_assert(ARRAY_SIZE(LookupInstructionStrings) == SETDSLEADERTXNPOOL + 1,
               "LookupInstructionStrings definition is not correct");
 
 static const std::string *MessageTypeInstructionStrings[]{

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -105,7 +105,8 @@ enum LookupInstructionType : unsigned char {
   GETPENDINGTXNFROML2LDATAPROVIDER =
       0x24,  // UNUSED GETPENDINGTXNFROML2LDATAPROVIDER
   GETMICROBLOCKFROML2LDATAPROVIDER = 0x25,  // ProcessGetMicroBlockFromL2l,
-  GETTXNSFROML2LDATAPROVIDER = 0x26         // ProcessGetTxnsFromL2l
+  GETTXNSFROML2LDATAPROVIDER = 0x26,         // ProcessGetTxnsFromL2l
+  SETDSLEADERTXNPOOL = 0x27
 };
 
 enum TxSharingMode : unsigned char {

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -40,6 +40,7 @@ enum DSInstructionType : unsigned char {
   POWPACKETSUBMISSION = 0x07,
   NEWDSGUARDIDENTITY = 0x08,
   SETCOSIGSREWARDSFROMSEED = 0x09,
+  GETDSLEADERTXNPOOL = 0x0A
 };
 
 enum NodeInstructionType : unsigned char {

--- a/src/common/Messages.h
+++ b/src/common/Messages.h
@@ -106,7 +106,7 @@ enum LookupInstructionType : unsigned char {
       0x24,  // UNUSED GETPENDINGTXNFROML2LDATAPROVIDER
   GETMICROBLOCKFROML2LDATAPROVIDER = 0x25,  // ProcessGetMicroBlockFromL2l,
   GETTXNSFROML2LDATAPROVIDER = 0x26,         // ProcessGetTxnsFromL2l
-  SETDSLEADERTXNPOOL = 0x27
+  SETDSLEADERTXNPOOL = 0x27              // ProcessSetDSLeaderTxnPoolFromSeed
 };
 
 enum TxSharingMode : unsigned char {

--- a/src/libCps/CpsAccountStoreInterface.h
+++ b/src/libCps/CpsAccountStoreInterface.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-struct EvmProcessContext;
+class EvmProcessContext;
 
 namespace libCps {
 struct CpsAccountStoreInterface {

--- a/src/libCps/CpsExecuteValidator.h
+++ b/src/libCps/CpsExecuteValidator.h
@@ -21,7 +21,7 @@
 #include "common/BaseType.h"
 #include "libCps/CpsExecuteResult.h"
 
-struct EvmProcessContext;
+class EvmProcessContext;
 
 namespace libCps {
 class Amount;

--- a/src/libCps/CpsExecutor.h
+++ b/src/libCps/CpsExecutor.h
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-struct EvmProcessContext;
+class EvmProcessContext;
 class TransactionReceipt;
 
 namespace libCps {

--- a/src/libData/AccountData/TxnPool.h
+++ b/src/libData/AccountData/TxnPool.h
@@ -51,7 +51,7 @@ struct TxnPool {
     NonceIndex.clear();
   }
 
-  unsigned int size() { return HashIndex.size(); }
+  unsigned int size() const { return HashIndex.size(); }
 
   bool exist(const TxnHash& th) {
     return HashIndex.find(th) != HashIndex.end();

--- a/src/libData/AccountStore/AccountStoreSC.h
+++ b/src/libData/AccountStore/AccountStoreSC.h
@@ -50,7 +50,7 @@ struct counter_t {
 class ScillaIPCServer;
 
 class AccountStoreSC : public AccountStoreBase {
-  friend struct AccountStoreCpsInterface;
+  friend class AccountStoreCpsInterface;
   /// the amount transfers happened within the current txn will only commit when
   /// the txn is successful
   std::unique_ptr<AccountStoreAtomic> m_accountStoreAtomic;

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1058,6 +1058,23 @@ bool DirectoryService::ProcessCosigsRewardsFromSeed(
   return true;
 }
 
+bool DirectoryService::ProcessGetDSLeaderTxnPool(
+    const zbytes& /*message*/, unsigned int /*offset*/, const Peer& /*from*/,
+    const unsigned char& /*startByte*/) {
+  LOG_MARKER();
+
+  if (LOOKUP_NODE_MODE) {
+    LOG_GENERAL(WARNING,
+                "DirectoryService::ProcessGetDSLeaderTxnPool not expected "
+                "to be called from LookUp node.");
+    return true;
+  }
+
+  LOG_GENERAL(INFO, "DirectoryService::ProcessGetDSLeaderTxnPool invoked");
+
+  return true;
+}
+
 void DirectoryService::GetCoinbaseRewardees(
     std::map<uint64_t, std::map<int32_t, std::vector<PubKey>>>&
         coinbase_rewardees) {
@@ -1087,7 +1104,8 @@ bool DirectoryService::Execute(const zbytes& message, unsigned int offset,
                        &DirectoryService::ProcessVCPushLatestDSTxBlock,
                        &DirectoryService::ProcessPoWPacketSubmission,
                        &DirectoryService::ProcessNewDSGuardNetworkInfo,
-                       &DirectoryService::ProcessCosigsRewardsFromSeed});
+                       &DirectoryService::ProcessCosigsRewardsFromSeed,
+                       &DirectoryService::ProcessGetDSLeaderTxnPool});
 
   const unsigned char ins_byte = message.at(offset);
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1088,12 +1088,14 @@ bool DirectoryService::ProcessGetDSLeaderTxnPool(
 
   LOG_GENERAL(INFO,
               "Returning created transactions for " << m_mediator.m_selfPeer);
-  zbytes txnPoolMessage = {MessageType::DIRECTORY,
+  zbytes txnPoolMessage = {MessageType::LOOKUP,
                            LookupInstructionType::SETDSLEADERTXNPOOL};
 
-  if (!Messenger::SetTransactionArray(txnPoolMessage, MessageOffset::BODY,
-                                      m_mediator.m_node->GetCreatedTxns())) {
-    LOG_GENERAL(WARNING, "Messenger::SetTransactionArray failed");
+  if (!Messenger::SetLookupSetDSLeaderTxnPool(
+          txnPoolMessage, MessageOffset::BODY,
+          m_mediator.m_node->GetCreatedTxns())) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+              "Messenger::SetLookupSetDSLeaderTxnPool failed.");
     return false;
   }
 

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1070,7 +1070,14 @@ bool DirectoryService::ProcessGetDSLeaderTxnPool(
     return true;
   }
 
-  LOG_GENERAL(INFO, "DirectoryService::ProcessGetDSLeaderTxnPool invoked");
+  LOG_GENERAL(INFO,
+              "Returning created transactions for " << m_mediator.m_selfPeer);
+  auto txns = m_mediator.m_node->GetCreatedTxns();
+  for (const auto& txn : txns) {
+    LOG_GENERAL(INFO, "Transaction ID: "
+                          << txn.GetTranID() << ", To Addr: " << txn.GetToAddr()
+                          << " (hex: " << txn.GetToAddr().hex() << ')');
+  }
 
   return true;
 }

--- a/src/libDirectoryService/DirectoryService.h
+++ b/src/libDirectoryService/DirectoryService.h
@@ -271,6 +271,10 @@ class DirectoryService : public Executable {
       const zbytes& message, unsigned int offset, const Peer& from,
       [[gnu::unused]] const unsigned char& startByte);
 
+  bool ProcessGetDSLeaderTxnPool(
+      const zbytes& message, unsigned int offset, const Peer& from,
+      [[gnu::unused]] const unsigned char& startByte);
+
   // To block certain types of incoming message for certain states
   bool ToBlockMessage(unsigned char ins_byte);
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1589,7 +1589,7 @@ bool Lookup::ProcessGetMBnForwardTxnFromL2l(const zbytes& message,
   return false;
 }
 
-bool Lookup::GetDSLeaderTxnPool() {
+std::optional<std::vector<Transaction>> Lookup::GetDSLeaderTxnPool() {
   zbytes retMsg = {MessageType::DIRECTORY,
                    DSInstructionType::GETDSLEADERTXNPOOL};
 
@@ -1597,7 +1597,7 @@ bool Lookup::GetDSLeaderTxnPool() {
           retMsg, MessageOffset::BODY, m_mediator.m_selfKey,
           m_mediator.m_selfPeer.m_listenPortHost)) {
     LOG_GENERAL(WARNING, "Failed to Process ");
-    return false;
+    return std::nullopt;
   }
 
   std::lock_guard<mutex> g(m_mediator.m_mutexDSCommittee);
@@ -1608,7 +1608,7 @@ bool Lookup::GetDSLeaderTxnPool() {
     LOG_GENERAL(WARNING, "consensusLeaderID = "
                              << consensusLeaderID << " >= DS committee size = "
                              << m_mediator.m_DSCommittee->size());
-    return true;
+    return std::nullopt;
   }
 
   LOG_GENERAL(INFO, "Sending GETDSLEADERTXNPOOL to consensusLeaderID = "
@@ -1616,7 +1616,20 @@ bool Lookup::GetDSLeaderTxnPool() {
 
   P2PComm::GetInstance().SendMessage(dsLeader.second, retMsg);
 
-  return true;
+  static constexpr const chrono::seconds GETDSLEADERTXNPOOL_TIMEOUT_IN_SECONDS{
+      3};
+  unique_lock<mutex> lock(m_mutexDSLeaderTxnPool);
+  if (cv_dsLeaderTxnPool.wait_for(lock,
+                                  GETDSLEADERTXNPOOL_TIMEOUT_IN_SECONDS) ==
+      std::cv_status::timeout) {
+    // timed out
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Timed out waiting for DS leader txn pool");
+    return std::nullopt;
+  }
+
+  LOG_GENERAL(INFO, "Received reply to GETDSLEADERTXNPOOL");
+  return m_dsLeaderTxnPool;
 }
 
 bool Lookup::ComposeAndStoreMBnForwardTxnMessage(const uint64_t& blockNum) {
@@ -3880,6 +3893,36 @@ bool Lookup::ProcessGetTxnsFromL2l(const zbytes& message, unsigned int offset,
   return true;
 }
 
+bool Lookup::ProcessSetDSLeaderTxnPoolFromSeed(
+    const zbytes& message, unsigned int offset, const Peer& /*from*/,
+    const unsigned char& /*startByte*/) {
+  if (!LOOKUP_NODE_MODE) {
+    LOG_GENERAL(WARNING,
+                "Function not expected to be called from non-lookup node");
+    return true;
+  }
+
+  if (offset >= message.size()) {
+    LOG_GENERAL(WARNING, "Invalid txn message, message size: "
+                             << message.size()
+                             << ", txn data offset: " << offset);
+    return false;
+  }
+
+  std::vector<Transaction> txns;
+  if (!Messenger::GetTransactionArray(message, offset, txns)) {
+    LOG_GENERAL(WARNING, "Messenger::GetTransactionArray failed");
+    return false;
+  }
+
+  LOG_GENERAL(INFO, "Received " << txns.size() << " transactions");
+
+  unique_lock<mutex> lock(m_mutexDSLeaderTxnPool);
+  m_dsLeaderTxnPool = std::move(txns);
+  cv_dsLeaderTxnPool.notify_all();
+  return true;
+}
+
 // Ex archival code
 bool Lookup::ProcessSetTxnsFromLookup(
     const zbytes& message, unsigned int offset,
@@ -5226,7 +5269,8 @@ bool Lookup::Execute(const zbytes& message, unsigned int offset,
       &Lookup::ProcessGetMBnForwardTxnFromL2l,
       &Lookup::NoOp,  // Previously for GETPENDINGTXNFROML2LDATAPROVIDER
       &Lookup::ProcessGetMicroBlockFromL2l,
-      &Lookup::ProcessGetTxnsFromL2l};
+      &Lookup::ProcessGetTxnsFromL2l,
+      &Lookup::ProcessSetDSLeaderTxnPoolFromSeed};
 
   const unsigned char ins_byte = message.at(offset);
   const unsigned int ins_handlers_count =

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -1588,6 +1588,28 @@ bool Lookup::ProcessGetMBnForwardTxnFromL2l(const zbytes& message,
   return false;
 }
 
+bool Lookup::GetDSLeaderTxnPool()
+{
+  zbytes retMsg = {MessageType::DIRECTORY,
+                   DSInstructionType::GETDSLEADERTXNPOOL};
+
+  if (!Messenger::SetLookupGetDSLeaderTxnPool(
+          retMsg, MessageOffset::BODY, m_mediator.m_selfKey,
+          m_mediator.m_selfPeer.m_listenPortHost)) {
+    LOG_GENERAL(WARNING, "Failed to Process ");
+    return false;
+  }
+
+  std::lock_guard<mutex> g(m_mediator.m_mutexDSCommittee);
+
+  auto consensusLeaderID = m_mediator.m_node->GetConsensusLeaderID();
+  const auto& dsLeader = m_mediator.m_DSCommittee->at(consensusLeaderID);
+
+  P2PComm::GetInstance().SendMessage(dsLeader.second, retMsg);
+
+  return true;
+}
+
 bool Lookup::ComposeAndStoreMBnForwardTxnMessage(const uint64_t& blockNum) {
   if (!LOOKUP_NODE_MODE || !ARCHIVAL_LOOKUP || !MULTIPLIER_SYNC_MODE) {
     LOG_GENERAL(

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -266,6 +266,8 @@ class Lookup : public Executable {
                                       unsigned int offset, const Peer& from,
                                       const unsigned char& startByte);
 
+  bool GetDSLeaderTxnPool();
+
   // Get the offline lookup nodes from lookup nodes
   bool GetOfflineLookupNodes();
 

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -266,7 +266,7 @@ class Lookup : public Executable {
                                       unsigned int offset, const Peer& from,
                                       const unsigned char& startByte);
 
-  bool GetDSLeaderTxnPool();
+  std::optional<std::vector<Transaction>> GetDSLeaderTxnPool();
 
   // Get the offline lookup nodes from lookup nodes
   bool GetOfflineLookupNodes();
@@ -339,6 +339,9 @@ class Lookup : public Executable {
                                 const unsigned char& startByte);
 
   bool ProcessGetTxnsFromL2l(const zbytes& message, unsigned int offset,
+                             const Peer& from, const unsigned char& startByte);
+
+  bool ProcessSetDSLeaderTxnPoolFromSeed(const zbytes& message, unsigned int offset,
                              const Peer& from, const unsigned char& startByte);
 
   bool ProcessSetTxnsFromLookup(const zbytes& message, unsigned int offset,
@@ -571,6 +574,10 @@ class Lookup : public Executable {
   std::mutex m_mutexVCFinalBlockProcessed;
   std::condition_variable cv_vcFinalBlockProcessed;
   bool m_vcFinalBlockProcessed = false;
+
+  std::mutex m_mutexDSLeaderTxnPool;
+  std::condition_variable cv_dsLeaderTxnPool;
+  std::vector<Transaction> m_dsLeaderTxnPool;
 
   // exit trigger
   std::atomic<bool> m_exitPullThread{};

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -7770,19 +7770,15 @@ bool Messenger::GetLookupGetCosigsRewardsFromSeed(const zbytes& src,
 }
 
 bool Messenger::SetLookupGetDSLeaderTxnPool(zbytes& dst, unsigned int offset,
-                                          const PairOfKey& keys,
-                                          uint32_t listenPort)
-{
-  LOG_MARKER();
-
+                                            const PairOfKey& keys,
+                                            uint32_t listenPort) {
   LookupGetDSLeaderTxnPool result;
 
   result.mutable_data()->set_portno(listenPort);
 
   Signature signature;
   if (!result.data().IsInitialized()) {
-    LOG_GENERAL(WARNING,
-                "SetLookupGetDSLeaderTxnPool initialization failed");
+    LOG_GENERAL(WARNING, "SetLookupGetDSLeaderTxnPool initialization failed");
     return false;
   }
   zbytes tmp(result.data().ByteSizeLong());
@@ -7797,12 +7793,40 @@ bool Messenger::SetLookupGetDSLeaderTxnPool(zbytes& dst, unsigned int offset,
   SerializableToProtobufByteArray(signature, *result.mutable_signature());
 
   if (!result.IsInitialized()) {
-    LOG_GENERAL(WARNING,
-                "SetLookupGetDSLeaderTxnPool initialization failed");
+    LOG_GENERAL(WARNING, "SetLookupGetDSLeaderTxnPool initialization failed");
     return false;
   }
 
   return SerializeToArray(result, dst, offset);
+}
+
+bool Messenger::GetLookupGetDSLeaderTxnPool(const zbytes& src,
+                                            unsigned int offset,
+                                            PubKey& senderPubkey,
+                                            uint32_t& listenPort) {
+  LookupGetDSLeaderTxnPool result;
+
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+  if (!result.IsInitialized() || !result.data().IsInitialized()) {
+    LOG_GENERAL(WARNING, "GetLookupGetDSLeaderTxnPool initialization failed");
+    return false;
+  }
+
+  // First deserialize the fields needed just for signature check
+  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.pubkey(), senderPubkey);
+  Signature signature;
+  PROTOBUFBYTEARRAYTOSERIALIZABLE(result.signature(), signature);
+
+  // Check signature
+  zbytes tmp(result.data().ByteSizeLong());
+  result.data().SerializeToArray(tmp.data(), tmp.size());
+  if (!Schnorr::Verify(tmp, 0, tmp.size(), signature, senderPubkey)) {
+    LOG_GENERAL(WARNING, "GetLookupGetDSLeaderTxnPool signature wrong");
+    return false;
+  }
+
+  listenPort = result.data().portno();
+  return true;
 }
 
 bool Messenger::SetLookupSetCosigsRewardsFromSeed(

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -7829,6 +7829,45 @@ bool Messenger::GetLookupGetDSLeaderTxnPool(const zbytes& src,
   return true;
 }
 
+bool Messenger::SetLookupSetDSLeaderTxnPool(
+    zbytes& dst, unsigned int offset,
+    const std::vector<Transaction>& transactions) {
+  LookupSetDSLeaderTxnPool result;
+
+  TransactionArrayToProtobuf(transactions, *result.mutable_dsleadertxnpool());
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "SetLookupSetDSLeaderTxnPool initialization failed");
+    return false;
+  }
+
+  return SerializeToArray(result, dst, offset);
+}
+
+bool Messenger::GetLookupSetDSLeaderTxnPool(
+    const zbytes& src, unsigned int offset,
+    std::vector<Transaction>& transactions) {
+  if (offset >= src.size()) {
+    LOG_GENERAL(WARNING, "Invalid data and offset, data size "
+                             << src.size() << ", offset " << offset);
+    return false;
+  }
+
+  LookupSetDSLeaderTxnPool result;
+  result.ParseFromArray(src.data() + offset, src.size() - offset);
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING, "GetLookupSetDSLeaderTxnPool initialization failed");
+    return false;
+  }
+
+  if (!ProtobufToTransactionArray(result.dsleadertxnpool(), transactions)) {
+    LOG_GENERAL(WARNING, "ProtobufToTransactionArray failed");
+    return false;
+  }
+
+  return true;
+}
+
 bool Messenger::SetLookupSetCosigsRewardsFromSeed(
     zbytes& dst, const unsigned int offset, const PairOfKey& myKey,
     const uint64_t& txBlkNumber, const std::vector<MicroBlock>& microblocks,

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -7769,6 +7769,42 @@ bool Messenger::GetLookupGetCosigsRewardsFromSeed(const zbytes& src,
   return true;
 }
 
+bool Messenger::SetLookupGetDSLeaderTxnPool(zbytes& dst, unsigned int offset,
+                                          const PairOfKey& keys,
+                                          uint32_t listenPort)
+{
+  LOG_MARKER();
+
+  LookupGetDSLeaderTxnPool result;
+
+  result.mutable_data()->set_portno(listenPort);
+
+  Signature signature;
+  if (!result.data().IsInitialized()) {
+    LOG_GENERAL(WARNING,
+                "SetLookupGetDSLeaderTxnPool initialization failed");
+    return false;
+  }
+  zbytes tmp(result.data().ByteSizeLong());
+  result.data().SerializeToArray(tmp.data(), tmp.size());
+
+  if (!Schnorr::Sign(tmp, keys.first, keys.second, signature)) {
+    LOG_GENERAL(WARNING, "Failed to sign SetLookupGetDSLeaderTxnPool message");
+    return false;
+  }
+
+  SerializableToProtobufByteArray(keys.second, *result.mutable_pubkey());
+  SerializableToProtobufByteArray(signature, *result.mutable_signature());
+
+  if (!result.IsInitialized()) {
+    LOG_GENERAL(WARNING,
+                "SetLookupGetDSLeaderTxnPool initialization failed");
+    return false;
+  }
+
+  return SerializeToArray(result, dst, offset);
+}
+
 bool Messenger::SetLookupSetCosigsRewardsFromSeed(
     zbytes& dst, const unsigned int offset, const PairOfKey& myKey,
     const uint64_t& txBlkNumber, const std::vector<MicroBlock>& microblocks,

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -899,6 +899,11 @@ class Messenger {
                                           const PairOfKey& keys,
                                           uint32_t listenPort);
 
+  static bool GetLookupGetDSLeaderTxnPool(const zbytes& src,
+                                          unsigned int offset,
+                                          PubKey& senderPubkey,
+                                          uint32_t& listenPort);
+
   static bool SetLookupSetCosigsRewardsFromSeed(
       zbytes& dst, const unsigned int offset, const PairOfKey& myKey,
       const uint64_t& txBlkNumber, const std::vector<MicroBlock>& microblocks,

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -895,6 +895,10 @@ class Messenger {
                                                 uint64_t& txBlockNumber,
                                                 uint32_t& port);
 
+  static bool SetLookupGetDSLeaderTxnPool(zbytes& dst, unsigned int offset,
+                                          const PairOfKey& keys,
+                                          uint32_t listenPort);
+
   static bool SetLookupSetCosigsRewardsFromSeed(
       zbytes& dst, const unsigned int offset, const PairOfKey& myKey,
       const uint64_t& txBlkNumber, const std::vector<MicroBlock>& microblocks,

--- a/src/libMessage/Messenger.h
+++ b/src/libMessage/Messenger.h
@@ -904,6 +904,14 @@ class Messenger {
                                           PubKey& senderPubkey,
                                           uint32_t& listenPort);
 
+  static bool SetLookupSetDSLeaderTxnPool(
+      zbytes& dst, unsigned int offset,
+      const std::vector<Transaction>& transactions);
+
+  static bool GetLookupSetDSLeaderTxnPool(
+      const zbytes& src, unsigned int offset,
+      std::vector<Transaction>& transactions);
+
   static bool SetLookupSetCosigsRewardsFromSeed(
       zbytes& dst, const unsigned int offset, const PairOfKey& myKey,
       const uint64_t& txBlkNumber, const std::vector<MicroBlock>& microblocks,

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -1191,6 +1191,11 @@ message LookupGetDSLeaderTxnPool
     ByteArray signature             = 3;
 }
 
+message LookupSetDSLeaderTxnPool
+{
+    ProtoTransactionArray dsLeaderTxnPool = 1;
+}
+
 // Lookup set cosigs/rewards for ds node
 message LookupSetCosigsRewardsFromSeed
 {

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -1179,6 +1179,18 @@ message LookupGetCosigsRewardsFromSeed
     ByteArray signature         = 3;
 }
 
+message LookupGetDSLeaderTxnPool
+{
+    message Data
+    {
+        uint32 portno           = 1;
+    }
+
+    Data data                       = 1;
+    ByteArray pubkey                = 2;
+    ByteArray signature             = 3;
+}
+
 // Lookup set cosigs/rewards for ds node
 message LookupSetCosigsRewardsFromSeed
 {

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -3271,3 +3271,20 @@ void Node::CheckPeers(const vector<Peer> &peers) {
   }
   P2PComm::GetInstance().SendMessage(peers, message);
 }
+
+std::vector<Transaction> Node::GetCreatedTxns() const {
+  lock_guard<mutex> g(m_mutexCreatedTransactions);
+
+  std::vector<Transaction> txns;
+  txns.reserve(m_createdTxns.size() + t_createdTxns.size());
+
+  for (const auto &[txnHash, txn] : m_createdTxns.HashIndex) {
+    txns.emplace_back(txn);
+  }
+
+  for (const auto &[txnHash, txn] : t_createdTxns.HashIndex) {
+    txns.emplace_back(txn);
+  }
+
+  return txns;
+}

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -140,7 +140,7 @@ class Node : public Executable {
   const static unsigned int GOSSIP_RATE = 48;
 
   // Transactions information
-  std::mutex m_mutexCreatedTransactions;
+  mutable std::mutex m_mutexCreatedTransactions;
   TxnPool m_createdTxns, t_createdTxns;
 
   std::vector<TxnHash> m_expectedTranOrdering;
@@ -772,6 +772,8 @@ class Node : public Executable {
                          const std::string& endDSEpoch);
 
   void CheckPeers(const std::vector<Peer>& peers);
+
+  std::vector<Transaction> GetCreatedTxns() const;
 
  private:
   static std::map<NodeState, std::string> NodeStateStrings;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -1734,8 +1734,15 @@ Json::Value EthRpcMethods::GetDSLeaderTxnPool() {
                            "Sent to a non-lookup");
   }
 
+  auto txns = m_sharedMediator.m_lookup->GetDSLeaderTxnPool();
+  if (!txns) {
+    throw JsonRpcException(ServerBase::RPC_MISC_ERROR, "Unable to Process");
+  }
+
   Json::Value res = Json::arrayValue;
-  m_sharedMediator.m_lookup->GetDSLeaderTxnPool();
+  for (const auto &txn : *txns) {
+    res.append(JSONConversion::convertTxtoJson(txn));
+  }
 
   return res;
 }

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -364,6 +364,11 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
                          jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
                          NULL),
       &EthRpcMethods::GetEthBlockReceiptsI);
+
+  m_lookupServer->bindAndAddExternalMethod(
+      jsonrpc::Procedure("GetDSLeaderTxnPool", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_STRING, nullptr),
+      &EthRpcMethods::GetDSLeaderTxnPoolI);
 }
 
 std::string EthRpcMethods::CreateTransactionEth(
@@ -1717,6 +1722,20 @@ Json::Value EthRpcMethods::GetEthBlockReceipts(const std::string &blockId) {
     auto const receipt = GetEthTransactionReceipt(tx.asString());
     res.append(receipt);
   }
+
+  return res;
+}
+
+Json::Value EthRpcMethods::GetDSLeaderTxnPool() {
+  INC_CALLS(GetInvocationsCounter());
+
+  if (!LOOKUP_NODE_MODE) {
+    throw JsonRpcException(ServerBase::RPC_INVALID_REQUEST,
+                           "Sent to a non-lookup");
+  }
+
+  Json::Value res = Json::arrayValue;
+  m_sharedMediator.m_lookup->GetDSLeaderTxnPool();
 
   return res;
 }

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -558,7 +558,7 @@ class EthRpcMethods {
    * @param request : no parameters
    * @param response : Json array of transactions from the DSLeader txn pool.
    */
-  inline virtual void GetDSLeaderTxnPoolI(const Json::Value& request,
+  inline virtual void GetDSLeaderTxnPoolI(const Json::Value& /*request*/,
                                                Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
     response = this->GetDSLeaderTxnPool();

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -554,6 +554,17 @@ class EthRpcMethods {
   }
 
   /**
+   * @brief Handles json rpc 2.0 request on method: GetDSLeaderTxnPool
+   * @param request : no parameters
+   * @param response : Json array of transactions from the DSLeader txn pool.
+   */
+  inline virtual void GetDSLeaderTxnPoolI(const Json::Value& request,
+                                               Json::Value& response) {
+    LOG_MARKER_CONTITIONAL(LOG_SC);
+    response = this->GetDSLeaderTxnPool();
+  }
+
+  /**
    * @brief Handles json rpc 2.0 request on method: debug_traceTransaction
    * @param request : transaction hash
    * @param response : transaction trace
@@ -635,6 +646,7 @@ class EthRpcMethods {
   std::string EthRecoverTransaction(const std::string& txnRpc) const;
 
   Json::Value GetEthBlockReceipts(const std::string& blockId);
+  Json::Value GetDSLeaderTxnPool();
   Json::Value DebugTraceTransaction(const std::string& txHash);
 
   void EnsureEvmAndLookupEnabled();


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Added an (Eth) RPC method 'GetDSLeaderTxnPool' (so ENABLE_EVM must be true in constants.xml).
This is sent to a lookup node which then requests the (memory) transaction pool from the DS leader and returns the list of transactions as an array of JSON objects.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
