### PR TITLE
[master] ZIL-5126: A GetVersion endpoint.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,11 @@ find_package(CryptoUtils REQUIRED)
 include_directories(${SCHNORR_INCLUDE_DIR}/include)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
+if (COMMIT_ID)
+   message(STATUS "Commit ID included")
+   add_definitions(-DCOMMIT_ID=${COMMIT_ID})
+endif()
+
 if(OPENCL_MINE)
     message(STATUS "OpenCL enabled")
     find_package(OpenCL REQUIRED)

--- a/build.sh
+++ b/build.sh
@@ -79,6 +79,14 @@ build_type="RelWithDebInfo"
 ./scripts/ci_xml_checker.sh constants_local.xml
 if [ "$OS" != "osx" ]; then ./scripts/depends/check_guard.sh; fi
 
+# Find the git tag if we can and include it so we can report it in our GetVersion call
+commit_id=`git rev-parse HEAD | cut -c -8`
+is_modified=`git status --porcelain=v1 2>/dev/null | wc -l`
+if [ $is_modified != 0 ]; then
+    commit_id="${commit_id}+"
+fi
+CMAKE_EXTRA_OPTIONS="-DCOMMIT_ID=\"${commit_id}\" ${CMAKE_EXTRA_OPTIONS}"
+
 for option in "$@"
 do
     case $option in

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -129,6 +129,9 @@ IsolatedServer::IsolatedServer(Mediator& mediator,
       jsonrpc::Procedure("GetRecentTransactions", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_OBJECT, NULL),
       &LookupServer::GetRecentTransactionsI);
+  AbstractServer<IsolatedServer>::bindAndAddMethod(
+      jsonrpc::Procedure("GetVersion", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT, NULL),
+      &Server::GetVersionI);
 
   if (timeDelta > 0) {
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/src/libServer/LookupServer.cpp
+++ b/src/libServer/LookupServer.cpp
@@ -322,6 +322,10 @@ LookupServer::LookupServer(Mediator& mediator,
                          "param02", jsonrpc::JSON_STRING, "param03",
                          jsonrpc::JSON_STRING, NULL),
       &LookupServer::GetStateProofI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("GetVersion", jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_OBJECT,
+                         NULL),
+      &Server::GetVersionI);
 
   m_StartTimeTx = 0;
   m_StartTimeDs = 0;
@@ -2357,6 +2361,7 @@ Json::Value LookupServer::GetStateProof(const string& address,
 
   return ret;
 }
+
 
 std::pair<std::string, unsigned int> LookupServer::CheckContractTxnShards(
     bool priority, unsigned int shard, const Transaction& tx,

--- a/src/libServer/Server.cpp
+++ b/src/libServer/Server.cpp
@@ -22,6 +22,7 @@
 #include "libNode/Node.h"
 #include "libUtils/Logger.h"
 #include "libUtils/TimeUtils.h"
+#include "libUtils/SWInfo.h"
 
 using namespace jsonrpc;
 using namespace std;
@@ -65,4 +66,22 @@ uint8_t Server::GetPrevDSDifficulty() {
 
 uint8_t Server::GetPrevDifficulty() {
   return m_mediator.m_dsBlockChain.GetLastBlock().GetHeader().GetDifficulty();
+}
+
+Json::Value Server::GetVersion() {
+  LOG_MARKER();
+  // GetVersion can be sent to any kind of node.
+  try {
+    Json::Value _json;
+    _json["Version"] = VERSION_TAG;
+#if defined(COMMIT_ID)
+    _json["Commit"] = COMMIT_ID;
+#endif
+    return _json;
+  } catch (const JsonRpcException& je) {
+    throw je;
+  } catch (exception& e) {
+    LOG_GENERAL(INFO, "[Error]" << e.what());
+    throw JsonRpcException(RPC_MISC_ERROR, "Unable to process");
+  }
 }

--- a/src/libServer/Server.h
+++ b/src/libServer/Server.h
@@ -92,10 +92,16 @@ class Server : public ServerBase {
     (void)request;
     response = this->GetPrevDifficulty();
   }
+  inline virtual void GetVersionI(const Json::Value& request,
+                                    Json::Value& response) {
+    (void)request;
+    response = this->GetVersion();
+  }
 
   virtual std::string GetCurrentMiniEpoch();
   virtual std::string GetCurrentDSEpoch();
   virtual std::string GetNodeType();
+  virtual Json::Value GetVersion();
   virtual uint8_t GetPrevDSDifficulty();
   virtual uint8_t GetPrevDifficulty();
 };

--- a/src/libServer/StatusServer.cpp
+++ b/src/libServer/StatusServer.cpp
@@ -199,6 +199,9 @@ StatusServer::StatusServer(Mediator& mediator,
       jsonrpc::Procedure("DisableJsonRpcPort", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_OBJECT, NULL),
       &StatusServer::DisableJsonRpcPortI);
+  this->bindAndAddMethod(
+      jsonrpc::Procedure("GetVersion", jsonrpc::PARAMS_BY_POSITION, NULL),
+      &Server::GetVersionI);
 }
 
 string StatusServer::GetLatestEpochStatesUpdated() {


### PR DESCRIPTION
## Description

This PR provides a simple `GetVersion` endpoint for all Zilliqa servers which tells you the version number specified in the code, and the commit id you were running. You may want to NAK the commit-id, since it does require additions to `build.sh` which may be annoying for some.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion

Please make sure it works (particularly on various flavours of OS X - I'm afraid my branches are in too hectic a state to really know), check that you are happy with the output format, and look over the source.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
