### PR TITLE
[master] ZIL-5168: Misc fixes.

### DIFF
--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -444,7 +444,12 @@ def sanitise_output(some_output):
     if some_output is None:
         return None
     else:
-        return some_output.decode('utf-8').strip()
+        try:
+            return some_output.decode('utf-8').strip()
+        except:
+            # Not UTF-8! Let's try latin-1 as a random codec that accepts
+            # any code sequence.
+            return some_output.decode('latin_1').strip()
 
 def get_mitm_instances(testnet_name):
     return { "explorer" : { "host" : f"{testnet_name}-explorer.localdomain", "port" : 5300 },

--- a/tests/EvmAcceptanceTests/hardhat.config.ts
+++ b/tests/EvmAcceptanceTests/hardhat.config.ts
@@ -125,7 +125,22 @@ const config: HardhatUserConfig = {
       protocolVersion: 0x41,
       zilliqaNetwork: true,
       miningState: false
-    }
+    },
+    localdev: {
+      url: "http://localhost:5301",
+      websocketUrl: "ws://localhost:5301",
+      accounts: [
+        "d96e9eb5b782a80ea153c937fa83e5948485fbfc8b7e7c069d7b914dbc350aba",
+        "589417286a3213dceb37f8f89bd164c3505a4cec9200c61f7c6db13a30a71b45",
+        "e7f59a4beb997a02a13e0d5e025b39a6f0adc64d37bb1e6a849a4863b4680411",
+        "410b0e0a86625a10c554f8248a77c7198917bd9135c15bb28922684826bb9f14"
+      ],
+      chainId: 0x8001,
+      web3ClientVersion: "Zilliqa/v8.2",
+      protocolVersion: 0x41,
+      zilliqaNetwork: true,
+      miningState: false
+    },
   },
   mocha: {
     timeout: ENV_VARS.mochaTimeout,


### PR DESCRIPTION
## Description

Add localdev to hardhat.config.ts, and let localdev cope with non-utf-8 logs.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion

Reading the code should do, but feel free to try it if you really want!
