### PR TITLE
[master] Networking fix

### DIFF
--- a/.github/workflows/ci-image-dev.yml
+++ b/.github/workflows/ci-image-dev.yml
@@ -52,6 +52,6 @@ jobs:
       run: DOCKER_BUILDKIT=1 docker build -t ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }} -f docker/Dockerfile .
       shell: bash
     - name: Push Docker images
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.ref_name == 'master'
       run: docker push ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }}
       shell: bash

--- a/.github/workflows/ci-image-dev.yml
+++ b/.github/workflows/ci-image-dev.yml
@@ -52,6 +52,6 @@ jobs:
       run: DOCKER_BUILDKIT=1 docker build -t ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }} -f docker/Dockerfile .
       shell: bash
     - name: Push Docker images
-      if: github.event_name == 'pull_request' || github.ref_name == 'master'
+      if: github.event_name == 'pull_request'
       run: docker push ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }}
       shell: bash

--- a/.github/workflows/ci-image-dev.yml
+++ b/.github/workflows/ci-image-dev.yml
@@ -10,9 +10,6 @@ on:
   push:
     branches-ignore:
       - 'release/**'
-  pull_request:
-    branches:
-      - 'master'
 
 jobs:
   push-to-ecr:
@@ -52,6 +49,5 @@ jobs:
       run: DOCKER_BUILDKIT=1 docker build -t ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }} -f docker/Dockerfile .
       shell: bash
     - name: Push Docker images
-      if: github.event_name == 'pull_request' || github.ref_name == 'master'
       run: docker push ${{ secrets.AWS_ACCOUNT_ID_ZILLIQA }}.dkr.ecr.${{ secrets.AWS_REGION_ZILLIQA }}.amazonaws.com/zilliqa:${{ steps.set-tag.outputs.tag }}
       shell: bash

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ The Zilliqa client works together with Scilla for executing smart contracts. Ple
 | **Development discussion (discord)** | <a href="https://discord.gg/XMRE9tt" target="_blank"><img src="https://img.shields.io/discord/370992535725932544.svg" /></a> |
 | **Bug report** | <a href="https://github.com/Zilliqa/zilliqa/issues" target="_blank"><img src="https://img.shields.io/github/issues/Zilliqa/zilliqa.svg" /></a> |
 | **Security contact** | `security` :globe_with_meridians: `zilliqa.com` |
-| **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> |
+| **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> | 

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ The Zilliqa client works together with Scilla for executing smart contracts. Ple
 | **Development discussion (discord)** | <a href="https://discord.gg/XMRE9tt" target="_blank"><img src="https://img.shields.io/discord/370992535725932544.svg" /></a> |
 | **Bug report** | <a href="https://github.com/Zilliqa/zilliqa/issues" target="_blank"><img src="https://img.shields.io/github/issues/Zilliqa/zilliqa.svg" /></a> |
 | **Security contact** | `security` :globe_with_meridians: `zilliqa.com` |
-| **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> | 
+| **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> |

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -55,6 +55,93 @@ const unsigned int GOSSIP_MSGTYPE_LEN = 1;
 const unsigned int GOSSIP_ROUND_LEN = 4;
 const unsigned int GOSSIP_SNDR_LISTNR_PORT_LEN = 4;
 
+namespace zil {
+namespace local {
+
+class P2PVariables {
+  std::atomic<int> broadcastReceived = 0;
+  std::atomic<int> gossipReceived = 0;
+  std::atomic<int> normalReceived = 0;
+  std::atomic<int> gossipReceivedForward = 0;
+  std::atomic<int> eventCallback = 0;
+  std::atomic<int> eventCallbackTooFewBytes = 0;
+  std::atomic<int> eventCallbackFailure = 0;
+  std::atomic<int> eventCallbackServerSeed = 0;
+  std::atomic<int> newConnections = 0;
+
+ public:
+  std::unique_ptr<Z_I64GAUGE> temp;
+
+  void AddBroadcastReceived(int count) {
+    Init();
+    broadcastReceived += count;
+  }
+
+  void AddGossipReceived(int count) {
+    Init();
+    gossipReceived += count;
+  }
+
+  void AddNormalReceived(int count) {
+    Init();
+    normalReceived += count;
+  }
+
+  void AddGossipReceivedForward(int count) {
+    Init();
+    gossipReceivedForward += count;
+  }
+
+  void AddEventCallback(int count) {
+    Init();
+    eventCallback += count;
+  }
+
+  void AddEventCallbackTooFewBytes(int count) {
+    Init();
+    eventCallbackTooFewBytes += count;
+  }
+
+  void AddEventCallbackFailure(int count) {
+    Init();
+    eventCallbackFailure += count;
+  }
+
+  void AddEventCbServerSeed(int count) {
+    Init();
+    eventCallbackServerSeed += count;
+  }
+
+  void AddNewConnections(int count) {
+    Init();
+    newConnections += count;
+  }
+
+  void Init() {
+    if (!temp) {
+      temp = std::make_unique<Z_I64GAUGE>(Z_FL::BLOCKS, "p2p.gauge",
+                                          "P2P metrics", "calls", true);
+
+      temp->SetCallback([this](auto&& result) {
+        result.Set(broadcastReceived.load(), {{"counter", "BroadcastReceived"}});
+        result.Set(gossipReceived.load(), {{"counter", "GossipReceived"}});
+        result.Set(normalReceived.load(), {{"counter", "NormalReceived"}});
+        result.Set(gossipReceivedForward.load(), {{"counter", "GossipReceivedForward"}});
+        result.Set(eventCallback.load(), {{"counter", "EventCallback"}});
+        result.Set(eventCallbackTooFewBytes.load(), {{"counter", "EventCallbackTooFewBytes"}});
+        result.Set(eventCallbackFailure.load(), {{"counter", "EventCallbackFailure"}});
+        result.Set(eventCallbackServerSeed.load(), {{"counter", "EventCallbackServerSeed"}});
+        result.Set(newConnections.load(), {{"counter", "NewConnections"}});
+      });
+    }
+  }
+};
+
+static P2PVariables variables{};
+
+}  // namespace local
+}  // namespace zil
+
 zil::p2p::Dispatcher P2PComm::m_dispatcher;
 std::mutex P2PComm::m_mutexPeerConnectionCount;
 std::map<uint128_t, uint16_t> P2PComm::m_peerConnectionCount;
@@ -143,6 +230,7 @@ void P2PComm::ProcessBroadCastMsg(zbytes& message, zbytes& hash,
 
   // Check if this message has been received before
   bool found = false;
+  zil::local::variables.AddBroadcastReceived(1);
   {
     lock_guard<mutex> guard(p2p.m_broadcastHashesMutex);
 
@@ -187,6 +275,8 @@ void P2PComm::ProcessBroadCastMsg(zbytes& message, zbytes& hash,
                                           std::string& traceInfo) {
   unsigned char gossipMsgTyp = message.at(0);
 
+  zil::local::variables.AddGossipReceived(1);
+
   const uint32_t gossipMsgRound = (message.at(GOSSIP_MSGTYPE_LEN) << 24) +
                                   (message.at(GOSSIP_MSGTYPE_LEN + 1) << 16) +
                                   (message.at(GOSSIP_MSGTYPE_LEN + 2) << 8) +
@@ -207,6 +297,7 @@ void P2PComm::ProcessBroadCastMsg(zbytes& message, zbytes& hash,
   P2PComm& p2p = P2PComm::GetInstance();
   if (gossipMsgTyp == (uint8_t)RRS::Message::Type::FORWARD) {
     LOG_GENERAL(INFO, "Gossip type FORWARD from " << from);
+    zil::local::variables.AddGossipReceivedForward(1);
 
     if (p2p.SpreadForeignRumor(rumor_message)) {
       // skip the keys and signature.
@@ -317,6 +408,8 @@ void P2PComm::ClearPeerConnectionCount() {
 
 void P2PComm::EventCallback(struct bufferevent* bev, short events,
                             [[gnu::unused]] void* ctx) {
+
+  zil::local::variables.AddEventCallback(1);
   struct AutoClose {
     ~AutoClose() {
       if (bev) {
@@ -355,6 +448,7 @@ void P2PComm::EventCallback(struct bufferevent* bev, short events,
   if (len < zil::p2p::HDR_LEN) {
     // not enough bytes received, wait for the next callback
     auto_close.bev = nullptr;
+    zil::local::variables.AddEventCallbackTooFewBytes(1);
     return;
   }
 
@@ -396,6 +490,7 @@ void P2PComm::EventCallback(struct bufferevent* bev, short events,
     LOG_PAYLOAD(INFO, "Incoming normal " << from, result.message,
                 Logger::MAX_BYTES_TO_DISPLAY);
 
+    zil::local::variables.AddNormalReceived(1);
     // Queue the message
     m_dispatcher(MakeMsg(std::move(result.message), from,
                          zil::p2p::START_BYTE_NORMAL, result.traceInfo));
@@ -419,18 +514,21 @@ void P2PComm::EventCallback(struct bufferevent* bev, short events,
           "Gossip Msg Type and/or Gossip Round and/or SNDR LISTNR is missing "
           "(messageLength = "
               << result.message.size() << ")");
+      zil::local::variables.AddEventCallbackFailure(1);
       return;
     }
 
     ProcessGossipMsg(result.message, from, result.traceInfo);
   } else {
     // Unexpected start byte. Drop this message
+    zil::local::variables.AddEventCallbackFailure(1);
     LOG_GENERAL(WARNING, "Incorrect start byte " << result.startByte);
   }
 }
 
 void P2PComm::EventCbServerSeed(struct bufferevent* bev, short events,
                                 [[gnu::unused]] void* ctx) {
+  zil::local::variables.AddEventCbServerSeed(1);
   int fd = bufferevent_getfd(bev);
   struct sockaddr_in cli_addr {};
   socklen_t addr_size = sizeof(struct sockaddr_in);
@@ -618,6 +716,7 @@ void P2PComm::AcceptConnectionCallback([[gnu::unused]] evconnlistener* listener,
   Peer from(uint128_t(((struct sockaddr_in*)cli_addr)->sin_addr.s_addr),
             ((struct sockaddr_in*)cli_addr)->sin_port);
 
+  zil::local::variables.AddNewConnections(1);
   LOG_GENERAL(DEBUG, "Connection from " << from);
 
   if (Blacklist::GetInstance().Exist(from.m_ipAddress,
@@ -990,7 +1089,7 @@ void P2PComm::EnableListener(uint32_t listenPort, bool startSeedNodeListener) {
 
   struct evconnlistener* listener1 = evconnlistener_new_bind(
       m_base, AcceptConnectionCallback, nullptr,
-      LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, -1,
+      LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 1024,
       (struct sockaddr*)&serv_addr, sizeof(struct sockaddr_in));
   if (listener1 == NULL) {
     LOG_GENERAL(FATAL, "evconnlistener_new_bind failure.");
@@ -1007,7 +1106,7 @@ void P2PComm::EnableListener(uint32_t listenPort, bool startSeedNodeListener) {
     serv_addr.sin_addr.s_addr = INADDR_ANY;
     listener2 = evconnlistener_new_bind(
         m_base, AcceptCbServerSeed, nullptr,
-        LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, -1,
+        LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 1024,
         (struct sockaddr*)&serv_addr, sizeof(struct sockaddr_in));
 
     if (listener2 == NULL) {


### PR DESCRIPTION
During testing of a rehearsal network, it would fail to generate microblocks for the shard of normals.

This was during a period of the consensus where normals would respond to the leader with a direct message (as opposed to the rumor system which is used to propagate the first step in consensus which is sharing the proposed microblock).

High rates of network timeout/failure were observed, and the peer queue would be ~200. The issue was determined to be that the backlog parameter in `evconnlistener_new_bind` defaults to 128 (the backlog of allowed pending connections), which is less than the 519 connections the leader would have to recieve at this point. This made it such that it could not be replicated on smaller networks as they wouldn't get to this network limit.