### PR TITLE
[master] ZIL-5298: add connection timer and make reconnection time configurable

### DIFF
--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -494,9 +494,9 @@ const unsigned int MAX_WHITELISTREQ_LIMIT{
 const unsigned int SENDJOBPEERS_TIMEOUT{
     ReadConstantNumeric("SENDJOBPEERS_TIMEOUT", "node.p2pcomm.")};
 const unsigned int CONNECTION_TIMEOUT_IN_MS{
-    ReadConstantNumeric("CONNECTION_TIMEOUT_IN_MS", "node.p2pcomm.", 60000)};
+    ReadConstantNumeric("CONNECTION_TIMEOUT_IN_MS", "node.p2pcomm.", 30000)};
 const unsigned int RECONNECT_INTERVAL_IN_MS{
-    ReadConstantNumeric("RECONNECT_INTERVAL_IN_MS", "node.p2pcomm.", 5000)};
+    ReadConstantNumeric("RECONNECT_INTERVAL_IN_MS", "node.p2pcomm.", 2500)};
 
 // PoW constants
 const bool FULL_DATASET_MINE{

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -493,6 +493,10 @@ const unsigned int MAX_WHITELISTREQ_LIMIT{
     ReadConstantNumeric("MAX_WHITELISTREQ_LIMIT", "node.p2pcomm.")};
 const unsigned int SENDJOBPEERS_TIMEOUT{
     ReadConstantNumeric("SENDJOBPEERS_TIMEOUT", "node.p2pcomm.")};
+const unsigned int CONNECTION_TIMEOUT_IN_MS{
+    ReadConstantNumeric("CONNECTION_TIMEOUT_IN_MS", "node.p2pcomm.", 60000)};
+const unsigned int RECONNECT_INTERVAL_IN_MS{
+    ReadConstantNumeric("RECONNECT_INTERVAL_IN_MS", "node.p2pcomm.", 5000)};
 
 // PoW constants
 const bool FULL_DATASET_MINE{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -344,6 +344,8 @@ extern const unsigned int MAX_PEER_CONNECTION;
 extern const unsigned int MAX_PEER_CONNECTION_P2PSEED;
 extern const unsigned int MAX_WHITELISTREQ_LIMIT;
 extern const unsigned int SENDJOBPEERS_TIMEOUT;
+extern const unsigned int CONNECTION_TIMEOUT_IN_MS;
+extern const unsigned int RECONNECT_INTERVAL_IN_MS;
 
 // PoW constants
 extern const bool FULL_DATASET_MINE;


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

Added the following (optional) constants:
* CONNECTION_TIMEOUT_IN_MS
* RECONNECT_INTERVAL_IN_MS

The reconnection timer is initially used to enforce a timeout before invoking async_connect.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
