### PR TITLE
[master] Zil 5287 isolated server scilla fix

### DIFF
--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -613,8 +613,11 @@ def isolated(config, enable_evm = True, block_time_ms = None):
     with open(os.path.join(target_workspace, 'constants.xml'), 'w') as f:
         f.write(output_config)
     new_env = os.environ.copy()
-    #old_path = new_env.get("DYLD_LIBRARY_PATH", "")
-    #new_env["DYLD_LIBRARY_PATH"] = f"{target_workspace}/lib:{old_path}"
+    # This used to contain DYLD_LIBRARY_PATH - and it probably still should,
+    # but I don't have a Mac to hand - rrw 2023-06-22
+    for var in [ "LD_LIBRARY_PATH" ]:
+        old_path = new_env.get(var, "")
+        new_env[var] = f"{target_workspace}/lib:{old_path}"
     cmd = [ "./bin/isolatedServer", "-f", "isolated-server-accounts.json", "-u", "999" ]
     if block_time_ms is not None:
         cmd.extend(["--time", str(block_time_ms)])

--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -839,8 +839,10 @@ def build_native_to_workspace(config):
         shutil.rmtree(workspace)
     except:
         pass
+    build_env = os.environ.copy()
+    build_env['SCILLA_REPO_ROOT'] = SCILLA_DIR
     # Let's start off by building Scilla, in case it breaks.
-    run_or_die(config, ["make"], in_dir = SCILLA_DIR)
+    run_or_die(config, ["make"], in_dir = SCILLA_DIR, env = build_env)
     run_or_die(config, ["./build.sh"], in_dir = ZILLIQA_DIR)
     run_or_die(config, ["cargo", "build", "--release", "--package", "evm-ds"], in_dir =
                os.path.join(ZILLIQA_DIR, "evm-ds"))


### PR DESCRIPTION
## Description

Make scilla-server run again on x64.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion

Check code. Run isolated on OS X and x64 (works on x86, OS X/x86 for me - can't test aarch64)

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
