### PR TITLE
[release/v9.2] Fix scilla restart condition for v9.0.1 mainnet outage

### DIFF
--- a/src/libScilla/ScillaClient.h
+++ b/src/libScilla/ScillaClient.h
@@ -46,8 +46,6 @@ class ScillaClient {
 
   void Init();
 
-  bool isScillaRuning();
-
   bool CallChecker(uint32_t version, const Json::Value& _json,
                    std::string& result, uint32_t counter = MAXRETRYCONN);
   bool CallRunner(uint32_t version, const Json::Value& _json,


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

The JSON-RPC library has some parsing issues that led to the scilla server not restarting itself. The PR fixes the error condition for starting the scilla.
Note: In the `v8.1.2` release scilla restart used to work fine when the scilla server process crashes for some reason.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
