### PR TITLE
[release/v9.1] Return response from `eth_getCode` in lowercase

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -1272,7 +1272,7 @@ Json::Value EthRpcMethods::GetEthCode(std::string const &address,
     LOG_GENERAL(INFO, "[Error]" << e.what() << " Input: " << address);
   }
   std::string result{"0x"};
-  boost::algorithm::hex(code.begin(), code.end(), std::back_inserter(result));
+  boost::algorithm::hex_lower(code.begin(), code.end(), std::back_inserter(result));
   return result;
 }
 


### PR DESCRIPTION
The specification doesn't explicitly document this, but its implied by the fact that most implementations return all hex data in lowercase.

Without this, some contract verification tools break, because they detect a mismatch in the compiled and deployed bytecode.
