### PR TITLE
Simplify `Amount`

### DIFF
--- a/src/libCps/Amount.h
+++ b/src/libCps/Amount.h
@@ -32,16 +32,10 @@ class Amount final {
     return Amount{qa * EVM_ZIL_SCALING_FACTOR};
   }
   constexpr uint256_t toWei() const {
-    if (std::holds_alternative<uint128_t>(m_value)) {
-      return uint256_t{std::get<uint128_t>(m_value) * EVM_ZIL_SCALING_FACTOR};
-    }
-    return std::get<uint256_t>(m_value);
+    return m_value;
   }
   constexpr uint128_t toQa() const {
-    if (std::holds_alternative<uint256_t>(m_value)) {
-      return uint128_t{std::get<uint256_t>(m_value) / EVM_ZIL_SCALING_FACTOR};
-    }
-    return std::get<uint128_t>(m_value);
+    return uint128_t{m_value / EVM_ZIL_SCALING_FACTOR};
   }
   constexpr auto operator<=(const Amount& other) const {
     return toQa() <= other.toQa();
@@ -66,7 +60,7 @@ class Amount final {
   constexpr Amount(const uint256_t& wei) : m_value(wei){};
 
  private:
-  std::variant<uint128_t, uint256_t> m_value;
+  uint256_t m_value;
 };
 }  // namespace libCps
 


### PR DESCRIPTION
As far as I can see, we never use the `uint128_t` half of the `m_value` variant. When passed an amount in Qa, we rescale it to Wei by multiplying it by `EVM_ZIL_SCALING_FACTOR` anyway.

Therefore, we simplify the type to just `uint256_t` and remove the unused branches.