### PR TITLE
[master] Fixed function so correctly returns GasLimit

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -2240,8 +2240,6 @@ Json::Value EthRpcMethods::GetBlockDetails(const uint64_t blockNumber) {
   uint128_t fees = (isVacuous ? 0 : txBlock.GetHeader().GetRewards() * EVM_ZIL_SCALING_FACTOR);
   auto jsonBlock = GetEthBlockCommon(txBlock, false);
 
-  jsonBlock["gasLimit"] = "0x1";
-
   jsonBlock.removeMember("transactions");
   jsonBlock["transactionCount"] = txBlock.GetHeader().GetNumTxs();
   jsonBlock["logsBloom"] = Json::nullValue;

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -2240,6 +2240,8 @@ Json::Value EthRpcMethods::GetBlockDetails(const uint64_t blockNumber) {
   uint128_t fees = (isVacuous ? 0 : txBlock.GetHeader().GetRewards() * EVM_ZIL_SCALING_FACTOR);
   auto jsonBlock = GetEthBlockCommon(txBlock, false);
 
+  if(jsonBlock["gasLimit"].asString() == "0x0") jsonBlock["gasLimit"] = "0x1";
+
   jsonBlock.removeMember("transactions");
   jsonBlock["transactionCount"] = txBlock.GetHeader().GetNumTxs();
   jsonBlock["logsBloom"] = Json::nullValue;


### PR DESCRIPTION
I removed the line that caused this API call to constantly return "0x1" as the GasLimit of a block.