### PR TITLE
Zil 5267 zilliiqad should terminate evm ds as well as scilla in its start new processes method

### DIFF
--- a/daemon/ZilliqaDaemon.cpp
+++ b/daemon/ZilliqaDaemon.cpp
@@ -253,6 +253,7 @@ void ZilliqaDaemon::StartNewProcess(bool cleanPersistence) {
   // Kill running processes ( zilliqa & scilla) if any
   KillProcess(programName[0]);
   KillProcess("scilla-server");
+  KillProcess("evm-ds");
 
   ZilliqaDaemon::LOG(m_log, "Create new Zilliqa process...");
   signal(SIGCHLD, SIG_IGN);


### PR DESCRIPTION
## Description
The create new process method should also killl evm-ds as well as scilla-server
<!-- What is the overall goal of your pull request? -->
Make it possible to restart the zilliqa process from the zilliqa dameon.
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
