### PR TITLE
[release/v8.9] Zil 5176 : Allow node to sync if not in shard

### DIFF
--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -706,6 +706,7 @@ bool Node::ProcessVCDSBlocksMessage(
       // Finally, start as a shard node
       StartFirstTxEpoch();
     }
+    m_allowRecoveryAllSync = false;
   } else {
     // Process sharding structure as a lookup node
     m_mediator.m_lookup->ProcessEntireShardingStructure();

--- a/src/libNode/Node.cpp
+++ b/src/libNode/Node.cpp
@@ -1113,7 +1113,6 @@ bool Node::StartRetrieveHistory(const SyncType syncType,
         m_mediator.m_ds->m_mapNodeReputation);
   }
   bool rejoinCondition = REJOIN_NODE_NOT_IN_NETWORK && !LOOKUP_NODE_MODE && !bDS;
-  LOG_GENERAL(INFO, "rejoinCondition = "<< rejoinCondition); //TODO: remove this log before merge
 
   if (rejoinCondition && bIpChanged) {
     LOG_GENERAL(

--- a/src/libNode/Node.h
+++ b/src/libNode/Node.h
@@ -547,6 +547,8 @@ class Node : public Executable {
   mutable std::mutex m_mutexPending;
   std::map<TxnHash, Transaction> m_pendingTxns;
 
+  std::atomic<bool> m_allowRecoveryAllSync{false};
+
   /// Constructor. Requires mediator reference to access DirectoryService and
   /// other global members.
   Node(Mediator& mediator, unsigned int syncType, bool toRetrieveHistory);


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

 If a node is not a part of the shard, we should allow it to sync after reading complete persistence. So at a point where the node determines that it is not part of the shard, we called the `StartSynchronization` function. The `StartSynchronization` function allows the node to perform normal sync with the network i.e fetch block one by one. I have to introduce `m_allowRecoveryAllSync` to make sure that the code does not change the node's state anytime. When the POW window is reached, the node attempts to perform POW and if it joins the network successfully then it gets ProcessVCDSBlocksMessage  where I reset the variable m_allowRecoveryAllSync






## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
