### PR TITLE
[master] ZIL-5302: Fix `contractAddress` calculation for non-Eth transactions

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -719,7 +719,7 @@ const Json::Value JSONConversion::convertTxtoEthJson(
     retJson["contractAddress"] =
         "0x" + Account::GetAddressForContract(
                    txn.GetTransaction().GetSenderAddr(),
-                   txn.GetTransaction().GetNonce() - 1, TRANSACTION_VERSION_ETH)
+                   txn.GetTransaction().GetNonce() - 1, txn.GetTransaction().GetVersionIdentifier())
                    .hex();
   }
   retJson["type"] = "0x0";

--- a/tests/EvmAcceptanceTests/test/scilla/ContractDeployment.ts
+++ b/tests/EvmAcceptanceTests/test/scilla/ContractDeployment.ts
@@ -1,6 +1,6 @@
 import {ScillaContract} from "hardhat-scilla-plugin";
 import {expect} from "chai";
-import hre from "hardhat";
+import hre, { ethers } from "hardhat";
 import {parallelizer} from "../../helpers";
 
 describe("Scilla Contract Deployment", function () {
@@ -30,6 +30,16 @@ describe("Scilla Contract Deployment", function () {
         vname: "address",
         type: "ByStr20"
       });
+    });
+
+    it("Should be possible to the get contract address using `GetContractAddressFromTransactionID`", async function () {
+      let address = (await parallelizer.zilliqaSetup.zilliqa.blockchain.getContractAddressFromTransactionID(contract.deployed_by.id)).result;
+      expect(address).to.be.equal(contract.address!!.toLowerCase().replace("0x", ""));
+    });
+
+    it("Should be possible to the get contract address using `eth_getTransactionReceipt`", async function () {
+      let address = (await ethers.provider.getTransactionReceipt(`0x${contract.deployed_by.id}`)).contractAddress;
+      expect(address.toLowerCase()).to.be.equal(contract.address!!.toLowerCase());
     });
   });
 });


### PR DESCRIPTION
We did not respect the version of the transaction, meaning all contract addresses were calculated using the Ethereum standard. This meant the contract address from `eth_` APIs was wrong for Scilla contract deployments.