### PR TITLE
[master] Added transactionCount field to fullblock object

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -2262,6 +2262,7 @@ Json::Value EthRpcMethods::GetBlockTransactions(const uint64_t blockNumber, cons
   auto jsonBlock = GetEthBlockCommon(txBlock, true);
 
   auto transactions = jsonBlock["transactions"];
+  jsonBlock["transactionCount"] = transactions.size();
 
   auto start = pageNumber * pageSize;
   auto end = std::min(transactions.size(), (pageNumber + 1) * pageSize);


### PR DESCRIPTION
Added a simple line that adds this new field.

Question: I see that in the above function `GetBlockDetails`, it gets the transaction count using `txBlock.GetHeader().GetNumTxs()`. Does this have any performance benefits over `transactions.size()`?