### PR TITLE
[master] ZIL-5145: Treat `TIMED_OUT` as a transient error

### DIFF
--- a/src/libNetwork/SendJobs.cpp
+++ b/src/libNetwork/SendJobs.cpp
@@ -112,11 +112,11 @@ inline bool IsBlacklisted(const Peer& peer, bool allow_relaxed_blacklist) {
 }
 
 inline bool IsHostHavingNetworkIssue(const ErrorCode& ec) {
-  return (ec == HOST_UNREACHABLE || ec == TIMED_OUT || ec == NETWORK_DOWN ||
+  return (ec == HOST_UNREACHABLE || ec == NETWORK_DOWN ||
           ec == NETWORK_UNREACHABLE);
 }
 
-inline bool IsNodeNotRunning(const ErrorCode& ec) { return ec == CONN_REFUSED; }
+inline bool IsNodeNotRunning(const ErrorCode& ec) { return (ec == TIMED_OUT || ec == CONN_REFUSED); }
 
 inline Milliseconds Clock() {
   return std::chrono::duration_cast<Milliseconds>(


### PR DESCRIPTION
Previously we treated it as a permanent error. This meant nodes could get strictly blacklisted during the startup of the network.