### PR TITLE
[master] ZIL-5185: Increase libevent queue to 4096

### DIFF
--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -1089,7 +1089,7 @@ void P2PComm::EnableListener(uint32_t listenPort, bool startSeedNodeListener) {
 
   struct evconnlistener* listener1 = evconnlistener_new_bind(
       m_base, AcceptConnectionCallback, nullptr,
-      LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 1024,
+      LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 4096,
       (struct sockaddr*)&serv_addr, sizeof(struct sockaddr_in));
   if (listener1 == NULL) {
     LOG_GENERAL(FATAL, "evconnlistener_new_bind failure.");
@@ -1106,7 +1106,7 @@ void P2PComm::EnableListener(uint32_t listenPort, bool startSeedNodeListener) {
     serv_addr.sin_addr.s_addr = INADDR_ANY;
     listener2 = evconnlistener_new_bind(
         m_base, AcceptCbServerSeed, nullptr,
-        LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 1024,
+        LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, 4096,
         (struct sockaddr*)&serv_addr, sizeof(struct sockaddr_in));
 
     if (listener2 == NULL) {


### PR DESCRIPTION
This wasn't the cause of the bug, but it also didn't cause any problems so we think its safest to raise the value. The mainnet network is larger than the rehearsal, so the queue may need to be larger to handle the extra traffic.