### PR TITLE
[master] ZIL-5278: Retry sending outgoing messages a fixed number of times

### DIFF
--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -471,6 +471,8 @@ const uint32_t MAXRECVMESSAGE{
     ReadConstantNumeric("MAXRECVMESSAGE", "node.p2pcomm.")};
 const unsigned int MAXRETRYCONN{
     ReadConstantNumeric("MAXRETRYCONN", "node.p2pcomm.")};
+const unsigned int MAX_EXPIRE_TIME_MILLISECONDS{
+    ReadConstantNumeric("MAX_EXPIRE_TIME_MILLISECONDS", "node.p2pcomm.", 300000u)};
 const unsigned int MSGQUEUE_SIZE{
     ReadConstantNumeric("MSGQUEUE_SIZE", "node.p2pcomm.")};
 const unsigned int PUMPMESSAGE_MILLISECONDS{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -332,7 +332,10 @@ extern const unsigned int BROADCAST_EXPIRY;
 extern const unsigned int FETCH_LOOKUP_MSG_MAX_RETRY;
 extern const uint32_t MAXSENDMESSAGE;
 extern const uint32_t MAXRECVMESSAGE;
+/// @brief The maximum number of retries for a single outgoing message.
 extern const unsigned int MAXRETRYCONN;
+/// @brief The duration at which an outgoing message will time out.
+extern const unsigned int MAX_EXPIRE_TIME_MILLISECONDS;
 extern const unsigned int MSGQUEUE_SIZE;
 extern const unsigned int PUMPMESSAGE_MILLISECONDS;
 extern const unsigned int SENDQUEUE_SIZE;

--- a/src/libNetwork/P2PComm.cpp
+++ b/src/libNetwork/P2PComm.cpp
@@ -1253,7 +1253,8 @@ void SendMessageImpl(const std::shared_ptr<zil::p2p::SendJobs>& sendJobs,
                      const PeerList& peers, const zbytes& message,
                      unsigned char startByteType,
                      bool bAllowSendToRelaxedBlacklist,
-                     bool inject_trace_context) {
+                     bool inject_trace_context,
+                     bool ignoreBlacklist) {
   if (message.size() <= MessageOffset::BODY) {
     return;
   }
@@ -1273,7 +1274,7 @@ void SendMessageImpl(const std::shared_ptr<zil::p2p::SendJobs>& sendJobs,
                                          inject_trace_context);
 
   for (const auto& peer : peers) {
-    sendJobs->SendMessageToPeer(peer, raw_msg, bAllowSendToRelaxedBlacklist);
+    sendJobs->SendMessageToPeer(peer, raw_msg, bAllowSendToRelaxedBlacklist, ignoreBlacklist);
   }
 }
 
@@ -1283,15 +1284,16 @@ void P2PComm::SendMessage(const vector<Peer>& peers, const zbytes& message,
                           unsigned char startByteType,
                           bool inject_trace_context) {
   SendMessageImpl(m_sendJobs, peers, message, startByteType, false,
-                  inject_trace_context);
+                  inject_trace_context, false);
 }
 
 void P2PComm::SendMessage(const deque<Peer>& peers, const zbytes& message,
                           unsigned char startByteType,
                           bool bAllowSendToRelaxedBlacklist,
-                          bool inject_trace_context) {
+                          bool inject_trace_context,
+                          bool ignoreBlacklist) {
   SendMessageImpl(m_sendJobs, peers, message, startByteType,
-                  bAllowSendToRelaxedBlacklist, inject_trace_context);
+                  bAllowSendToRelaxedBlacklist, inject_trace_context, ignoreBlacklist);
 }
 
 void P2PComm::SendMessage(const Peer& peer, const zbytes& message,

--- a/src/libNetwork/P2PComm.h
+++ b/src/libNetwork/P2PComm.h
@@ -139,7 +139,8 @@ class P2PComm {
   void SendMessage(const std::deque<Peer>& peers, const zbytes& message,
                    unsigned char startByteType = zil::p2p::START_BYTE_NORMAL,
                    bool inject_trace_context = false,
-                   bool bAllowSendToRelaxedBlacklist = false);
+                   bool bAllowSendToRelaxedBlacklist = false,
+                   bool ignoreBlacklist = false);
 
   /// Sends normal message to specified peer.
   void SendMessage(const Peer& peer, const zbytes& message,

--- a/src/libNetwork/SendJobs.h
+++ b/src/libNetwork/SendJobs.h
@@ -38,15 +38,15 @@ class SendJobs {
 
   /// Enqueues message to be sent to peer
   virtual void SendMessageToPeer(const Peer& peer, RawMessage message,
-                                 bool allow_relaxed_blacklist) = 0;
+                                 bool allow_relaxed_blacklist, bool ignoreBlacklist = false) = 0;
 
   /// Helper for the function above, for the most common case
   void SendMessageToPeer(const Peer& peer, const zbytes& message,
-                         uint8_t start_byte, bool inject_trace_context) {
+                         uint8_t start_byte, bool inject_trace_context, bool ignoreBlacklist = false) {
     static const zbytes no_hash;
     SendMessageToPeer(
         peer, CreateMessage(message, no_hash, start_byte, inject_trace_context),
-        false);
+        false, ignoreBlacklist);
   }
 
   /// Sends message to peer in the current thread, without queueing.


### PR DESCRIPTION
We keep the existing time-based retries, but increase the default value from 5 seconds to 300 seconds. My intention here is to effectively disable the time-based timeouts, but keep the option to re-enable it with a configuration change.

We also start respecting the `MAXRETRYCONN` configuration again which limits the number of times we will retry the sending of a message.
