### PR TITLE
[master] Fixing condition variables - Lookup.cpp

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -454,6 +454,7 @@ void DirectoryService::StartNextTxEpoch() {
           (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW != 0)
               ? 0
               : EXTRA_TX_DISTRIBUTE_TIME_IN_MS / 1000;
+      // TODO: cv fix
       if (cv_scheduleDSMicroBlockConsensus.wait_for(
               cv_lk, std::chrono::seconds(MICROBLOCK_TIMEOUT + extra_time)) ==
           std::cv_status::timeout) {
@@ -610,6 +611,7 @@ void DirectoryService::StartFirstTxEpoch() {
             (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW != 0)
                 ? 0
                 : EXTRA_TX_DISTRIBUTE_TIME_IN_MS / 1000;
+        // TODO: cv fix
         if (cv_scheduleDSMicroBlockConsensus.wait_for(
                 cv_lk, std::chrono::seconds(MICROBLOCK_TIMEOUT + extra_time)) ==
             std::cv_status::timeout) {
@@ -889,6 +891,7 @@ bool DirectoryService::ProcessDSBlockConsensus(
 
       std::unique_lock<std::mutex> cv_lk(m_MutexCVDSBlockConsensusObject);
 
+      // TODO: cv fix
       if (cv_DSBlockConsensusObject.wait_for(
               cv_lk, std::chrono::seconds(CONSENSUS_OBJECT_TIMEOUT)) ==
           std::cv_status::timeout) {

--- a/src/libDirectoryService/DSBlockPreProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPreProcessing.cpp
@@ -1641,6 +1641,7 @@ void DirectoryService::RunConsensusOnDSBlock() {
   // View change will wait for timeout. If conditional variable is notified
   // before timeout, the thread will return without triggering view change.
   std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeDSBlock);
+  // TODO: cv fix
   if (cv_viewChangeDSBlock.wait_for(cv_lk,
                                     std::chrono::seconds(VIEWCHANGE_TIME)) ==
       std::cv_status::timeout) {

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -1106,6 +1106,10 @@ bool DirectoryService::ProcessCosigsRewardsFromSeed(
       m_totalTxnFees += cogsrews.GetRewards();
     }
   }
+  {
+    lock_guard<mutex> lock(m_mediator.m_lookup->m_mutexSetCosigRewardsFromSeed);
+    m_mediator.m_lookup->m_setCosigRewardsFromSeedSignal = true;
+  }
   m_mediator.m_lookup->cv_setCosigRewardsFromSeed.notify_all();
 
   return true;

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -701,12 +701,15 @@ bool DirectoryService::FinishRejoinAsDS(bool fetchShardingStruct) {
 
   if (fetchShardingStruct) {
     // Ask for the sharding structure from lookup
+    {
+      std::unique_lock<std::mutex> cv_lk(m_mediator.m_lookup->m_mutexShardStruct);
+      m_mediator.m_lookup->m_shardStructSignal = false;
+    }
     m_mediator.m_lookup->ComposeAndSendGetShardingStructureFromSeed();
-    // TODO: cv fix
     std::unique_lock<std::mutex> cv_lk(m_mediator.m_lookup->m_mutexShardStruct);
-    if (m_mediator.m_lookup->cv_shardStruct.wait_for(
-            cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
-        std::cv_status::timeout) {
+    if (!m_mediator.m_lookup->cv_shardStruct.wait_for(
+            cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS),
+            [this]() { return m_mediator.m_lookup->m_shardStructSignal; })) {
       LOG_GENERAL(WARNING,
                   "Didn't receive sharding structure! Try checking next epoch");
     } else {

--- a/src/libDirectoryService/DirectoryService.cpp
+++ b/src/libDirectoryService/DirectoryService.cpp
@@ -702,6 +702,7 @@ bool DirectoryService::FinishRejoinAsDS(bool fetchShardingStruct) {
   if (fetchShardingStruct) {
     // Ask for the sharding structure from lookup
     m_mediator.m_lookup->ComposeAndSendGetShardingStructureFromSeed();
+    // TODO: cv fix
     std::unique_lock<std::mutex> cv_lk(m_mediator.m_lookup->m_mutexShardStruct);
     if (m_mediator.m_lookup->cv_shardStruct.wait_for(
             cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
@@ -793,6 +794,7 @@ void DirectoryService::StartNewDSEpochConsensus(bool isRejoin) {
     // So let's add that to our wait time to allow new nodes to get last TxBlock
     // + DSInfo and submit a PoW
     m_powSubmissionWindowExpired = false;
+    // TODO: cv fix
     if (cv_DSBlockConsensus.wait_for(
             cv_lk, std::chrono::seconds(
                        (isRejoin ? 0 : NEW_NODE_SYNC_INTERVAL) +
@@ -812,6 +814,7 @@ void DirectoryService::StartNewDSEpochConsensus(bool isRejoin) {
         DetachedFunction(1, func);
       }
 
+      // TODO: cv fix
       if (cv_DSBlockConsensus.wait_for(
               cv_lk,
               std::chrono::seconds(POWPACKETSUBMISSION_WINDOW_IN_SECONDS)) ==

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -359,6 +359,7 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
             (m_mediator.m_currentEpochNum % NUM_FINAL_BLOCK_PER_POW != 0)
                 ? 0
                 : EXTRA_TX_DISTRIBUTE_TIME_IN_MS / 1000;
+        // TODO: cv fix
         if (cv_scheduleDSMicroBlockConsensus.wait_for(
                 cv_lk, std::chrono::seconds(MICROBLOCK_TIMEOUT + extra_time)) ==
             std::cv_status::timeout) {
@@ -537,6 +538,7 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
   // It is possible for ANNOUNCE to arrive before correct DS state
   // In that case, state transition will occurs and ANNOUNCE will be processed.
   std::unique_lock<mutex> cv_lk(m_mutexProcessConsensusMessage);
+  // TODO: cv fix
   if (cv_processConsensusMessage.wait_for(
           cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW),
           [this, message, offset]() -> bool {
@@ -614,6 +616,7 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
 
       // Block till microblock is fetched
       unique_lock<mutex> lock(m_mutexCVMissingMicroBlock);
+      // TODO: cv fix
       if (cv_MissingMicroBlock.wait_for(
               lock, chrono::seconds(FETCHING_MISSING_DATA_TIMEOUT)) ==
           std::cv_status::timeout) {
@@ -642,6 +645,7 @@ bool DirectoryService::ProcessFinalBlockConsensusCore(
 
       // Block till txn is fetched
       unique_lock<mutex> lock(m_mediator.m_node->m_mutexCVMicroBlockMissingTxn);
+      // TODO: cv fix      
       if (m_mediator.m_node->cv_MicroBlockMissingTxn.wait_for(
               lock, chrono::seconds(FETCHING_MISSING_DATA_TIMEOUT)) ==
           std::cv_status::timeout) {

--- a/src/libDirectoryService/FinalBlockPreProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPreProcessing.cpp
@@ -205,6 +205,7 @@ bool DirectoryService::WaitUntilCompleteFinalBlockIsReady() {
 
   // wait for final block ( with complete microblock ) to be ready
   if (!m_completeFinalBlockReady) {
+    // TODO: cv fix
     if (m_cvCompleteFinalBlockReady.wait_for(
             lock, chrono::seconds(timeout_time)) == std::cv_status::timeout) {
       // timed out
@@ -1401,6 +1402,7 @@ void DirectoryService::RunConsensusOnFinalBlock() {
     // View change will wait for timeout. If conditional variable is notified
     // before timeout, the thread will return without triggering view change.
     std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeFinalBlock);
+    // TODO: cv fix
     if (cv_viewChangeFinalBlock.wait_for(
             cv_lk, std::chrono::seconds(VIEWCHANGE_TIME)) ==
         std::cv_status::timeout) {

--- a/src/libDirectoryService/PoWProcessing.cpp
+++ b/src/libDirectoryService/PoWProcessing.cpp
@@ -266,7 +266,7 @@ bool DirectoryService::VerifyPoWSubmission(const DSPowSolution& sol) {
 
   if (m_state == FINALBLOCK_CONSENSUS) {
     std::unique_lock<std::mutex> cv_lk(m_MutexCVPOWSubmission);
-
+    // TODO: cv fix
     if (cv_POWSubmission.wait_for(
             cv_lk, std::chrono::seconds(POW_SUBMISSION_TIMEOUT)) ==
         std::cv_status::timeout) {

--- a/src/libDirectoryService/ViewChangePreProcessing.cpp
+++ b/src/libDirectoryService/ViewChangePreProcessing.cpp
@@ -364,6 +364,7 @@ void DirectoryService::ScheduleViewChangeTimeout() {
   }
 
   std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangeVCBlock);
+  // TODO: cv fix
   if (cv_ViewChangeVCBlock.wait_for(cv_lk,
                                     std::chrono::seconds(VIEWCHANGE_TIME)) ==
       std::cv_status::timeout) {
@@ -450,6 +451,7 @@ bool DirectoryService::NodeVCPrecheck() {
   }
 
   std::unique_lock<std::mutex> cv_lk(m_MutexCVViewChangePrecheck);
+  // TODO: cv fix
   if (cv_viewChangePrecheck.wait_for(
           cv_lk, std::chrono::seconds(VIEWCHANGE_PRECHECK_TIME)) ==
       std::cv_status::timeout) {

--- a/src/libEth/filters/PendingTxnUpdater.cpp
+++ b/src/libEth/filters/PendingTxnUpdater.cpp
@@ -43,6 +43,7 @@ PendingTxnUpdater::~PendingTxnUpdater() {
 bool PendingTxnUpdater::Wait() {
   std::unique_lock lk(m_mutex);
   if (!m_stopped) {
+    // TODO: cv fix
     m_cond.wait_for(lk, UPDATE_INTERVAL);
   }
   return !m_stopped;

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -209,6 +209,7 @@ void Lookup::GetInitialBlocksAndShardingStructure() {
         LOOKUP_NODE_MODE);
     GetTxBlockFromSeedNodes(txBlockNum, 0);
     std::unique_lock<std::mutex> cv_lk(m_mutexCvSetRejoinRecovery);
+    // TODO: cv fix
     if (m_mediator.m_lookup->cv_setRejoinRecovery.wait_for(
             cv_lk, std::chrono::seconds(NEW_NODE_SYNC_INTERVAL)) !=
         std::cv_status::timeout) {
@@ -221,6 +222,7 @@ void Lookup::GetInitialBlocksAndShardingStructure() {
     // Ask for the sharding structure from lookup
     ComposeAndSendGetShardingStructureFromSeed();
     std::unique_lock<std::mutex> cv_lk(m_mutexShardStruct);
+    // TODO: cv fix
     if (cv_shardStruct.wait_for(
             cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
         std::cv_status::timeout) {
@@ -889,6 +891,7 @@ bool Lookup::GetDSBlockFromL2lDataProvider(uint64_t blockNum) {
         ComposeGetDSBlockMessageForL2l(blockNum));
 
     unique_lock<mutex> lock(m_mediator.m_lookup->m_mutexVCDSBlockProcessed);
+    // TODO: cv fix
     if (m_mediator.m_lookup->cv_vcDsBlockProcessed.wait_for(
             lock, chrono::seconds(SEED_SYNC_SMALL_PULL_INTERVAL)) ==
             std::cv_status::timeout &&
@@ -913,6 +916,7 @@ bool Lookup::GetVCFinalBlockFromL2lDataProvider(uint64_t blockNum) {
               "GetVCFinalBlockFromL2lDataProvider for block " << blockNum);
     SendMessageToRandomL2lDataProvider(getmessage);
     unique_lock<mutex> lock(m_mediator.m_lookup->m_mutexVCFinalBlockProcessed);
+    // TODO: cv fix
     if (m_mediator.m_lookup->cv_vcFinalBlockProcessed.wait_for(
             lock, chrono::seconds(SEED_SYNC_SMALL_PULL_INTERVAL)) ==
             std::cv_status::timeout &&
@@ -1598,6 +1602,7 @@ std::optional<std::vector<Transaction>> Lookup::GetDSLeaderTxnPool() {
   static constexpr const chrono::seconds GETDSLEADERTXNPOOL_TIMEOUT_IN_SECONDS{
       3};
   unique_lock<mutex> lock(m_mutexDSLeaderTxnPool);
+  // TODO: cv fix
   if (cv_dsLeaderTxnPool.wait_for(lock,
                                   GETDSLEADERTXNPOOL_TIMEOUT_IN_SECONDS) ==
       std::cv_status::timeout) {
@@ -3110,6 +3115,7 @@ bool Lookup::GetDSInfo() {
     while (!m_fetchedDSInfo) {
       LOG_EPOCH(INFO, m_mediator.m_currentEpochNum, "Waiting for DSInfo");
 
+      // TODO: cv fix
       if (cv_dsInfoUpdate.wait_for(lock,
                                    chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
           std::cv_status::timeout) {
@@ -3159,6 +3165,7 @@ bool Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
       // Get the state-delta for all txBlocks from random lookup nodes
       GetStateDeltasFromSeedNodes(lowBlockNum, highBlockNum);
       std::unique_lock<std::mutex> cv_lk(m_mutexSetStateDeltasFromSeed);
+      // TODO: cv fix
       if (cv_setStateDeltasFromSeed.wait_for(
               cv_lk, std::chrono::seconds(GETSTATEDELTAS_TIMEOUT_IN_SECONDS)) ==
           std::cv_status::timeout) {
@@ -3237,6 +3244,7 @@ bool Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
         auto txblk_num = txBlock.GetHeader().GetBlockNum();
         ComposeAndSendGetCosigsRewardsFromSeed(txblk_num);
         std::unique_lock<std::mutex> cv_lk(m_mutexSetCosigRewardsFromSeed);
+        // TODO: cv fix
         if (cv_setCosigRewardsFromSeed.wait_for(
                 cv_lk,
                 std::chrono::seconds(GETCOSIGREWARDS_TIMEOUT_IN_SECONDS)) ==
@@ -3288,6 +3296,7 @@ bool Lookup::CommitTxBlocks(const vector<TxBlock>& txBlocks) {
         // Ask for the sharding structure from lookup
         ComposeAndSendGetShardingStructureFromSeed();
         std::unique_lock<std::mutex> cv_lk(m_mutexShardStruct);
+        // TODO: cv fix
         if (cv_shardStruct.wait_for(
                 cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
             std::cv_status::timeout) {
@@ -4305,6 +4314,7 @@ void Lookup::StartSynchronization() {
     // with new sharding struct)
     ComposeAndSendGetShardingStructureFromSeed();
     std::unique_lock<std::mutex> cv_lk(m_mutexShardStruct);
+    // TODO: cv fix
     if (cv_shardStruct.wait_for(
             cv_lk, std::chrono::seconds(GETSHARD_TIMEOUT_IN_SECONDS)) ==
         std::cv_status::timeout) {
@@ -4334,6 +4344,7 @@ bool Lookup::GetDSInfoLoop() {
   while (counter <= FETCH_LOOKUP_MSG_MAX_RETRY) {
     GetDSInfoFromSeedNodes();
     unique_lock<mutex> lk(m_mutexDSInfoUpdation);
+    // TODO: cv fix
     if (cv_dsInfoUpdate.wait_for(lk, chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
         cv_status::timeout) {
       counter++;

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -124,6 +124,7 @@ class Lookup : public Executable {
   // Get StateDeltas from seed
   std::mutex m_mutexSetStateDeltasFromSeed;
   std::condition_variable cv_setStateDeltasFromSeed;
+  bool m_setStateDeltasFromSeedSignal;
 
   // TxBlockBuffer
   std::vector<TxBlock> m_txBlockBuffer;

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -191,6 +191,7 @@ class Lookup : public Executable {
 
   std::mutex m_mutexShardStruct;
   std::condition_variable cv_shardStruct;
+  bool m_shardStructSignal;
 
   void ComposeAndSendGetShardingStructureFromSeed();
 

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -530,6 +530,7 @@ class Lookup : public Executable {
   // Get cosigrewards from seed
   std::mutex m_mutexSetCosigRewardsFromSeed;
   std::condition_variable cv_setCosigRewardsFromSeed;
+  bool m_setCosigRewardsFromSeedSignal;
 
   // Seed rejoin recovery
   std::mutex m_mutexCvSetRejoinRecovery;

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -581,6 +581,7 @@ class Lookup : public Executable {
   std::mutex m_mutexDSLeaderTxnPool;
   std::condition_variable cv_dsLeaderTxnPool;
   std::vector<Transaction> m_dsLeaderTxnPool;
+  bool m_dsLeaderTxnPoolSignal = false;
 
   // exit trigger
   std::atomic<bool> m_exitPullThread{};

--- a/src/libLookup/Lookup.h
+++ b/src/libLookup/Lookup.h
@@ -532,6 +532,7 @@ class Lookup : public Executable {
   // Seed rejoin recovery
   std::mutex m_mutexCvSetRejoinRecovery;
   std::condition_variable cv_setRejoinRecovery;
+  std::atomic<bool> m_rejoinRecoverySignal{false};
 
   // Enable/Disable jsonrpc port
   std::mutex m_mutexJsonRpc;

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1006,6 +1006,7 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
              (m_state == MICROBLOCK_CONSENSUS ||
               m_state == MICROBLOCK_CONSENSUS_PREP)) {
       std::unique_lock<mutex> cv_lk(m_MutexCVFBWaitMB);
+      // TODO: cv fix
       if (cv_FBWaitMB.wait_for(
               cv_lk, std::chrono::seconds(CONSENSUS_MSG_ORDER_BLOCK_WINDOW)) ==
           std::cv_status::timeout) {

--- a/src/libNode/MicroBlockPostProcessing.cpp
+++ b/src/libNode/MicroBlockPostProcessing.cpp
@@ -342,6 +342,7 @@ bool Node::ProcessMicroBlockConsensusCore(
 
       // Block till txn is fetched
       unique_lock<mutex> lock(m_mutexCVMicroBlockMissingTxn);
+      // TODO: cv fix
       if (cv_MicroBlockMissingTxn.wait_for(
               lock, chrono::seconds(FETCHING_MISSING_DATA_TIMEOUT)) ==
           std::cv_status::timeout) {

--- a/src/libNode/MicroBlockPreProcessing.cpp
+++ b/src/libNode/MicroBlockPreProcessing.cpp
@@ -1080,6 +1080,7 @@ bool Node::WaitUntilCompleteMicroBlockIsReady() {
                   << timeout_time << " seconds");
 
   if (!m_completeMicroBlockReady) {
+    // TODO: cv verify
     if (m_cvCompleteMicroBlockReady.wait_for(
             lock, chrono::seconds(timeout_time)) == std::cv_status::timeout) {
       // timed out

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -795,6 +795,7 @@ void Node::WaitForNextTwoBlocksBeforeRejoin() {
     do {
       m_mediator.m_lookup->GetTxBlockFromSeedNodes(
           m_mediator.m_txBlockChain.GetBlockCount(), 0);
+    // TODO: cv fix
     } while (m_mediator.m_lookup->cv_setTxBlockFromSeed.wait_for(
                  lock, chrono::seconds(RECOVERY_SYNC_TIMEOUT)) ==
              cv_status::timeout);
@@ -1002,6 +1003,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
             m_mediator.m_txBlockChain.GetBlockCount(), 0);
         LOG_GENERAL(INFO,
                     "Retrieve final block from lookup node, please wait...");
+        // TODO: cv fix
       } while (m_mediator.m_lookup->cv_setTxBlockFromSeed.wait_for(
                    lock, chrono::seconds(RECOVERY_SYNC_TIMEOUT)) ==
                cv_status::timeout);
@@ -1030,6 +1032,7 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         LOG_GENERAL(INFO,
                     "Retrieve final block state delta from lookup node, please "
                     "wait...");
+        // TODO: cv fix
       } while (m_mediator.m_lookup->cv_setStateDeltaFromSeed.wait_for(
                    lock, chrono::seconds(RECOVERY_SYNC_TIMEOUT)) ==
                cv_status::timeout);
@@ -1379,6 +1382,7 @@ bool Node::GetOfflineLookups(bool endless) {
     {
       unique_lock<mutex> lock(
           m_mediator.m_lookup->m_mutexOfflineLookupsUpdation);
+      // TODO: cv fix
       if (m_mediator.m_lookup->cv_offlineLookups.wait_for(
               lock, chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
           std::cv_status::timeout) {

--- a/src/libNode/PoWProcessing.cpp
+++ b/src/libNode/PoWProcessing.cpp
@@ -62,6 +62,7 @@ bool Node::GetLatestDSBlock() {
     {
       unique_lock<mutex> lock(
           m_mediator.m_lookup->m_mutexLatestDSBlockUpdation);
+      // TODO: cv fix
       if (m_mediator.m_lookup->cv_latestDSBlock.wait_for(
               lock, chrono::seconds(NEW_NODE_SYNC_INTERVAL)) ==
           std::cv_status::timeout) {
@@ -162,6 +163,7 @@ bool Node::StartPoW(const uint64_t& block_num, uint8_t ds_difficulty,
       const unsigned int fixedDSBlockDistributionDelayTime =
           DELAY_FIRSTXNEPOCH_IN_MS / 1000;
       const unsigned int extraWaitTime = DSBLOCK_EXTRA_WAIT_TIME;
+      // TODO: cv fix
       if (cv_waitDSBlock.wait_for(
               lk, chrono::seconds(fixedDSNodesPoWTime +
                                   fixedDSBlockDistributionDelayTime +

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -59,6 +59,7 @@ bool Retriever::RetrieveTxBlocks() {
             m_mediator.m_lookup->m_mutexSetStateDeltaFromSeed);
         m_mediator.m_lookup->m_skipAddStateDeltaToAccountStore = true;
         m_mediator.m_lookup->GetStateDeltaFromSeedNodes(blockNum);
+        // TODO: cv fix
         if (m_mediator.m_lookup->cv_setStateDeltaFromSeed.wait_for(
                 cv_lk,
                 std::chrono::seconds(GETSTATEDELTAS_TIMEOUT_IN_SECONDS)) ==


### PR DESCRIPTION
## Description

The goal is to fix the ubiquitious error in using condition variables, where the condition is not being checked before waiting itself, which results into the recepient never aware that the message has arrived, in case it had arrived quickly.

This will be a sequence of PRs, so that the blast radius of each is limited.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
