### PR TITLE
[master] Log the EVM result in the same message as the summary

### DIFF
--- a/evm-ds/src/evm_server_run.rs
+++ b/evm-ds/src/evm_server_run.rs
@@ -131,10 +131,9 @@ pub async fn run_evm_impl(
                 let result = build_exit_result(executor, &runtime, &backend, listener.traces.clone(), exit_reason, remaining_gas);
                 info!(
                     "EVM execution summary: context: {:?}, origin: {:?} address: {:?} gas: {:?} value: {:?}, 
-                    extras: {:?}, estimate: {:?}, cps: {:?}",
+                    extras: {:?}, estimate: {:?}, cps: {:?}, result: {}",
                     evm_context, backend.origin, address, gas_limit, apparent_value,
-                    backend.extras, estimate, enable_cps);
-                log_evm_result(&result);
+                    backend.extras, estimate, enable_cps, log_evm_result(&result));
                 result
             },
             CpsReason::CallInterrupt(i) => {

--- a/evm-ds/src/pretty_printer.rs
+++ b/evm-ds/src/pretty_printer.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use primitive_types::{H160, H256, U256};
 use protobuf::Message;
 use std::fmt::Write;
@@ -43,10 +42,9 @@ fn apply_delete_to_string(delete: &EvmProto::Apply_Delete) -> String {
     )
 }
 
-pub fn log_evm_result(result: &EvmProto::EvmResult) {
+pub fn log_evm_result(result: &EvmProto::EvmResult) -> String {
     let mut result_string = String::new();
 
-    debug!("evm_result: {:#?}", result);
     write!(
         result_string,
         "\nexit_reason: {:#?}",
@@ -68,5 +66,5 @@ pub fn log_evm_result(result: &EvmProto::EvmResult) {
         }
     });
 
-    debug!("{}", result_string);
+    result_string
 }


### PR DESCRIPTION
Right now on testnet I'm just not able to find them.   Because usually we search by transation ID, or by source/destination address etc.  Log messages with just EVM results are not super useful unfortunately.