### PR TITLE
[master] ZIL-5249: Format response from `net_version` as a decimal

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -1101,6 +1101,12 @@ std::string EthRpcMethods::GetEthChainId() {
   return (boost::format("0x%x") % ETH_CHAINID).str();
 }
 
+std::string EthRpcMethods::GetNetVersion() {
+  INC_CALLS(GetInvocationsCounter());
+
+  return (boost::format("%d") % ETH_CHAINID).str();
+}
+
 Json::Value EthRpcMethods::GetEthSyncing() {
   INC_CALLS(GetInvocationsCounter());
 

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -282,7 +282,7 @@ class EthRpcMethods {
   virtual void GetNetVersionI(const Json::Value& /*request*/,
                               Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
-    response = this->GetEthChainId();
+    response = this->GetNetVersion();
   }
 
   /**
@@ -617,6 +617,7 @@ class EthRpcMethods {
   std::string GetNetPeerCount();
   std::string GetProtocolVersion();
   std::string GetEthChainId();
+  std::string GetNetVersion();
   Json::Value GetEthSyncing();
   Json::Value GetEthTransactionByHash(const std::string& hash);
   Json::Value GetEmptyResponse();


### PR DESCRIPTION
This is what the documentation tells us to do and some clients (notably Metamask as of the latest update) validate this format.