### PR TITLE
[master] Fix issues ZIL-5305 to ZIL-5307

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -754,7 +754,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
     } else if (tracer.compare("otter_internal_tracer") == 0) {
       auto const item = trace_json["otter_internal_tracer"];
       if(item.isNull()){
-        parsed = Json::Value::Value(Json::ValueType::arrayValue)
+        parsed = Json::Value(Json::ValueType::arrayValue);
       }else{
         parsed = item;
       }
@@ -765,7 +765,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       auto const item = trace_json["otter_transaction_error"];
       // If there was no error return 0x
       if(item.isNull()){
-        parsed = Json::Value::Value("0x")
+        parsed = Json::Value("0x");
       }else{
         parsed = item;
       }

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -753,7 +753,11 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
     } else if (tracer.compare("otter_internal_tracer") == 0) {
       auto const item = trace_json["otter_internal_tracer"];
-      parsed = item;
+      if(item.isNull()){
+        parsed = Json::Value::Value(Json::ValueType::arrayValue)
+      }else{
+        parsed = item;
+      }
     } else if (tracer.compare("otter_call_tracer") == 0) {
       auto const item = trace_json["otter_call_tracer"];
       parsed = item;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -759,7 +759,12 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
     } else if (tracer.compare("otter_transaction_error") == 0) {
       auto const item = trace_json["otter_transaction_error"];
-      parsed = item;
+      // If there was no error return 0x
+      if(item.isNull()){
+        parsed = Json::Value::Value("0x")
+      }else{
+        parsed = item;
+      }
     } else {
       throw JsonRpcException(
           ServerBase::RPC_MISC_ERROR,

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -2096,6 +2096,9 @@ Json::Value EthRpcMethods::OtterscanSearchTransactions(const std::string& addres
                            "The node is not configured to store otter internal operations");
   }
 
+  //Records whether blockNumber was 0 on input
+  bool blockNumberWasZero = !blockNumber;
+
   // if blocnumber is 0 and it's a before search, then we need to get the latest block number
   if (blockNumber == 0 && before) {
     blockNumber = m_sharedMediator.m_txBlockChain.GetLastBlock().GetHeader().GetBlockNum();
@@ -2128,8 +2131,8 @@ Json::Value EthRpcMethods::OtterscanSearchTransactions(const std::string& addres
 
     // Otterscan docs:
     // These are the conditions for which these variables are set to true
-    response["firstPage"] = (before && !blockNumber) || (!before && !wasMore);
-    response["lastPage"] = (!before && !blockNumber) || (before && !wasMore);
+    response["firstPage"] = (before && blockNumberWasZero) || (!before && !wasMore);
+    response["lastPage"] = (!before && blockNumberWasZero) || (before && !wasMore);
 
     return response;
   } catch (exception &e) {


### PR DESCRIPTION
The first fix of ZIL-5305 did not take into account that the blockNumber is changed further up in the function if it is equal to 0 when passed in.
Change adds a boolean value which checks whether blockNumber is passed in as 0 and is then used instead

Fix for ZIL-5306 ensures that if there is no error, it returns the string "0x" to indicate there was no error instead of null

Fix for ZIL-5307 ensures that if there were no internal operations, it returns an empty array instead of null
