### PR TITLE
[master] API enable otterscan extended tracing

### DIFF
--- a/src/cmd/isolated_server.cpp
+++ b/src/cmd/isolated_server.cpp
@@ -107,8 +107,6 @@ int main(int argc, const char* argv[]) {
   ENABLE_EVM = true;
   LOOKUP_NODE_MODE = true;
   SCILLA_SERVER_LOOP_WAIT_MICROSECONDS = 100000;
-  ARCHIVAL_LOOKUP_WITH_TX_TRACES =
-      true;  // Force saving traces if they are generated
   if (SCILLA_ROOT == "/scilla") {
     SCILLA_ROOT = "/tmp";
   }

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -375,6 +375,12 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
       &EthRpcMethods::DebugTraceTransactionI);
 
   m_lookupServer->bindAndAddExternalMethod(
+      jsonrpc::Procedure("ots_enable", jsonrpc::PARAMS_BY_POSITION,
+                         jsonrpc::JSON_STRING, "param01",
+                         jsonrpc::JSON_BOOLEAN, NULL),
+      &EthRpcMethods::OtterscanEnableI);
+
+  m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("ots_getInternalOperations", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
                          NULL),

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -592,8 +592,7 @@ class EthRpcMethods {
   inline virtual void OtterscanEnableI(const Json::Value& request,
                                                       Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
-    std::cerr << "Enabling otterscan" << std::endl;
-    ARCHIVAL_LOOKUP_WITH_TX_TRACES = !ARCHIVAL_LOOKUP_WITH_TX_TRACES;
+    ARCHIVAL_LOOKUP_WITH_TX_TRACES = request[0u].asBool();
   }
 
   /**

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -585,6 +585,18 @@ class EthRpcMethods {
   }
 
   /**
+   * @brief Handles json rpc 2.0 request on method: ots_enable
+   * @param request : none
+   * @param response : none
+   */
+  inline virtual void OtterscanEnableI(const Json::Value& request,
+                                                      Json::Value& response) {
+    LOG_MARKER_CONTITIONAL(LOG_SC);
+    std::cerr << "Enabling otterscan" << std::endl;
+    ARCHIVAL_LOOKUP_WITH_TX_TRACES = !ARCHIVAL_LOOKUP_WITH_TX_TRACES;
+  }
+
+  /**
    * @brief Handles json rpc 2.0 request on method: ots_getInternalOperations
    * @param request : transaction hash
    * @param response : transaction internal operations

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -460,6 +460,12 @@ void IsolatedServer::BindAllEvmMethods() {
         &LookupServer::DebugTraceTransactionI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
+        jsonrpc::Procedure("ots_enable",
+                           jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
+                           "param01", jsonrpc::JSON_BOOLEAN, NULL),
+        &EthRpcMethods::OtterscanEnableI);
+
+    AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("ots_getInternalOperations",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
                            "param01", jsonrpc::JSON_STRING, NULL),

--- a/tests/EvmAcceptanceTests/test/ChainedCalls.ts
+++ b/tests/EvmAcceptanceTests/test/ChainedCalls.ts
@@ -12,6 +12,13 @@ describe("Chained Contract Calls Functionality", function () {
     contractOne = await parallelizer.deployContract("ContractOne");
     contractTwo = await parallelizer.deployContract("ContractTwo");
     contractThree = await parallelizer.deployContract("ContractThree");
+
+    // Make sure traceing is enabled
+    const METHOD = "ots_enable";
+
+    await sendJsonRpcRequest(METHOD, 1, [true], (result, status) => {
+      assert.equal(status, 200, "has status code");
+    });
   });
 
   describe("Install and call chained contracts", function () {

--- a/tests/EvmAcceptanceTests/test/OtterTests.ts
+++ b/tests/EvmAcceptanceTests/test/OtterTests.ts
@@ -17,10 +17,6 @@ describe("Otterscan api tests", function () {
   });
 
   it("When we revert the TX, we can get the tx error ", async function () {
-    assert(true);
-  });
-
-  it("When we revert the TX, we can get the tx error ", async function () {
     const METHOD = "ots_getTransactionError";
     const REVERT_MESSAGE = "Transaction too old";
 

--- a/tests/EvmAcceptanceTests/test/OtterTests.ts
+++ b/tests/EvmAcceptanceTests/test/OtterTests.ts
@@ -34,8 +34,6 @@ describe("Otterscan api tests", function () {
     // a similar passing call and use this (+30% leeway) to override the gas field
     const estimatedGas = await this.contract.estimateGas.requireCustom(true, REVERT_MESSAGE);
 
-    console.log("Estimated gas: ", estimatedGas);
-
     const tx = await this.contract.requireCustom(false, REVERT_MESSAGE, {gasLimit: estimatedGas.mul(130).div(100)});
 
     await sendJsonRpcRequest(METHOD, 1, [tx.hash], (result, status) => {

--- a/tests/EvmAcceptanceTests/test/OtterTests.ts
+++ b/tests/EvmAcceptanceTests/test/OtterTests.ts
@@ -5,6 +5,21 @@ import sendJsonRpcRequest from "../helpers/JsonRpcHelper";
 import {parallelizer} from "../helpers";
 
 describe("Otterscan api tests", function () {
+
+  before(async function () {
+      const METHOD = "ots_enable";
+
+      // Make sure traceing is enabled
+      await sendJsonRpcRequest(METHOD, 1, [true], (result, status) => {
+        assert.equal(status, 200, "has status code");
+      });
+
+  });
+
+  it("When we revert the TX, we can get the tx error ", async function () {
+    assert(true);
+  });
+
   it("When we revert the TX, we can get the tx error ", async function () {
     const METHOD = "ots_getTransactionError";
     const REVERT_MESSAGE = "Transaction too old";


### PR DESCRIPTION
In the tests, it is possible in a devnet it is testing the otter and trace tx tests against a network that doesn't have the trace flag on.

This adds an endpoint so that the flag can be externally set. This lets the test make sure it is set before it runs (it will still fail if you are not running against a seed node though, ie one with ARCHIVAL_LOOKUP set to true)