### PR TITLE
[master] Add `erigon_getHeaderByNumber`

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -384,6 +384,14 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
       jsonrpc::Procedure("GetDSLeaderTxnPool", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, nullptr),
       &EthRpcMethods::GetDSLeaderTxnPoolI);
+
+  m_lookupServer->bindAndAddExternalMethod(
+    jsonrpc::Procedure("erigon_getHeaderByNumber", jsonrpc::PARAMS_BY_POSITION,
+                       jsonrpc::JSON_OBJECT,
+                       "param01", jsonrpc::JSON_INTEGER,
+                       NULL),
+    &EthRpcMethods::GetHeaderByNumberI
+  );
 }
 
 std::string EthRpcMethods::CreateTransactionEth(
@@ -1968,4 +1976,9 @@ Json::Value EthRpcMethods::DebugTraceTransaction(const std::string &txHash,
     LOG_GENERAL(INFO, "[Error]" << e.what() << ". Input: " << txHash);
     throw JsonRpcException(ServerBase::RPC_MISC_ERROR, "Unable to Process");
   }
+}
+
+Json::Value EthRpcMethods::GetHeaderByNumber(const uint64_t blockNumber) {
+  // Erigon headers are a subset of a full block - So just return the full block.
+  return EthRpcMethods::GetEthBlockByNumber(std::to_string(blockNumber), false);
 }

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -596,6 +596,11 @@ class EthRpcMethods {
         this->DebugTraceBlockByNumber(request[0u].asString(), request[1u]);
   }
 
+  inline virtual void GetHeaderByNumberI(const Json::Value& request,
+                                         Json::Value& response) {
+    LOG_MARKER_CONTITIONAL(LOG_SC);
+    response = this->GetHeaderByNumber(request[0u].asUInt64());
+  }
   struct ApiKeys;
   std::string GetEthCallZil(const Json::Value& _json);
   std::string GetEthCallEth(const Json::Value& _json,
@@ -675,6 +680,8 @@ class EthRpcMethods {
                                     const Json::Value& json);
   Json::Value DebugTraceBlockByNumber(const std::string& blockNum,
                                       const Json::Value& json);
+
+  Json::Value GetHeaderByNumber(const uint64_t blockNumber);
 
   Json::Value GetDSLeaderTxnPool();
   void EnsureEvmAndLookupEnabled();


### PR DESCRIPTION
This is a trivial implementation, because Erigon headers are a subset of the `eth_getBlockBy*` response. So, we just return that instead.