### PR TITLE
[master] EM-49: Protect m_txnProcessingFinished with a mutex consistently to prevent race condition

### DIFF
--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -328,8 +328,9 @@ void Node::NotifyTimeout(bool& txnProcTimeout) {
   LOG_GENERAL(INFO, "The overall timeout for txn processing will be "
                         << timeout_time << " seconds");
   unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
-  if (cv_TxnProcFinished.wait_for(lock, chrono::seconds(timeout_time)) ==
-      cv_status::timeout) {
+  if (!cv_TxnProcFinished.wait_for(lock, chrono::seconds(timeout_time), [this] {
+        return m_txnProcessingFinished == true;
+      })) {
     txnProcTimeout = true;
     AccountStore::GetInstance().NotifyTimeoutTemp();
     m_txnProcessingFinished = true;
@@ -655,7 +656,10 @@ void Node::ProcessTransactionWhenShardBackup(
   t_processedTransactions.clear();
 
   bool txnProcTimeout = false;
-  m_txnProcessingFinished = false;
+  {
+    unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
+    m_txnProcessingFinished = false;
+  }
 
   auto txnProcTimer = [this, &txnProcTimeout]() -> void {
     NotifyTimeout(txnProcTimeout);
@@ -838,8 +842,11 @@ void Node::ProcessTransactionWhenShardBackup(
   AccountStore::GetInstance().ProcessStorageRootUpdateBufferTemp();
   AccountStore::GetInstance().CleanNewLibrariesCacheTemp();
 
-  m_txnProcessingFinished = true;
-  cv_TxnProcFinished.notify_all();
+  {
+    unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
+    m_txnProcessingFinished = true;
+    cv_TxnProcFinished.notify_all();
+  }
 
   PutTxnsInTempDataBase(t_processedTransactions);
 
@@ -1041,7 +1048,6 @@ bool Node::WaitUntilTxnProcessingDone() {
     return true;
   }
   // wait for txn processing being ready by me (backup)
-  unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
   int timeout_time =
       (m_mediator.m_ds->m_mode == DirectoryService::Mode::IDLE)
           ? std::max(0, ((int)MICROBLOCK_TIMEOUT -
@@ -1054,15 +1060,15 @@ bool Node::WaitUntilTxnProcessingDone() {
               "The overall timeout for completing txns processing will be "
                   << timeout_time << " seconds");
 
-  while (!m_txnProcessingFinished) {
-    if (cv_TxnProcFinished.wait_for(lock, chrono::seconds(timeout_time)) ==
-        std::cv_status::timeout) {
-      // timed out
-      LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
-                "Timed out waiting for txn processing being completed. May "
-                "need to adjust timeouts.");
-      return false;
-    }
+  unique_lock<mutex> lock(m_mutexCVTxnProcFinished);
+  if (!cv_TxnProcFinished.wait_for(lock, chrono::seconds(timeout_time), [this] {
+        return m_txnProcessingFinished == true;
+      })) {
+    // timed out
+    LOG_EPOCH(INFO, m_mediator.m_currentEpochNum,
+              "Timed out waiting for txn processing being completed. May "
+              "need to adjust timeouts.");
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

m_txnProcessingFinished wasn't always protected by the mutex (m_mutexCVTxnProcFinished) used by the condition variable (cv_TxnProcFinished) to check whether transaction processing had finished. In addition, waiting wasn't done properly and can be done more correctly in C++20.
This fix solves the situation where WaitUntilTxnProcessingDone() was called after the condition variable had been signaled making it wait until the next epoch, ultimately causing a crash.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
