### PR TITLE
[master] Fix nonce from `eth_getBlockBy{Hash,Number}`

### DIFF
--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -159,7 +159,7 @@ const Json::Value JSONConversion::convertTxBlocktoEthJson(
   retJson["version"] = (boost::format("0x%x") % txheader.GetVersion()).str();
   // Required by ethers
   retJson["extraData"] = "0x";
-  retJson["nonce"] = "0x0";
+  retJson["nonce"] = "0x0000000000000000";
   retJson["receiptsRoot"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
   retJson["transactionsRoot"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
 


### PR DESCRIPTION
The spec says

> nonce: DATA, 8 Bytes - hash of the generated proof-of-work. null when its pending block.

> When encoding unformatted data (byte arrays, account addresses, hashes, bytecode arrays): encode as hex, prefix with "0x", two hex digits per byte.

Therefore, the nonce should always be 8 bytes long (e.g. `0x0000000000000000`). However, we respond with `0x0`. This causes problems for some particularly picky client (e.g. ethers.rs).