### PR TITLE
[release/v9.2] Cherry pick PR-3728(Fix Eth Gas Estimate) on release/v9.2 branch

### DIFF
--- a/src/depends/jsonrpccpp/common/procedure.h
+++ b/src/depends/jsonrpccpp/common/procedure.h
@@ -19,7 +19,7 @@
 namespace jsonrpc
 {
     typedef std::map<std::string, jsontype_t> parameterNameList_t;
-    typedef std::vector<jsontype_t> parameterPositionList_t;
+    typedef std::vector<std::pair<jsontype_t, jsonflags_t>> parameterPositionList_t;
 
     typedef enum {PARAMS_BY_NAME, PARAMS_BY_POSITION} parameterDeclaration_t;
 
@@ -75,7 +75,7 @@ namespace jsonrpc
              * @param name describes the name of the parameter. In case of an positional parameters, this value can be anything.
              * @param type describes the defined type for this parameter.
              */
-            void AddParameter(const std::string& name, jsontype_t type);
+            void AddParameter(const std::string& name, jsontype_t type, jsonflags_t flags = (jsonflags_t)0);
 
             bool ValidateNamedParameters        (const Json::Value &parameters) const;
             bool ValidatePositionalParameters   (const Json::Value &parameters) const;

--- a/src/depends/jsonrpccpp/common/specification.h
+++ b/src/depends/jsonrpccpp/common/specification.h
@@ -16,6 +16,11 @@
 #define KEY_SPEC_PROCEDURE_PARAMETERS    "params"
 #define KEY_SPEC_RETURN_TYPE             "returns"
 
+
+// This is rather horrid, but the alternative is to try and rejig the whole library to make
+// C++0x enums work, which is quite disruptive.
+#define OPTIONAL_JSONTYPE(t)  ((int)((int)(t) | (int)JSON_FLAG_OPTIONAL))
+
 namespace jsonrpc
 {
     /**
@@ -40,6 +45,12 @@ namespace jsonrpc
         JSON_ARRAY = 6,
         JSON_NUMERIC = 7
     } ;
+
+    enum jsonflags_t
+    {
+      JSON_FLAG_OPTIONAL = 0x010000
+    };
+
 }
 
 #endif // JSONRPC_CPP_SPECIFICATION_H

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -198,6 +198,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_estimateGas", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_OBJECT,
+                         "param02", OPTIONAL_JSONTYPE(jsonrpc::JSON_STRING),
                          NULL),
       &EthRpcMethods::GetEthEstimateGasI);
 
@@ -830,13 +831,18 @@ bool EthRpcMethods::UnpackRevert(const std::string &data_in,
   return true;
 }
 
-std::string EthRpcMethods::GetEthEstimateGas(const Json::Value &json) {
+std::string EthRpcMethods::GetEthEstimateGas(const Json::Value &json, const std::string *block_or_tag) {
   Address fromAddr;
 
   auto span = zil::trace::Tracing::CreateSpan(zil::trace::FilterClass::TXN,
                                               __FUNCTION__);
 
   INC_CALLS(GetInvocationsCounter());
+
+  if (block_or_tag != nullptr && !isSupportedTag(*block_or_tag)) {
+    throw JsonRpcException(ServerBase::RPC_INVALID_PARAMS,
+                           "Unsupported block or tag in eth_call");
+  }
 
   if (!json.isMember("from")) {
     TRACE_ERROR("Missing from account");

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -121,7 +121,13 @@ class EthRpcMethods {
                                          Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
     EnsureEvmAndLookupEnabled();
-    response = this->GetEthEstimateGas(request[0u]);
+    std::string block_or_tag;
+    if (request.size()> 1) {
+      block_or_tag = request[1u].asString();
+    }
+
+    response = this->GetEthEstimateGas(request[0u],
+                                       (request.size() > 1 ? &block_or_tag : nullptr));
   }
 
   inline virtual void GetEthTransactionCountI(const Json::Value& request,
@@ -714,7 +720,7 @@ class EthRpcMethods {
   std::string DebugTraceCallEth(const Json::Value& _json,
                                 const std::string& block_or_tag,
                                 const Json::Value& tracer);
-  std::string GetEthEstimateGas(const Json::Value& _json);
+  std::string GetEthEstimateGas(const Json::Value& _json, const std::string *block_or_tag);
   std::string GetEthCallImpl(const Json::Value& _json, const ApiKeys& apiKeys,
                              std::string const& tracer = "");
   Json::Value GetBalanceAndNonce(const std::string& address);

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -326,7 +326,9 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_estimateGas", jsonrpc::PARAMS_BY_POSITION,
                            jsonrpc::JSON_STRING, "param01",
-                           jsonrpc::JSON_OBJECT, NULL),
+                           jsonrpc::JSON_OBJECT,
+                           "param02", OPTIONAL_JSONTYPE(jsonrpc::JSON_STRING),
+                           NULL),
         &LookupServer::GetEthEstimateGasI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/tests/EvmAcceptanceTests/test/rpc/eth_estimateGas.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_estimateGas.ts
@@ -3,24 +3,45 @@ import {assert} from "chai";
 
 const METHOD = "eth_estimateGas";
 
-// TODO, finish test when  code on zilliqa is implemented to calculate the estimated gas price
 
-// describe("Calling " + METHOD, function () {
-//   it("should return the estimated gas as calculated over the transaction provided", async function () {
-//     await sendJsonRpcRequest(METHOD, 2, [
-//       "{\"from\":\"\", \"to\":\"\", \"value\":\"\", \"gas\":\"\", \"data\":\"\"}",
-//       "latest"],
-//       (result, status) => {
-//         console.log(result);
-//
-//         assert.equal(status, 200, 'has status code');
-//         assert.property(result, 'result', (result.error) ? result.error.message : 'error');
-//         assert.isString(result.result, 'is string');
-//         assert.match(result.result, /^0x/, 'should be HEX starting with 0x');
-//         assert.isNumber(+result.result, 'can be converted to a number');
-//
-//         const estimatedGas = 2000000000
-//         assert.equal(+result.result, estimatedGas, 'should have an estimated gas' + estimatedGas);
-//       })
-//   })
-// })
+// TODO: When/if we want to, assert the gas price so as to check the gas calculations.
+describe("Calling " + METHOD, function () {
+  it("should accept estimateGas with a block tag", async function () {
+    await sendJsonRpcRequest(METHOD, 2, [
+      {"data": "0x60806040526040516101a63803806101a68339818101604052810190610025919061006d565b806000819055505061009a565b600080fd5b6000819050919050565b61004a81610037565b811461005557600080fd5b50565b60008151905061006781610041565b92915050565b60006020828403121561008357610082610032565b5b600061009184828501610058565b91505092915050565b60fe806100a86000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80638381f58a146037578063ef5fb05b146051575b600080fd5b603d6059565b6040516048919060af565b60405180910390f35b6057605f565b005b60005481565b7f6907508952f1c853768d61a5d281b8e23ad78ab8503ddc9404e21d6affade6d3600054604051608e919060af565b60405180910390a1565b6000819050919050565b60a9816098565b82525050565b600060208201905060c2600083018460a2565b9291505056fea26469706673582212203151b21ab4ce0f1e6e7333acb907eae279eb97b81e4926925139a34fe623454e64736f6c63430008130033000000000000000000000000000000000000000000000000000000000000002a", "from": "0xf0cb24ac66ba7375bf9b9c4fa91e208d9eaabd2e" },
+      "pending" ],
+                             (result, status) => {
+                               assert.equal(status, 200, 'has status code');
+                               assert.property(result, 'result', (result.error) ? result.error.message : 'error');
+                               assert.isString(result.result, 'is string');
+                               assert.match(result.result, /^0x/, 'should be HEX starting with 0x');
+                               assert.isNumber(+result.result, 'can be converted to a number');
+                             })
+  })
+
+  it("should accept estimateGas without a block tag", async function () {
+    await sendJsonRpcRequest(METHOD, 1, [
+      {"data": "0x60806040526040516101a63803806101a68339818101604052810190610025919061006d565b806000819055505061009a565b600080fd5b6000819050919050565b61004a81610037565b811461005557600080fd5b50565b60008151905061006781610041565b92915050565b60006020828403121561008357610082610032565b5b600061009184828501610058565b91505092915050565b60fe806100a86000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80638381f58a146037578063ef5fb05b146051575b600080fd5b603d6059565b6040516048919060af565b60405180910390f35b6057605f565b005b60005481565b7f6907508952f1c853768d61a5d281b8e23ad78ab8503ddc9404e21d6affade6d3600054604051608e919060af565b60405180910390a1565b6000819050919050565b60a9816098565b82525050565b600060208201905060c2600083018460a2565b9291505056fea26469706673582212203151b21ab4ce0f1e6e7333acb907eae279eb97b81e4926925139a34fe623454e64736f6c63430008130033000000000000000000000000000000000000000000000000000000000000002a", "from": "0xf0cb24ac66ba7375bf9b9c4fa91e208d9eaabd2e" },
+      ],
+                             (result, status) => {
+                               assert.equal(status, 200, 'has status code');
+                               assert.property(result, 'result', (result.error) ? result.error.message : 'error');
+                               assert.isString(result.result, 'is string');
+                               assert.match(result.result, /^0x/, 'should be HEX starting with 0x');
+                               assert.isNumber(+result.result, 'can be converted to a number');
+                             })
+  })
+
+  it("should not accept estimateGas with an invalid block tag", async function () {
+    await sendJsonRpcRequest(METHOD, 2, [
+      {"data": "0x60806040526040516101a63803806101a68339818101604052810190610025919061006d565b806000819055505061009a565b600080fd5b6000819050919050565b61004a81610037565b811461005557600080fd5b50565b60008151905061006781610041565b92915050565b60006020828403121561008357610082610032565b5b600061009184828501610058565b91505092915050565b60fe806100a86000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80638381f58a146037578063ef5fb05b146051575b600080fd5b603d6059565b6040516048919060af565b60405180910390f35b6057605f565b005b60005481565b7f6907508952f1c853768d61a5d281b8e23ad78ab8503ddc9404e21d6affade6d3600054604051608e919060af565b60405180910390a1565b6000819050919050565b60a9816098565b82525050565b600060208201905060c2600083018460a2565b9291505056fea26469706673582212203151b21ab4ce0f1e6e7333acb907eae279eb97b81e4926925139a34fe623454e64736f6c63430008130033000000000000000000000000000000000000000000000000000000000000002a", "from": "0xf0cb24ac66ba7375bf9b9c4fa91e208d9eaabd2e" },
+      "fish"
+      ],
+                             (result, status) => {
+                               assert.equal(status, 200, 'has status code');
+                               assert.property(result, 'error', "result should be an error");
+                               assert.equal(result.error.code, -32602);
+                             })
+  })
+})
+


### PR DESCRIPTION
Cherry-pick #3728 
* (fix) ZIL-5313: Allow an optional block_or_tag argument in eth_estimateGas
* (fix) ZIL-5313: Write an apitest command to check that it worked.
* (fix) ZIL-5313: Remove rust API tests and roll into the EvmAcceptanceTests that were already there.

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
