### PR TITLE
[master] ZIL-5214: Make request queue size and threads configurable

### DIFF
--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -439,6 +439,8 @@ const unsigned int CONNECTION_ALL_TIMEOUT{
     ReadConstantNumeric("CONNECTION_ALL_TIMEOUT", "node.jsonrpc.")};
 const unsigned int CONNECTION_CALLBACK_TIMEOUT{
     ReadConstantNumeric("CONNECTION_CALLBACK_TIMEOUT", "node.jsonrpc.")};
+const size_t REQUEST_PROCESSING_THREADS{ReadConstantNumeric("REQUEST_PROCESSING_THREADS", "node.jsonrpc.", 64)};
+const size_t REQUEST_QUEUE_SIZE{ReadConstantNumeric("REQUEST_QUEUE_SIZE", "node.jsonrpc.", 65536)};
 
 // Network composition constants
 const unsigned int COMM_SIZE{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -314,6 +314,8 @@ extern const unsigned int PENDING_TXN_QUERY_MAX_RESULTS;
 extern const bool CONNECTION_IO_USE_EPOLL;
 extern const unsigned int CONNECTION_ALL_TIMEOUT;
 extern const unsigned int CONNECTION_CALLBACK_TIMEOUT;
+extern const size_t REQUEST_PROCESSING_THREADS;
+extern const size_t REQUEST_QUEUE_SIZE;
 
 // Network composition constants
 extern const unsigned int COMM_SIZE;

--- a/src/libServer/APIServer.h
+++ b/src/libServer/APIServer.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include "common/Constants.h"
 
 namespace boost {
 namespace asio {
@@ -58,10 +59,10 @@ class APIServer {
     std::string threadPoolName;
 
     /// Number of threads in thread pool
-    size_t numThreads = 6;
+    size_t numThreads = REQUEST_PROCESSING_THREADS;
 
     /// Max size of unhandled requests queue
-    size_t maxQueueSize = 256;
+    size_t maxQueueSize = REQUEST_QUEUE_SIZE;
 
     // TODO enable TLS later
     // std::string tlsCertificateFileName;


### PR DESCRIPTION
We also adjust the defaults to 65536 and 64, which is closer to the values from v8.1.0.
