### PR TITLE
[master] MVP-5173: Install `pigz` in `Dockerfile.lite`

### DIFF
--- a/docker/Dockerfile.lite
+++ b/docker/Dockerfile.lite
@@ -50,6 +50,7 @@ RUN apt-get update \
     nload \
     ocl-icd-opencl-dev \
     openssh-client \
+    pigz \
     pkg-config \
     python3-dev \
     python3-pip \


### PR DESCRIPTION
This means nodes can download and unzip persistence.
