### PR TITLE
[master] Add `ots_getApiLevel`

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -384,6 +384,13 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
       jsonrpc::Procedure("GetDSLeaderTxnPool", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, nullptr),
       &EthRpcMethods::GetDSLeaderTxnPoolI);
+
+  m_lookupServer->bindAndAddExternalMethod(
+    jsonrpc::Procedure("ots_getApiLevel", jsonrpc::PARAMS_BY_POSITION,
+                       jsonrpc::JSON_INTEGER,
+                       NULL),
+    &EthRpcMethods::GetOtterscanApiLevelI
+  );
 }
 
 std::string EthRpcMethods::CreateTransactionEth(

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -596,6 +596,11 @@ class EthRpcMethods {
         this->DebugTraceBlockByNumber(request[0u].asString(), request[1u]);
   }
 
+  inline virtual void GetOtterscanApiLevelI(const Json::Value& request,
+                                         Json::Value& response) {
+    LOG_MARKER_CONTITIONAL(LOG_SC);
+    response = 8;
+  }
   struct ApiKeys;
   std::string GetEthCallZil(const Json::Value& _json);
   std::string GetEthCallEth(const Json::Value& _json,


### PR DESCRIPTION
This is an API which returns the currently implemented version of the Otterscan API (`ots_*`). The frontend checks this number is high enough before trying to do anything else. The current minimum version in the frontend is `8`, so we return `8`.