### PR TITLE
[master] Fixed checks so that they test the correct field

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -753,8 +753,8 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
     } else if (tracer.compare("otter_internal_tracer") == 0) {
       auto const item = trace_json["otter_internal_tracer"];
-      if(item.isNull()){
-        parsed = Json::Value(Json::ValueType::arrayValue);
+      if(item["result"].isNull()){
+        parsed["result"] = Json::Value(Json::arrayValue);
       }else{
         parsed = item;
       }
@@ -764,7 +764,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
     } else if (tracer.compare("otter_transaction_error") == 0) {
       auto const item = trace_json["otter_transaction_error"];
       // If there was no error return 0x
-      if(item.isNull()){
+      if(item["result"].isNull()){
         parsed = Json::Value("0x");
       }else{
         parsed = item;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -769,8 +769,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
       Json::FastWriter fastWriter;
       string output = fastWriter.write(item);
-      LOG_GENERAL(DEBUG, "DEBUG: " << output);
-      cout << output;
+      LOG_GENERAL(INFO, "DEBUG: " << output);
       // If there was no error return 0x
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value("0x");

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -765,7 +765,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       auto const item = trace_json["otter_transaction_error"];
       // If there was no error return 0x
       if(item["result"].isNull()){
-        parsed = Json::Value("0x");
+        parsed["result"] = Json::Value("0x");
       }else{
         parsed = item;
       }

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -753,21 +753,19 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
     } else if (tracer.compare("otter_internal_tracer") == 0) {
       auto const item = trace_json["otter_internal_tracer"];
+      parsed = item;
       if(item["result"].isNull()){
         parsed["result"] = Json::Value(Json::arrayValue);
-      }else{
-        parsed = item;
       }
     } else if (tracer.compare("otter_call_tracer") == 0) {
       auto const item = trace_json["otter_call_tracer"];
       parsed = item;
     } else if (tracer.compare("otter_transaction_error") == 0) {
       auto const item = trace_json["otter_transaction_error"];
+      parsed = item;
       // If there was no error return 0x
-      if(item["result"].isNull()){
+      if(parsed["result"].isNull()){
         parsed["result"] = Json::Value("0x");
-      }else{
-        parsed = item;
       }
     } else {
       throw JsonRpcException(

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -758,8 +758,8 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       Json::FastWriter fastWriter;
       string output = fastWriter.write(parsed);
       LOG_GENERAL(INFO, "DEBUG: " << output);
-      if(parsed["result"].isNull()){
-        parsed["result"] = Json::Value(Json::arrayValue);
+      if(parsed.isNull()){
+        parsed = Json::Value(Json::arrayValue);
       }
     } else if (tracer.compare("otter_call_tracer") == 0) {
       auto const item = trace_json["otter_call_tracer"];
@@ -771,8 +771,8 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       string output = fastWriter.write(item);
       LOG_GENERAL(INFO, "DEBUG: " << output);
       // If there was no error return 0x
-      if(parsed["result"].isNull()){
-        parsed["result"] = Json::Value("0x");
+      if(parsed.isNull()){
+        parsed = Json::Value("0x");
       }
     } else {
       throw JsonRpcException(

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -768,8 +768,9 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       auto const item = trace_json["otter_transaction_error"];
       parsed = item;
       Json::FastWriter fastWriter;
-      string output = fastWriter.write(parsed);
+      string output = fastWriter.write(item);
       LOG_GENERAL(DEBUG, "DEBUG: " << output);
+      cout << output;
       // If there was no error return 0x
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value("0x");

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -757,7 +757,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
       Json::FastWriter fastWriter;
       string output = fastWriter.write(parsed);
-      LOG_GENERAL(DEBUG, "DEBUG: " << output);
+      LOG_GENERAL(INFO, "DEBUG: " << output);
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value(Json::arrayValue);
       }

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -26,6 +26,7 @@
 #include "common/CommonData.h"
 #include "common/Constants.h"
 #include "json/value.h"
+#include "json/writer.h"
 #include "libCrypto/EthCrypto.h"
 #include "libData/AccountData/Account.h"
 #include "libData/AccountData/Transaction.h"
@@ -754,7 +755,10 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
     } else if (tracer.compare("otter_internal_tracer") == 0) {
       auto const item = trace_json["otter_internal_tracer"];
       parsed = item;
-      if(item["result"].isNull()){
+      Json::FastWriter fastWriter;
+      string output = fastWriter.write(parsed);
+      cout << output;
+      if(parsed["result"].isNull()){
         parsed["result"] = Json::Value(Json::arrayValue);
       }
     } else if (tracer.compare("otter_call_tracer") == 0) {
@@ -763,6 +767,9 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
     } else if (tracer.compare("otter_transaction_error") == 0) {
       auto const item = trace_json["otter_transaction_error"];
       parsed = item;
+      Json::FastWriter fastWriter;
+      string output = fastWriter.write(parsed);
+      cout << output;
       // If there was no error return 0x
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value("0x");

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -757,7 +757,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
       Json::FastWriter fastWriter;
       string output = fastWriter.write(parsed);
-      cout << output;
+      LOG_GENERAL(DEBUG, "DEBUG: " << output);
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value(Json::arrayValue);
       }
@@ -769,7 +769,7 @@ Json::Value extractTracer(const std::string &tracer, const std::string &trace) {
       parsed = item;
       Json::FastWriter fastWriter;
       string output = fastWriter.write(parsed);
-      cout << output;
+      LOG_GENERAL(DEBUG, "DEBUG: " << output);
       // If there was no error return 0x
       if(parsed["result"].isNull()){
         parsed["result"] = Json::Value("0x");


### PR DESCRIPTION
The previous push was checking whether the entire json object was null instead of the field "result". In addition, I incorrectly referred to the `arrayValue` field.

Side question: Is this solution less efficient than if we made changes to the json string just before it was stored in the otterscan database in the node. My thinking is that that is done once whereas doing it when servicing the API request will be done each time there is an API call. On the other hand it would require more work to turn the string into a Json object, check for the nulls and convert it back to a string before writing to the database as well as having to update the entire current table.