### PR TITLE
[master] Add funding script for testnets

### DIFF
--- a/tests/EvmAcceptanceTests/README.md
+++ b/tests/EvmAcceptanceTests/README.md
@@ -327,6 +327,14 @@ npx hardhat run scripts/Accounts.js
 npx hardhat run scripts/Accounts.js --network public_testnet
 ```
 
+When you start a testnet, your funds are initially in zil addresses, which is inconvenient.
+The following script takes the private keys you have in your hardhat config,
+and moves half of the funds at that address to the same address, but eth style.
+
+```bash
+npx hardhat run scripts/FundAccountsFromZil.ts --network testnet
+```
+
 ## Setup github pre-commit hook
 
 You may want to set up pre-commit hook to fix your code before commit by:

--- a/tests/EvmAcceptanceTests/hardhat.config.ts
+++ b/tests/EvmAcceptanceTests/hardhat.config.ts
@@ -96,6 +96,21 @@ const config: HardhatUserConfig = {
       protocolVersion: 0x41,
       miningState: false
     },
+    testnet: {
+      url: "https://devnetnh-l2api.dev.z7a.xyz",
+      websocketUrl: "wss://devnetnh-l2api.dev.z7a.xyz",
+      accounts: [
+        "db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3",
+        "e53d1c3edaffc7a7bab5418eb836cf75819a82872b4a1a0f1c7fcf5c3e020b89",
+        "db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3",
+        "e53d1c3edaffc7a7bab5418eb836cf75819a82872b4a1a0f1c7fcf5c3e020b89"
+      ],
+      chainId: 32769,
+      zilliqaNetwork: true,
+      web3ClientVersion: "Zilliqa/v8.2",
+      protocolVersion: 0x41,
+      miningState: false
+    },
     local_network: {
       url: "http://localhost:8080",
       websocketUrl: "ws://localhost:8080",

--- a/tests/EvmAcceptanceTests/scripts/FundAccountsFromZil.ts
+++ b/tests/EvmAcceptanceTests/scripts/FundAccountsFromZil.ts
@@ -13,7 +13,7 @@ async function main() {
   const VERSION = bytes.pack(hre.getZilliqaChainId(), msgVersion);
 
   const accounts: string[] = await provider.send("eth_accounts");
-  const balances = await Promise.all(
+  let balances = await Promise.all(
     accounts.map((account: string) => provider.send("eth_getBalance", [account, "latest"]))
   );
 
@@ -27,7 +27,7 @@ async function main() {
     console.log("Starting transfer...");
 
     // Get corresponding eth account
-    let ethAddr = web3.eth.accounts.privateKeyToAccount('db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3');
+    let ethAddr = web3.eth.accounts.privateKeyToAccount(element);
     let ethAddrConverted = toChecksumAddress(ethAddr.address); // Zil checksum
     let initialAccountBal = await web3.eth.getBalance(ethAddr.address);
     console.log("Account to send to (zil checksum): ", ethAddrConverted);
@@ -54,7 +54,7 @@ async function main() {
           toAddr: ethAddrConverted,
           amount: new BN(balance).div(new BN(2)), // Sending an amount in Zil (1) and converting the amount to Qa
           gasPrice: gasPrice, // Minimum gasPrice veries. Check the `GetMinimumGasPrice` on the blockchain
-          gasLimit: Long.fromNumber(50),
+          gasLimit: Long.fromNumber(2100),
         },
         false,
       ),
@@ -70,6 +70,10 @@ async function main() {
     let finalBal = await web3.eth.getBalance(ethAddr.address);
     console.log(`My new account balance is: ${finalBal}`);
   }
+
+  balances = await Promise.all(
+    accounts.map((account: string) => provider.send("eth_getBalance", [account, "latest"]))
+  );
 
   // Print balances of eth accounts before
   accounts.forEach((element, index) => {

--- a/tests/EvmAcceptanceTests/scripts/FundAccountsFromZil.ts
+++ b/tests/EvmAcceptanceTests/scripts/FundAccountsFromZil.ts
@@ -1,0 +1,85 @@
+import hre, {web3} from "hardhat";
+import clc from "cli-color";
+import { bytes, toBech32Address, toChecksumAddress, units, Zilliqa } from "@zilliqa-js/zilliqa";
+import {getAddressFromPrivateKey} from "@zilliqa-js/crypto";
+const { BN, Long } = require('@zilliqa-js/util');
+
+
+async function main() {
+  const {provider} = hre.network;
+
+  // Constants needed for zil transfer
+  const msgVersion = 1; // current msgVersion
+  const VERSION = bytes.pack(hre.getZilliqaChainId(), msgVersion);
+
+  const accounts: string[] = await provider.send("eth_accounts");
+  const balances = await Promise.all(
+    accounts.map((account: string) => provider.send("eth_getBalance", [account, "latest"]))
+  );
+
+  // Print balances of eth accounts before
+  accounts.forEach((element, index) => {
+    console.log(clc.bold("Account"), clc.green(element), clc.bold("Initial balance:"), clc.greenBright(balances[index]));
+  });
+
+  for (const element of hre.network["config"]["accounts"]) {
+    console.log("");
+    console.log("Starting transfer...");
+
+    // Get corresponding eth account
+    let ethAddr = web3.eth.accounts.privateKeyToAccount('db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3');
+    let ethAddrConverted = toChecksumAddress(ethAddr.address); // Zil checksum
+    let initialAccountBal = await web3.eth.getBalance(ethAddr.address);
+    console.log("Account to send to (zil checksum): ", ethAddrConverted);
+    console.log("Account to send to, initial balance : ", initialAccountBal);
+
+    // Transfer half funds to this account
+    let zilliqa = new Zilliqa(hre.getNetworkUrl());
+    zilliqa.wallet.addByPrivateKey(element);
+    const address = getAddressFromPrivateKey(element);
+
+    const res = await zilliqa.blockchain.getBalance(address);
+    const balance = res.result.balance;
+
+    console.log(`My ZIL account address is: ${address}`);
+    console.log(`My ZIL account balance is: ${balance}`);
+
+    const gasp = await web3.eth.getGasPrice();
+    const gasPrice = new BN(gasp);
+
+    const tx = await zilliqa.blockchain.createTransactionWithoutConfirm(
+      zilliqa.transactions.new(
+        {
+          version: VERSION,
+          toAddr: ethAddrConverted,
+          amount: new BN(balance).div(new BN(2)), // Sending an amount in Zil (1) and converting the amount to Qa
+          gasPrice: gasPrice, // Minimum gasPrice veries. Check the `GetMinimumGasPrice` on the blockchain
+          gasLimit: Long.fromNumber(50),
+        },
+        false,
+      ),
+    );
+
+    // process confirm
+    console.log(`The transaction id is:`, tx.id);
+    const confirmedTxn = await tx.confirm(tx.id);
+
+    console.log(`The transaction status is:`);
+    console.log(confirmedTxn.receipt);
+
+    let finalBal = await web3.eth.getBalance(ethAddr.address);
+    console.log(`My new account balance is: ${finalBal}`);
+  }
+
+  // Print balances of eth accounts before
+  accounts.forEach((element, index) => {
+    console.log(clc.bold("Account"), clc.green(element), clc.bold("Initial balance:"), clc.greenBright(balances[index]));
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
When you start a testnet, your funds are initially in zil addresses, which is inconvenient. This script takes the private keys you have in your hardhat config, and moves half of the funds at that address to the same address, but eth style.