### PR TITLE
[master] ZIL-5280: Various localdev fixes

### DIFF
--- a/docs/localdev.md
+++ b/docs/localdev.md
@@ -46,5 +46,27 @@ scripts/localdev.py log-snapshot 120
 
 Which generates a directory in `/tmp` where it puts the logs of all pods from the last 120s, allowing you to easily see how the transaction flowed through the system.
 
+## Troubleshooting
+
+### Linux attempts to use a rootless docker context
 
 
+If `localdev setup` fails with:
+
+```
+📌  Using rootless Docker driver
+
+❌  Exiting due to MK_USAGE: --container-runtime must be set to "containerd" or "cri-o" for rootless
+
+```
+
+You have probably configured docker to be rootless; you can fix this with:
+
+```
+docker context create rootful --docker host=unix:///var/run/docker.sock
+docker context use rootful
+```
+
+### Linux packages to install
+
+Helm: See https://helm.sh/docs/intro/install/

--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -134,6 +134,10 @@ def run_or_die(config, cmd, in_dir = None, env = None, in_background = False, pi
         else:
             raise e
 
+def helm_remove_repository(config, repo):
+    run_or_die(config, ["helm", "uninstall", repo], allow_failure = True)
+
+
 def setup_podman(ctx, cpus, memory, disk_size):
     """
     Set up podman.
@@ -345,7 +349,7 @@ def localstack_up(config):
 
 def localstack_down(config):
     """ Let helm undeploy localstack """
-    run_or_die(config, ["helm", "uninstall", "localstack"])
+    helm_remove_repository(config, 'localstack')
 
 def grafana_up(config, testnet_name):
     """ Let helm deploy grafana """
@@ -385,7 +389,7 @@ adminPassword: admin
 
 def grafana_down(config):
     """ Let helm undeploy grafana """
-    run_or_die(config, ["helm", "uninstall", "grafana"])
+    helm_remove_repository(config, 'grafana')
 
 def prometheus_up(config, testnet_name, count = 23):
     """ Let helm deploy prometheus """
@@ -438,7 +442,7 @@ serverFiles:
 
 def prometheus_down(config):
     """ Let helm undeploy prometheus """
-    run_or_die(config, ["helm", "uninstall", "prometheus"])
+    helm_remove_repository(config, 'prometheus')
 
 def tempo_up(config, testnet_name):
     """ Let helm deploy tempo """
@@ -473,7 +477,8 @@ tempo:
 
 def tempo_down(config):
     """ Let helm undeploy tempo """
-    run_or_die(config, ["helm", "uninstall", "tempo"])
+    helm_remove_repository(config, "tempo")
+
 
 @click.command("up")
 @click.pass_context
@@ -491,7 +496,7 @@ def tempo_down(config):
               help="The test network's name")
 @click.option("--isolated-server-accounts",
               is_flag=True,
-              default=False,
+              default=True,
               show_default=True,
               help="Use isolated_server_accounts.json to create accounts when zilliqa is up")
 @click.option("--persistence", help="A persistence directory to start the network with. Has no effect without also passing `--key-file`.")
@@ -1075,7 +1080,7 @@ def restart_ingress_cmd(ctx):
               help="The test network's name")
 @click.option("--isolated-server-accounts",
               is_flag=True,
-              default=False,
+              default=True,
               show_default=True,
               help="Use isolated_server_accounts.json to create accounts when zilliqa is up")
 @click.option("--keep-persistence",
@@ -1091,6 +1096,10 @@ def reup_cmd(ctx, driver, zilliqa_image, testnet_name, isolated_server_accounts,
     """
     config = get_config(ctx)
     down(config, testnet_name, keep_persistence)
+    if not zilliqa_image:
+        zilliqa_image = build_zilliqa(config, driver, None, None)
+    else:
+        adjust_config(config, driver)
     up(config, zilliqa_image, testnet_name, isolated_server_accounts, persistence, key_file)
 
 @click.command("show-proxy")


### PR DESCRIPTION


## Description

(fix) ZIL-5280 Localdev down should resume properly on interruption 
(fix) ZIL-5280 isolated-server-accounts=true should be the default.
(fix) ZIL-5280 Localdev reup should work without an explicit image
(fix) ZIL-5280 Add some FAQs to the docs.

## Review Suggestion

Look at the code and try running it.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ x] local machine test

