### PR TITLE
[master] Rework zil mint check on selfdestruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,4 @@ The Zilliqa client works together with Scilla for executing smart contracts. Ple
 | **Bug report** | <a href="https://github.com/Zilliqa/zilliqa/issues" target="_blank"><img src="https://img.shields.io/github/issues/Zilliqa/zilliqa.svg" /></a> |
 | **Security contact** | `security` :globe_with_meridians: `zilliqa.com` |
 | **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> |
+

--- a/README.md
+++ b/README.md
@@ -174,4 +174,3 @@ The Zilliqa client works together with Scilla for executing smart contracts. Ple
 | **Bug report** | <a href="https://github.com/Zilliqa/zilliqa/issues" target="_blank"><img src="https://img.shields.io/github/issues/Zilliqa/zilliqa.svg" /></a> |
 | **Security contact** | `security` :globe_with_meridians: `zilliqa.com` |
 | **Security bug bounty** | <a href="https://hackerone.com/zilliqa" target="_blank">HackerOne bug bounty</a> |
-

--- a/src/libCps/Amount.h
+++ b/src/libCps/Amount.h
@@ -49,6 +49,17 @@ class Amount final {
   constexpr auto operator>(const Amount& other) const {
     return !(*this <= other);
   }
+  constexpr auto operator+(const Amount& rhs) const {
+    // return the sum of two numbers as biggest type to avoid overflow
+    return Amount{this->toWei() + rhs.toWei()};
+  }
+  constexpr auto operator-(const Amount& rhs) const {
+    // return the sum of two numbers as biggest type to avoid overflow
+    return Amount{this->toWei() - rhs.toWei()};
+  }
+  constexpr auto operator==(const Amount& rhs) const {
+    return this->toWei() == rhs.toWei();
+  }
 
  private:
   constexpr Amount(const uint256_t& wei) : m_value(wei){};

--- a/src/libCps/Amount.h
+++ b/src/libCps/Amount.h
@@ -50,15 +50,16 @@ class Amount final {
     return !(*this <= other);
   }
   constexpr auto operator+(const Amount& rhs) const {
-    // return the sum of two numbers as biggest type to avoid overflow
     return Amount{this->toWei() + rhs.toWei()};
   }
   constexpr auto operator-(const Amount& rhs) const {
-    // return the sum of two numbers as biggest type to avoid overflow
     return Amount{this->toWei() - rhs.toWei()};
   }
   constexpr auto operator==(const Amount& rhs) const {
     return this->toWei() == rhs.toWei();
+  }
+  constexpr auto operator!=(const Amount& rhs) const {
+    return this->toWei() != rhs.toWei();
   }
 
  private:

--- a/src/libCps/CpsRunEvm.cpp
+++ b/src/libCps/CpsRunEvm.cpp
@@ -660,7 +660,7 @@ void CpsRunEvm::HandleApply(const evm::EvmResult& result,
     // Funds is what we want our contract to become/be modified to.
     // Check that the contract funds plus the current funds in our account
     // is equal to this value
-    if(!(funds == recipientPreFunds + currentContractFunds)) {
+    if(funds != recipientPreFunds + currentContractFunds) {
         std::string error =
             "Possible zil mint. Funds in destroyed account: " +
             currentContractFunds.toWei().convert_to<std::string>() +

--- a/src/libCps/CpsRunEvm.cpp
+++ b/src/libCps/CpsRunEvm.cpp
@@ -648,24 +648,30 @@ void CpsRunEvm::HandleApply(const evm::EvmResult& result,
 
   // Allow only removal of self in non-static calls
   if (accountToRemove == thisContractAddress && !mProtoArgs.is_static_call()) {
-    const auto currentFunds =
+    const auto currentContractFunds =
         mAccountStore.GetBalanceForAccountAtomic(accountToRemove);
+
+    // Funds for recipient
+    const auto recipientPreFunds =
+        mAccountStore.GetBalanceForAccountAtomic(fundsRecipient);
+
     const auto zero = Amount::fromQa(0);
 
-    if (funds > zero && funds <= currentFunds) {
-      mAccountStore.TransferBalanceAtomic(accountToRemove, fundsRecipient,
-                                          funds);
-    } else if (funds > zero) {
-      std::string error =
-          "Possible zil mint. Funds in destroyed account: " +
-          currentFunds.toWei().convert_to<std::string>() +
-          ", requested: " + funds.toWei().convert_to<std::string>();
+    // Funds is what we want our contract to become/be modified to.
+    // Check that the contract funds plus the current funds in our account
+    // is equal to this value
+    if(!(funds == recipientPreFunds + currentContractFunds)) {
+        std::string error =
+            "Possible zil mint. Funds in destroyed account: " +
+            currentContractFunds.toWei().convert_to<std::string>() +
+            ", requested: " + (funds - recipientPreFunds).toWei().convert_to<std::string>();
 
-      LOG_GENERAL(WARNING, "possible zil mint! " << error);
-      mAccountStore.TransferBalanceAtomic(accountToRemove, fundsRecipient,
-                                          currentFunds);
-      span.SetError(error);
+        LOG_GENERAL(WARNING, "ERROR IN DESTUCT! " << error);
+        span.SetError(error);
     }
+
+    mAccountStore.TransferBalanceAtomic(accountToRemove, fundsRecipient,
+                                        currentContractFunds);
     mAccountStore.SetBalanceAtomic(accountToRemove, zero);
     mAccountStore.AddAddressToUpdateBufferAtomic(accountToRemove);
     mAccountStore.AddAddressToUpdateBufferAtomic(fundsRecipient);


### PR DESCRIPTION
This checks that the refunded amount from contracts is EXACT. Before it was incorrectly understanding 'fund' to mean how much to transfer, when it was what the (non-contract) account value should become.

The logic should be the same.