### PR TITLE
Delegate call fix so gets current context

### DIFF
--- a/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
+++ b/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
@@ -6,15 +6,16 @@ contract TestDelegatecall {
     uint public value;
     uint public num;
 
-    event A(string message);
+    event DebugMsg(string message);
 
     function setVars(uint _num) external payable {
 
-        emit A("we are here 0");
+        emit DebugMsg("Setting vars!");
+
         require(value == 9, "Didn't reflect variables from calling contract correctly");
-        emit A("we are here 1");
         require(num == 10, "Didn't reflect variables from calling contract correctly");
-        emit A("we are here 2");
+
+        emit DebugMsg("Vars are OK");
 
         sender = msg.sender;
         value = msg.value;
@@ -27,7 +28,7 @@ contract Delegatecall {
     uint public value;
     uint public num;
 
-    event A(string message);
+    event DebugMsg(string message);
 
     function setVars(address _test, uint _num) external payable {
 
@@ -38,13 +39,13 @@ contract Delegatecall {
         require(num == 10, "cannot set own variables correctly(num)");
 
 
-        emit A("making the call...");
+        emit DebugMsg("making the call...");
 
         (bool success, bytes memory data) = _test.delegatecall(
             abi.encodeWithSelector(TestDelegatecall.setVars.selector, _num)
         );
 
-        emit A("making the call... done.");
+        emit DebugMsg("making the call... done.");
 
         if (success) {
             emit A("this was a success");
@@ -54,4 +55,4 @@ contract Delegatecall {
 
         require(success, "delegatecall failed");
     }
-}
+

--- a/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
+++ b/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
@@ -55,4 +55,4 @@ contract Delegatecall {
 
         require(success, "delegatecall failed");
     }
-
+}

--- a/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
+++ b/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
@@ -48,9 +48,9 @@ contract Delegatecall {
         emit DebugMsg("making the call... done.");
 
         if (success) {
-            emit A("this was a success");
+            emit DebugMsg("this was a success");
         } else {
-            emit A("this was a failure");
+            emit DebugMsg("this was a failure");
         }
 
         require(success, "delegatecall failed");

--- a/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
+++ b/tests/EvmAcceptanceTests/contracts/Delegatecall.sol
@@ -6,7 +6,16 @@ contract TestDelegatecall {
     uint public value;
     uint public num;
 
+    event A(string message);
+
     function setVars(uint _num) external payable {
+
+        emit A("we are here 0");
+        require(value == 9, "Didn't reflect variables from calling contract correctly");
+        emit A("we are here 1");
+        require(num == 10, "Didn't reflect variables from calling contract correctly");
+        emit A("we are here 2");
+
         sender = msg.sender;
         value = msg.value;
         num = _num;
@@ -18,10 +27,30 @@ contract Delegatecall {
     uint public value;
     uint public num;
 
+    event A(string message);
+
     function setVars(address _test, uint _num) external payable {
+
+        value = 9;
+        num = 10;
+
+        require(value == 9, "cannot set own variables correctly (value)");
+        require(num == 10, "cannot set own variables correctly(num)");
+
+
+        emit A("making the call...");
+
         (bool success, bytes memory data) = _test.delegatecall(
             abi.encodeWithSelector(TestDelegatecall.setVars.selector, _num)
         );
+
+        emit A("making the call... done.");
+
+        if (success) {
+            emit A("this was a success");
+        } else {
+            emit A("this was a failure");
+        }
 
         require(success, "delegatecall failed");
     }

--- a/tests/EvmAcceptanceTests/test/Delegatecall.ts
+++ b/tests/EvmAcceptanceTests/test/Delegatecall.ts
@@ -13,15 +13,25 @@ describe("Delegatecall functionality", function () {
     const NUM = 123;
 
     const owner = this.delegateContract.signer;
+
+    console.log("0");
     await this.delegateContract.setVars(this.testDelegateContract.address, NUM, {value: VALUE});
+    console.log("0");
     expect(await this.delegateContract.num()).to.be.eq(NUM);
+    console.log("0");
     expect(await this.delegateContract.value()).to.be.eq(VALUE);
+    console.log("0");
     expect(await this.delegateContract.sender()).to.be.eq(owner.address);
+    console.log("0");
     expect(await ethers.provider.getBalance(this.delegateContract.address)).to.be.eq(VALUE);
+    console.log("0");
 
     expect(await this.testDelegateContract.num()).to.be.eq(0);
+    console.log("0");
     expect(await this.testDelegateContract.value()).to.be.eq(0);
+    console.log("0");
     expect(await this.testDelegateContract.sender()).to.be.eq("0x0000000000000000000000000000000000000000");
+    console.log("0");
     expect(await ethers.provider.getBalance(this.testDelegateContract.address)).to.be.eq(0);
   });
 });

--- a/tests/EvmAcceptanceTests/test/Delegatecall.ts
+++ b/tests/EvmAcceptanceTests/test/Delegatecall.ts
@@ -13,25 +13,15 @@ describe("Delegatecall functionality", function () {
     const NUM = 123;
 
     const owner = this.delegateContract.signer;
-
-    console.log("0");
     await this.delegateContract.setVars(this.testDelegateContract.address, NUM, {value: VALUE});
-    console.log("0");
     expect(await this.delegateContract.num()).to.be.eq(NUM);
-    console.log("0");
     expect(await this.delegateContract.value()).to.be.eq(VALUE);
-    console.log("0");
     expect(await this.delegateContract.sender()).to.be.eq(owner.address);
-    console.log("0");
     expect(await ethers.provider.getBalance(this.delegateContract.address)).to.be.eq(VALUE);
-    console.log("0");
 
     expect(await this.testDelegateContract.num()).to.be.eq(0);
-    console.log("0");
     expect(await this.testDelegateContract.value()).to.be.eq(0);
-    console.log("0");
     expect(await this.testDelegateContract.sender()).to.be.eq("0x0000000000000000000000000000000000000000");
-    console.log("0");
     expect(await ethers.provider.getBalance(this.testDelegateContract.address)).to.be.eq(0);
   });
 });


### PR DESCRIPTION
This FAILS on iso server (passes on ganache). The issue is that if you set your contract's state and then call delegate call, it will look for the state as it currently is on the CPP side (which is likely 0).