### PR TITLE
[master] (fix) ZIL-5144: Don't send Scilla contract creation to ARCHIVAL_SEND_…

### DIFF
--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -2391,7 +2391,9 @@ std::pair<std::string, unsigned int> LookupServer::CheckContractTxnShards(
   if (!tx.IsEth() && scType == Transaction::CONTRACT_CREATION) {
     // Scilla smart CONTRACT_CREATION call should be executed in shard rather
     // than DS.
-    mapIndex = SEND_TYPE::ARCHIVAL_SEND_SHARD;
+    if (ARCHIVAL_LOOKUP) {
+      mapIndex = SEND_TYPE::ARCHIVAL_SEND_SHARD;
+    }
     resultStr = "Contract Creation txn, sent to shard";
   } else {
     // CONTRACT_CALL - scilla and EVM , CONTRACT_CREATION - EVM


### PR DESCRIPTION
…SHARD unless you are actually a lookup or archival node.

## Description

Fix ZIL-5144.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion

Check that the logic is correct - please be careful; this is my first PR which touches actual logic and I'm far from sure I have it right - the only evidence I have is traces and the fact that my trivial deploy-a-Scilla-contract test works with this patch, and fails without it.

