### PR TITLE
[master] Use pigz for faster compression of persistence

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
     htop \
     iproute2 \
     lcov \
+    pigz \
     libcurl4-openssl-dev \
     libgmp-dev \
     libsecp256k1-dev \


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
Currently, `auto_backup.py` script spent 2 hours just to compress the data. This causes the next few epoch of persistence not to get backed up and also will slow down the mainnet deployment time.

With the use of pigz tool, the `m5.4xlarge` machine can compress the persistence in 15 mins.

Here is the testnet PR for the same where we use the same tool for the extraction of zipped persistence.
https://github.com/Zilliqa/testnet/pull/1002

To merge or hold the PR depends if everyone is ok with the change.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
