### PR TITLE
[master] ZIL-5001: Enable and fix out of gas test

### DIFF
--- a/tests/EvmAcceptanceTests/test/ContractRevert.ts
+++ b/tests/EvmAcceptanceTests/test/ContractRevert.ts
@@ -36,8 +36,14 @@ describe("Revert Contract Call", function () {
     await expect(this.contract.callChainOk()).not.to.be.reverted;
   });
 
-  // FIXME: https://zilliqa-jira.atlassian.net/browse/ZIL-5001
-  xit("Should be reverted without any reason if specified gasLimit is not enough to complete txn", async function () {
-    await expect(this.contract.outOfGas({gasLimit: 100000})).to.be.revertedWithoutReason();
+  it("Should be reverted without any reason if specified gasLimit is not enough to complete txn", async function () {
+    const txn = await this.contract.outOfGas({gasLimit: 100000});
+    expect(txn).not.to.be.reverted;
+    try {
+      await txn.wait();
+      throw new Error("transaction succeeded, it should have failed");
+    } catch (err: any) {
+      // out of gas
+    }
   });
 });


### PR DESCRIPTION
I've tested on Sepolia and the behaviour is consistent there - the contract does not revert, it fails with an out of gas error.
