### PR TITLE
[master] ZIL-5114: carry the trace & span Ids when logging

### DIFF
--- a/src/libMetrics/Tracing.h
+++ b/src/libMetrics/Tracing.h
@@ -25,6 +25,8 @@
 #include <string>
 #include <variant>
 
+#include <g3log/loglevels.hpp>
+
 #ifndef HAVE_CPP_STDLIB
 #define HAVE_CPP_STDLIB
 #endif
@@ -216,6 +218,22 @@ class Tracing {
 
   // TODO some research needed to shutdown it gracefully
   // static void Shutdown();
+};
+
+// Used by the logger to get the trace Ids
+struct TracingExtraData : g3::ExtraData {
+  TracingExtraData()
+      : m_tracingIds{Tracing::GetActiveSpanIds()},
+        m_tracingStringIds{zil::trace::Tracing::GetActiveSpanStringIds()} {}
+
+  const auto& GetTracingIds() const noexcept { return m_tracingIds; }
+  const auto& GetTracingStringIds() const noexcept {
+    return m_tracingStringIds;
+  }
+
+ private:
+  std::optional<std::pair<TraceId, SpanId>> m_tracingIds;
+  std::optional<std::pair<std::string, std::string>> m_tracingStringIds;
 };
 
 }  // namespace zil::trace

--- a/src/libUtils/Logger.h
+++ b/src/libUtils/Logger.h
@@ -130,11 +130,17 @@ class Logger {
   };
 };
 
-std::string_view LogTracesImpl();
+std::shared_ptr<g3::ExtraData> CreateTracingExtraData();
 
-inline std::string_view LogTraces(auto level) {
-  return (g3::logLevel(level) && JSON_LOGGING) ? LogTracesImpl() : "";
-}
+#define TRACED_FILTERED_INTERNAL_LOG_MESSAGE(level, pred)                \
+  LogCapture(__FILE__, __LINE__,                                         \
+             static_cast<const char*>(__PRETTY_FUNCTION__), level, pred, \
+             CreateTracingExtraData())
+
+#define TRACED_FILTERED_LOG(level, pred) \
+  if (!g3::logLevel(level)) {            \
+  } else                                 \
+    TRACED_FILTERED_INTERNAL_LOG_MESSAGE(level, pred).stream()
 
 #define INIT_FILE_LOGGER(filePrefix, filePath) \
   Logger::GetLogger().AddGeneralSink(filePrefix, filePath);
@@ -151,13 +157,10 @@ inline std::string_view LogTraces(auto level) {
   Logger::GetLogger().AddJsonSink(filePrefix, filePath);
 
 #define LOG_STATE(msg) \
-  { FILTERED_LOG(INFO, &Logger::IsStateSink) << ' ' << msg; }
+  { TRACED_FILTERED_LOG(INFO, &Logger::IsStateSink) << ' ' << msg; }
 
-#define LOG_GENERAL(level, msg)                 \
-  {                                             \
-    FILTERED_LOG(level, &Logger::IsGeneralSink) \
-        << ' ' << msg << LogTraces(level);      \
-  }
+#define LOG_GENERAL(level, msg) \
+  { TRACED_FILTERED_LOG(level, &Logger::IsGeneralSink) << ' ' << msg; }
 
 #define LOG_MARKER() \
   Logger::ScopeMarker marker{__FILE__, __LINE__, __FUNCTION__};
@@ -167,7 +170,7 @@ inline std::string_view LogTraces(auto level) {
 
 #define LOG_EPOCH(level, epoch, msg)                                  \
   {                                                                   \
-    FILTERED_LOG(level, &Logger::IsGeneralSink)                       \
+    TRACED_FILTERED_LOG(level, &Logger::IsGeneralSink)                \
         << "[Epoch " << std::to_string(epoch).c_str() << "] " << msg; \
   }
 
@@ -175,7 +178,7 @@ inline std::string_view LogTraces(auto level) {
   {                                                                     \
     std::unique_ptr<char[]> payload_string;                             \
     Logger::GetPayloadS(payload, max_bytes_to_display, payload_string); \
-    FILTERED_LOG(level, &Logger::IsGeneralSink)                         \
+    TRACED_FILTERED_LOG(level, &Logger::IsGeneralSink)                  \
         << ' ' << msg << " (Len=" << (payload).size()                   \
         << "): " << payload_string.get()                                \
         << (((payload).size() > max_bytes_to_display) ? "..." : "");    \
@@ -186,7 +189,7 @@ inline std::string_view LogTraces(auto level) {
 
 #define LOG_EPOCHINFO(blockNum, msg)                             \
   {                                                              \
-    FILTERED_LOG(INFO, &Logger::IsEpochInfoSink)                 \
+    TRACED_FILTERED_LOG(INFO, &Logger::IsEpochInfoSink)          \
         << "[Epoch " << std::to_string(blockNum) << "] " << msg; \
   }
 

--- a/vcpkg-registry/ports/g3log/extra_data.patch
+++ b/vcpkg-registry/ports/g3log/extra_data.patch
@@ -1,0 +1,183 @@
+diff --git a/src/g3log.cpp b/src/g3log.cpp
+index 9d32ee5..870a2c9 100644
+--- a/src/g3log.cpp
++++ b/src/g3log.cpp
+@@ -157,9 +157,10 @@ namespace g3 {
+       /** explicitly copy of all input. This is makes it possibly to use g3log across dynamically loaded libraries
+       * i.e. (dlopen + dlsym)  */
+       void saveMessage(const char* entry, const char* file, int line, const char* function, const LEVELS& level,
+-                       const FilterPred& filter, const char* boolean_expression, int fatal_signal, const char* stack_trace) {
++                       const FilterPred& filter, std::shared_ptr<ExtraData> extra_data,
++                       const char* boolean_expression, int fatal_signal, const char* stack_trace) {
+          LEVELS msgLevel {level};
+-         LogMessagePtr message {std::make_unique<LogMessage>(file, line, function, msgLevel)};
++         LogMessagePtr message {std::make_unique<LogMessage>(file, line, function, msgLevel, std::move(extra_data))};
+          message.get()->write().append(entry);
+          message.get()->setExpression(boolean_expression);
+ 
+diff --git a/src/g3log/g3log.hpp b/src/g3log/g3log.hpp
+index f4617d2..65d8418 100644
+--- a/src/g3log/g3log.hpp
++++ b/src/g3log/g3log.hpp
+@@ -105,7 +105,8 @@ namespace g3 {
+ 
+       // Save the created LogMessage to any existing sinks
+       void saveMessage(const char *message, const char *file, int line, const char *function, const LEVELS &level,
+-                       const FilterPred& filter, const char *boolean_expression, int fatal_signal, const char *stack_trace);
++                       const FilterPred& filter, std::shared_ptr<ExtraData> extra_data,
++                       const char *boolean_expression, int fatal_signal, const char *stack_trace);
+ 
+       // forwards the message to all sinks
+       void pushMessageToLogger(LogMessagePtr log_entry, const FilterPred& filter);
+diff --git a/src/g3log/logcapture.hpp b/src/g3log/logcapture.hpp
+index 2a21863..df8a453 100644
+--- a/src/g3log/logcapture.hpp
++++ b/src/g3log/logcapture.hpp
+@@ -15,6 +15,7 @@
+ #include <sstream>
+ #include <cstdarg>
+ #include <csignal>
++#include <memory>
+ #ifdef _MSC_VER
+ # include <sal.h>
+ #endif
+@@ -38,7 +39,7 @@ struct LogCapture {
+     */
+    LogCapture(const char *file, const int line, const char *function, const LEVELS &level, const char *expression = "", g3::SignalType fatal_signal = SIGABRT, const char *dump = nullptr);
+ 
+-   LogCapture(const char *file, const int line, const char *function, const LEVELS &level, g3::FilterPred filter, const char *expression = "", g3::SignalType fatal_signal = SIGABRT, const char *dump = nullptr);
++   LogCapture(const char *file, const int line, const char *function, const LEVELS &level, g3::FilterPred filter, std::shared_ptr<g3::ExtraData> extra_data = {}, const char *expression = "", g3::SignalType fatal_signal = SIGABRT, const char *dump = nullptr);
+ 
+    // At destruction the message will be forwarded to the g3log worker.
+    // In the case of dynamically (at runtime) loaded libraries, the important thing to know is that
+@@ -80,6 +81,7 @@ struct LogCapture {
+    const char* _expression;
+    const g3::SignalType _fatal_signal;
+    const g3::FilterPred _filter;
++   const std::shared_ptr<g3::ExtraData> _extra_data;
+ 
+ };
+ //} // g3
+diff --git a/src/g3log/loglevels.hpp b/src/g3log/loglevels.hpp
+index 774ec61..c9e8bf4 100644
+--- a/src/g3log/loglevels.hpp
++++ b/src/g3log/loglevels.hpp
+@@ -144,6 +144,12 @@ namespace g3 {
+    struct LogMessage;
+    using FilterPred = std::function<bool (internal::SinkWrapper&, LogMessage&)>;
+ 
++   struct ExtraData
++   {
++      virtual ~ExtraData() noexcept = default;
++   };
++
++
+ #ifdef G3_DYNAMIC_LOGGING
+    // Only safe if done at initialization in a single-thread context
+    namespace only_change_at_initialization {
+diff --git a/src/g3log/logmessage.hpp b/src/g3log/logmessage.hpp
+index 83795ee..d065b81 100644
+--- a/src/g3log/logmessage.hpp
++++ b/src/g3log/logmessage.hpp
+@@ -75,7 +75,7 @@ namespace g3 {
+       LogMessage& operator=(LogMessage other);
+ 
+ 
+-      LogMessage(std::string file, const int line, std::string function, const LEVELS level);
++      LogMessage(std::string file, const int line, std::string function, const LEVELS level, std::shared_ptr<ExtraData> extra_data = {});
+ 
+       explicit LogMessage(const std::string& fatalOsSignalCrashMessage);
+       LogMessage(const LogMessage& other);
+@@ -108,7 +108,6 @@ namespace g3 {
+      void overrideLogDetailsFunc(LogDetailsFunc func) const;
+ 
+ 
+-
+       //
+       // Complete access to the raw data in case the helper functions above
+       // are not enough.
+@@ -123,6 +122,7 @@ namespace g3 {
+       LEVELS _level;
+       std::string _expression; // only with content for CHECK(...) calls
+       mutable std::string _message;
++      std::shared_ptr<ExtraData> _extra_data;
+ 
+ 
+ 
+diff --git a/src/logcapture.cpp b/src/logcapture.cpp
+index ca7d7c2..02dc94c 100644
+--- a/src/logcapture.cpp
++++ b/src/logcapture.cpp
+@@ -41,7 +41,7 @@ void g3::only_change_at_initialization::setMaxMessageSize(size_t max_size) {
+ LogCapture::~LogCapture() noexcept (false) {
+    using namespace g3::internal;
+    SIGNAL_HANDLER_VERIFY();
+-   saveMessage(_stream.str().c_str(), _file, _line, _function, _level, _filter, _expression, _fatal_signal, _stack_trace.c_str());
++   saveMessage(_stream.str().c_str(), _file, _line, _function, _level, _filter, _extra_data, _expression, _fatal_signal, _stack_trace.c_str());
+ }
+ 
+ 
+@@ -55,9 +55,9 @@ LogCapture::LogCapture(const LEVELS &level, g3::SignalType fatal_signal, const c
+  * @expression for CHECK calls
+  * @fatal_signal for failed CHECK:SIGABRT or fatal signal caught in the signal handler
+  */
+-LogCapture::LogCapture(const char *file, const int line, const char *function, const LEVELS &level, g3::FilterPred filter, const char *expression, g3::SignalType fatal_signal, const char *dump)
++LogCapture::LogCapture(const char *file, const int line, const char *function, const LEVELS &level, g3::FilterPred filter, std::shared_ptr<g3::ExtraData> extra_data, const char *expression, g3::SignalType fatal_signal, const char *dump)
+    : _file(file), _line(line), _function(function), _level(level), _expression(expression), _fatal_signal(fatal_signal),
+-     _filter(std::move(filter)) {
++     _filter(std::move(filter)), _extra_data(std::move(extra_data)) {
+ 
+    if (g3::internal::wasFatal(level)) {
+       _stack_trace = std::string{"\n*******\tSTACKDUMP *******\n"};
+@@ -67,7 +67,7 @@ LogCapture::LogCapture(const char *file, const int line, const char *function, c
+ 
+ LogCapture::LogCapture(const char *file, const int line, const char *function, const LEVELS &level,
+                        const char *expression, g3::SignalType fatal_signal, const char *dump)
+-   : LogCapture(file, line, function, level, g3::FilterPred{}, expression, fatal_signal, dump)
++   : LogCapture(file, line, function, level, g3::FilterPred{}, {}, expression, fatal_signal, dump)
+ {
+ }
+ 
+diff --git a/src/logmessage.cpp b/src/logmessage.cpp
+index e12a884..ab5ff29 100644
+--- a/src/logmessage.cpp
++++ b/src/logmessage.cpp
+@@ -153,7 +153,7 @@ namespace g3 {
+ 
+ 
+    LogMessage::LogMessage(std::string file, const int line,
+-                          std::string function, const LEVELS level)
++                          std::string function, const LEVELS level, std::shared_ptr<ExtraData> extra_data /*= {}*/)
+       : _logDetailsToStringFunc(LogMessage::DefaultLogDetailsToString)
+       , _timestamp(std::chrono::high_resolution_clock::now())
+       , _call_thread_id(std::this_thread::get_id())
+@@ -165,7 +165,8 @@ namespace g3 {
+       , _file_path(file)
+       , _line(line)
+       , _function(function)
+-      , _level(level) {
++      , _level(level)
++      , _extra_data(std::move(extra_data)) {
+    }
+ 
+ 
+@@ -184,7 +185,8 @@ namespace g3 {
+       , _function(other._function)
+       , _level(other._level)
+       , _expression(other._expression)
+-      , _message(other._message) {
++      , _message(other._message)
++      , _extra_data(other._extra_data) {
+    }
+ 
+    LogMessage::LogMessage(LogMessage&& other)
+@@ -197,7 +199,8 @@ namespace g3 {
+       , _function(std::move(other._function))
+       , _level(other._level)
+       , _expression(std::move(other._expression))
+-      , _message(std::move(other._message)) {
++      , _message(std::move(other._message))
++      , _extra_data(std::move(other._extra_data)) {
+    }
+ 
+ 

--- a/vcpkg-registry/ports/g3log/portfile.cmake
+++ b/vcpkg-registry/ports/g3log/portfile.cmake
@@ -1,6 +1,7 @@
 set(PATCHES
     0001-cxx17.patch
-    sink_filter.patch)
+    sink_filter.patch
+    extra_data.patch)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/vcpkg-registry/ports/g3log/vcpkg.json
+++ b/vcpkg-registry/ports/g3log/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "g3log",
   "version": "1.3.4",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Asynchronous logger with Dynamic Sinks (with dynamic log levels)",
   "homepage": "https://github.com/KjellKod/g3log",
   "supports": "!(uwp)"

--- a/vcpkg-registry/versions/baseline.json
+++ b/vcpkg-registry/versions/baseline.json
@@ -1,7 +1,7 @@
 {
   "default": {
     "python3": { "baseline": "3.10.5", "port-version": 6 },
-    "g3log": { "baseline": "1.3.4", "port-version": 4 },
+    "g3log": { "baseline": "1.3.4", "port-version": 5 },
     "g3sinks": { "baseline": "2.0.1", "port-version": 0 },
     "schnorr": { "baseline": "8.2.0", "port-version": 0 },
     "cryptoutils": { "baseline": "8.3.0", "port-version": 1 },

--- a/vcpkg-registry/versions/g-/g3log.json
+++ b/vcpkg-registry/versions/g-/g3log.json
@@ -3,7 +3,7 @@
     {
       "path": "$/ports/g3log",
       "version": "1.3.4",
-      "port-version": 4
+      "port-version": 5
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "g3log",
-      "version-string": "1.3.4#4"
+      "version-string": "1.3.4#5"
     },
     {
       "name": "schnorr",


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Patch g3log to be able to attach extra data to LogMessage. When logging, request the trace & span Ids at the time of logging so that they're available to every sink.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
