### PR TITLE
[master] Support integer block numbers in eth APIs.

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -140,10 +140,10 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
                          jsonrpc::JSON_STRING, NULL),
       &EthRpcMethods::GetEthBlockNumberI);
 
+  //Parameters are not listed to bypass library's parameter validation.
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getBalance", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
-                         "param02", jsonrpc::JSON_STRING, NULL),
+                         jsonrpc::JSON_STRING, NULL),
       &EthRpcMethods::GetEthBalanceI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -179,8 +179,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getTransactionByBlockNumberAndIndex",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                         "param01", jsonrpc::JSON_STRING, "param02",
-                         jsonrpc::JSON_STRING, NULL),
+                         NULL),
       &EthRpcMethods::GetEthTransactionByBlockNumberAndIndexI);
 
   m_lookupServer->bindAndAddExternalMethod(

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -143,12 +143,12 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   //Parameters are not listed to bypass library's parameter validation.
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getBalance", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, NULL),
+                         jsonrpc::JSON_STRING, nullptr),
       &EthRpcMethods::GetEthBalanceI);
 
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, NULL),
+                         jsonrpc::JSON_STRING, nullptr),
       &EthRpcMethods::GetEthBlockByNumberI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -179,7 +179,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getTransactionByBlockNumberAndIndex",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                         NULL),
+                         nullptr),
       &EthRpcMethods::GetEthTransactionByBlockNumberAndIndexI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -189,8 +189,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
 
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getCode", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
-                         "param02", jsonrpc::JSON_STRING, NULL),
+                         jsonrpc::JSON_STRING, nullptr),
       &EthRpcMethods::GetEthCodeI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -202,8 +201,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
 
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getTransactionCount", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
-                         "param02", jsonrpc::JSON_STRING, NULL),
+                         jsonrpc::JSON_STRING, NULL),
       &EthRpcMethods::GetEthTransactionCountI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -262,7 +260,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getUncleCountByBlockNumber",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,
-                         "param01", jsonrpc::JSON_STRING, nullptr),
+                         nullptr),
       &EthRpcMethods::GetEthUncleCountI);
 
   m_lookupServer->bindAndAddExternalMethod(

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -148,8 +148,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
 
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
-                         jsonrpc::JSON_STRING, "param01", jsonrpc::JSON_STRING,
-                         "param02", jsonrpc::JSON_BOOLEAN, NULL),
+                         jsonrpc::JSON_STRING, NULL),
       &EthRpcMethods::GetEthBlockByNumberI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -167,7 +166,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("eth_getBlockTransactionCountByNumber",
                          jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                         "param01", jsonrpc::JSON_STRING, NULL),
+                         NULL),
       &EthRpcMethods::GetEthBlockTransactionCountByNumberI);
 
   m_lookupServer->bindAndAddExternalMethod(

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -463,6 +463,11 @@ class EthRpcMethods {
   inline virtual void GetEthTransactionByBlockNumberAndIndexI(
       const Json::Value& request, Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
+
+    if (request[0].empty() || request[1].empty()){
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     response = this->GetEthTransactionByBlockNumberAndIndex(
         request[0u].asString(), request[1u].asString());
   }

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -141,7 +141,12 @@ class EthRpcMethods {
   inline virtual void GetEthTransactionCountI(const Json::Value& request,
                                               Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
+    if (request[0u].empty() || request[1u].empty()) {
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     try {
+
       std::string address = request[0u].asString();
       DataConversion::NormalizeHexString(address);
       const auto resp = this->GetBalanceAndNonce(address)["nonce"].asUInt();
@@ -192,6 +197,12 @@ class EthRpcMethods {
   inline virtual void GetEthBalanceI(const Json::Value& request,
                                      Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
+
+    // Because we bypassed the library parameters validation, let's do it manually.
+    if (request[0].empty() || request[1].empty()){
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     auto address{request[0u].asString()};
     DataConversion::NormalizeHexString(address);
 
@@ -393,6 +404,12 @@ class EthRpcMethods {
 
   virtual void GetEthCodeI(const Json::Value& request, Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
+
+    // Because we bypassed the library parameters validation, let's do it manually.
+    if (request[0].empty() || request[1].empty()){
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     response = this->GetEthCode(request[0u].asString(), request[1u].asString());
   }
 

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -427,6 +427,12 @@ class EthRpcMethods {
   inline virtual void GetEthBlockTransactionCountByNumberI(
       const Json::Value& request, Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
+
+    // Because we bypassed the library to validate parameters, we should do it manually.
+    if (request[0].empty()){
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     response =
         this->GetEthBlockTransactionCountByNumber(request[0u].asString());
   }

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -17,6 +17,8 @@
 #ifndef ZILLIQA_SRC_LIBSERVER_ETHRPCMETHODS_H_
 #define ZILLIQA_SRC_LIBSERVER_ETHRPCMETHODS_H_
 
+#include "Server.h"
+#include <jsonrpccpp/common/exception.h>
 #include "common/Constants.h"
 #include "libCrypto/EthCrypto.h"
 #include "libEth/Eth.h"
@@ -84,6 +86,12 @@ class EthRpcMethods {
                                            Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
     EnsureEvmAndLookupEnabled();
+
+    // Because we bypassed the library to validate parameters, we should do it manually.
+    if (request[0].empty() || !request[1].isBool()){
+      throw jsonrpc::JsonRpcException(ServerBase::RPC_INVALID_PARAMS);
+    }
+
     response =
         this->GetEthBlockByNumber(request[0u].asString(), request[1u].asBool());
   }

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -297,10 +297,9 @@ void IsolatedServer::BindAllEvmMethods() {
                            jsonrpc::JSON_STRING, NULL),
         &LookupServer::GetNetVersionI);
 
+    //Parameters are not listed to bypass library's parameter validation.
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getBalance", jsonrpc::PARAMS_BY_POSITION,
-                           jsonrpc::JSON_STRING, "param01",
-                           jsonrpc::JSON_STRING, "param02",
                            jsonrpc::JSON_STRING, NULL),
         &LookupServer::GetEthBalanceI);
 
@@ -395,8 +394,7 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getTransactionByBlockNumberAndIndex",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                           "param01", jsonrpc::JSON_STRING, "param02",
-                           jsonrpc::JSON_STRING, NULL),
+                           NULL),
         &LookupServer::GetEthTransactionByBlockNumberAndIndexI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -242,7 +242,7 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getUncleCountByBlockNumber",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_ARRAY,
-                           "param01", jsonrpc::JSON_STRING, nullptr),
+                           nullptr),
         &LookupServer::GetEthUncleCountI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
@@ -305,7 +305,7 @@ void IsolatedServer::BindAllEvmMethods() {
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
-                           jsonrpc::JSON_STRING, NULL),
+                           jsonrpc::JSON_STRING, nullptr),
         &LookupServer::GetEthBlockByNumberI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
@@ -331,8 +331,7 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getTransactionCount",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                           "param01", jsonrpc::JSON_STRING, "param02",
-                           jsonrpc::JSON_STRING, NULL),
+                           NULL),
         &LookupServer::GetEthTransactionCountI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
@@ -367,9 +366,7 @@ void IsolatedServer::BindAllEvmMethods() {
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getCode", jsonrpc::PARAMS_BY_POSITION,
-                           jsonrpc::JSON_STRING, "param01",
-                           jsonrpc::JSON_STRING, "param02",
-                           jsonrpc::JSON_STRING, NULL),
+                           jsonrpc::JSON_STRING, nullptr),
         &LookupServer::GetEthCodeI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
@@ -394,7 +391,7 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getTransactionByBlockNumberAndIndex",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                           NULL),
+                           nullptr),
         &LookupServer::GetEthTransactionByBlockNumberAndIndexI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -382,7 +382,7 @@ void IsolatedServer::BindAllEvmMethods() {
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getBlockTransactionCountByNumber",
                            jsonrpc::PARAMS_BY_POSITION, jsonrpc::JSON_STRING,
-                           "param01", jsonrpc::JSON_STRING, NULL),
+                           NULL),
         &LookupServer::GetEthBlockTransactionCountByNumberI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/src/libServer/IsolatedServer.cpp
+++ b/src/libServer/IsolatedServer.cpp
@@ -306,9 +306,7 @@ void IsolatedServer::BindAllEvmMethods() {
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(
         jsonrpc::Procedure("eth_getBlockByNumber", jsonrpc::PARAMS_BY_POSITION,
-                           jsonrpc::JSON_STRING, "param01",
-                           jsonrpc::JSON_STRING, "param02",
-                           jsonrpc::JSON_BOOLEAN, NULL),
+                           jsonrpc::JSON_STRING, NULL),
         &LookupServer::GetEthBlockByNumberI);
 
     AbstractServer<IsolatedServer>::bindAndAddMethod(

--- a/tests/EvmAcceptanceTests/helpers/parallel-tests/Display.ts
+++ b/tests/EvmAcceptanceTests/helpers/parallel-tests/Display.ts
@@ -1,5 +1,5 @@
 import clc from "cli-color";
-import { performance } from "perf_hooks";
+import {performance} from "perf_hooks";
 
 export class Chronometer {
   constructor() {

--- a/tests/EvmAcceptanceTests/helpers/parallel-tests/Scenario.ts
+++ b/tests/EvmAcceptanceTests/helpers/parallel-tests/Scenario.ts
@@ -13,7 +13,7 @@ export enum Block {
 export type TestInfo = {
   txn: Txn;
   msg: string;
-  describes: string[];   // Because `describe` blocks can be nested, this test can belong to a nested describe, this is a list of all of its describes
+  describes: string[]; // Because `describe` blocks can be nested, this test can belong to a nested describe, this is a list of all of its describes
   run_in: Block;
   disabled?: true;
 };

--- a/tests/EvmAcceptanceTests/helpers/parallel-tests/Worker.ts
+++ b/tests/EvmAcceptanceTests/helpers/parallel-tests/Worker.ts
@@ -1,15 +1,19 @@
 import {HardhatRuntimeEnvironment} from "hardhat/types";
 import {Block, Scenario, TestInfo, Txn} from "./Scenario";
 import fs from "fs";
-import { getState, resetState } from 'jest-circus';
+import {getState, resetState} from "jest-circus";
 
-const processDescribeChild = (child: any, describes: string[], regex: RegExp): [tests: TestInfo[], beforeHooks: Txn[]] => {
-  const nestedDescribes = [...describes, child.name]
+const processDescribeChild = (
+  child: any,
+  describes: string[],
+  regex: RegExp
+): [tests: TestInfo[], beforeHooks: Txn[]] => {
+  const nestedDescribes = [...describes, child.name];
   const allTests: TestInfo[] = [];
   const allBeforeBlocks: Txn[] = [];
   allBeforeBlocks.push(...child.hooks.filter((hook: any) => hook.type === "beforeAll").map((hook: any) => hook.fn));
   for (const subChild of child.children) {
-    if (subChild.type === 'describeBlock') {
+    if (subChild.type === "describeBlock") {
       const [tests, beforeHooks] = processDescribeChild(subChild, nestedDescribes, regex);
       allTests.push(...tests);
       allBeforeBlocks.push(...beforeHooks);
@@ -20,20 +24,20 @@ const processDescribeChild = (child: any, describes: string[], regex: RegExp): [
       } catch (error) {
         continue;
       }
-      
+
       if (regex.test(subChild.name)) {
         allTests.push({
           txn: subChild.fn,
           msg: subChild.name,
           describes: nestedDescribes,
           run_in: block
-        })
+        });
       }
     }
   }
 
   return [allTests, allBeforeBlocks];
-}
+};
 
 export const parseTestFile = async function (
   testFile: string,
@@ -47,7 +51,7 @@ export const parseTestFile = async function (
   const before = beforeAll;\n
   const after = afterAll;\n
   const xit = () => {};
-  ${await fs.promises.readFile(testFile, "utf8")}`
+  ${await fs.promises.readFile(testFile, "utf8")}`;
 
   // Does file contain #parallel tag?? If not, skip it!
   if (!code.includes("#parallel")) {
@@ -56,7 +60,7 @@ export const parseTestFile = async function (
 
   await fs.promises.writeFile(testFile, code);
 
-  require(fs.realpathSync(testFile))
+  require(fs.realpathSync(testFile));
 
   const state = getState();
 
@@ -71,9 +75,8 @@ export const parseTestFile = async function (
       scenarios.push({
         scenario_name: describeName,
         beforeHooks,
-        tests,
-
-      })
+        tests
+      });
     }
   }
 

--- a/tests/EvmAcceptanceTests/tasks/InitSigners.ts
+++ b/tests/EvmAcceptanceTests/tasks/InitSigners.ts
@@ -18,13 +18,17 @@ task("init-signers", "A task to init signers")
     spinner.start(`Creating ${count} accounts...`);
 
     const accounts = await createAccountsEth(hre, from, hre.ethers.utils.parseEther(balance), count);
-  
+
     spinner.succeed();
 
     const file_name = `${hre.network.name}.json`;
 
     try {
-      await writeToFile(accounts.map(account => account.privateKey), append, file_name);
+      await writeToFile(
+        accounts.map((account) => account.privateKey),
+        append,
+        file_name
+      );
       console.log();
       console.log(
         clc.bold(`.signers/${file_name}`),
@@ -45,16 +49,19 @@ const writeToFile = async (signers: string[], append: boolean, file_name: string
   await fs.promises.writeFile(join(".signers", file_name), JSON.stringify(current_signers));
 };
 
-const createAccountsEth = async (hre: HardhatRuntimeEnvironment, privateKey: string, amount: BigNumber, count: number) => {
+const createAccountsEth = async (
+  hre: HardhatRuntimeEnvironment,
+  privateKey: string,
+  amount: BigNumber,
+  count: number
+) => {
   const wallet = new ethers.Wallet(privateKey, hre.ethers.provider);
 
   if ((await wallet.getBalance()).isZero()) {
     throw new Error("Sender doesn't have enough fund in its eth address.");
   }
 
-  const accounts = Array.from({length: count}, (v, k) =>
-    ethers.Wallet.createRandom().connect(hre.ethers.provider)
-  );
+  const accounts = Array.from({length: count}, (v, k) => ethers.Wallet.createRandom().connect(hre.ethers.provider));
 
   const addresses = accounts.map((signer) => signer.address);
 

--- a/tests/EvmAcceptanceTests/tasks/ParallelTest.ts
+++ b/tests/EvmAcceptanceTests/tasks/ParallelTest.ts
@@ -14,7 +14,7 @@ task("parallel-test", "Runs test in parallel")
   .setAction(async (taskArgs, hre) => {
     hre.run("compile");
     const signersCount = hre.signer_pool.count();
-  
+
     const {grep, testFiles}: {grep: string | undefined; testFiles: string[]} = taskArgs;
 
     // Running Typescript
@@ -44,7 +44,7 @@ task("parallel-test", "Runs test in parallel")
     // Display results
     await hre.run("parallel-test:output-results", {failures});
 
-    console.log(`🪪  ${clc.bold.white(signersCount - hre.signer_pool.count())} signers used.`)
+    console.log(`🪪  ${clc.bold.white(signersCount - hre.signer_pool.count())} signers used.`);
   });
 
 subtask("parallel-test:run-tsc", "Runs tsc to make sure everything's synced").setAction(async () => {
@@ -110,7 +110,7 @@ subtask("parallel-test:parse-files", "Parses files to extract parallel tests")
                 displayIgnored(`\`${scenario.scenario_name}\` doesn't have any tests. Did you add @block-n to tests?`);
                 return;
               }
-              
+
               beforeFns.push(...scenario.beforeHooks.map((hook) => hook()));
               scenarios.push(scenario);
             });
@@ -171,7 +171,7 @@ subtask("parallel-test:run", "Runs the tests").setAction(async (taskArgs) => {
 
 subtask("parallel-test:output-results", "Outputs test results").setAction(async (taskArgs) => {
   const {failures}: {failures: FailureResult[]} = taskArgs;
-  const space = (n: number) => ' '.repeat(n);
+  const space = (n: number) => " ".repeat(n);
 
   if (failures.length > 0) {
     console.log(clc.bold.bgRed(`Failures (${failures.length})`));
@@ -181,11 +181,19 @@ subtask("parallel-test:output-results", "Outputs test results").setAction(async 
       failure.describes.forEach((describe, describeIndex) => {
         currentIndent += describeIndex;
         console.log(`${space(currentIndent)}${describe}`);
-      })
+      });
       console.log(`${space(currentIndent + 1)}${clc.white.bold(failure.test_case)}`);
-      console.log(`${space(currentIndent + 2)}${clc.red.bold("Actual: ")} ${clc.red((failure.result as any).reason.actual)}`);
-      console.log(`${space(currentIndent + 2)}${clc.green.bold("Expected: ")} ${clc.red((failure.result as any).reason.expected)}`);
-      console.log(`${space(currentIndent + 2)}${clc.yellow.bold("Operator: ")} ${clc.red((failure.result as any).reason.operator)}`);
+      console.log(
+        `${space(currentIndent + 2)}${clc.red.bold("Actual: ")} ${clc.red((failure.result as any).reason.actual)}`
+      );
+      console.log(
+        `${space(currentIndent + 2)}${clc.green.bold("Expected: ")} ${clc.red((failure.result as any).reason.expected)}`
+      );
+      console.log(
+        `${space(currentIndent + 2)}${clc.yellow.bold("Operator: ")} ${clc.red(
+          (failure.result as any).reason.operator
+        )}`
+      );
       console.log();
     });
   }

--- a/tests/EvmAcceptanceTests/test/ChainedCalls.ts
+++ b/tests/EvmAcceptanceTests/test/ChainedCalls.ts
@@ -1,7 +1,7 @@
-import { assert, expect } from "chai";
-import { Contract } from "ethers";
+import {assert, expect} from "chai";
+import {Contract} from "ethers";
 import sendJsonRpcRequest from "../helpers/JsonRpcHelper";
-import hre, { ethers } from "hardhat";
+import hre, {ethers} from "hardhat";
 
 describe("Chained Contract Calls Functionality #parallel", function () {
   let contractOne: Contract;
@@ -13,7 +13,8 @@ describe("Chained Contract Calls Functionality #parallel", function () {
       [contractOne, contractTwo, contractThree] = await Promise.all([
         await hre.deployContract("ContractOne"),
         await hre.deployContract("ContractTwo"),
-        await hre.deployContract("ContractThree")]);
+        await hre.deployContract("ContractThree")
+      ]);
     } else {
       contractOne = await hre.deployContract("ContractOne");
       contractTwo = await hre.deployContract("ContractTwo");
@@ -40,7 +41,7 @@ describe("Chained Contract Calls Functionality #parallel", function () {
       let res = await contractOne.chainedCall([addrTwo, addrThree, addrOne], 0);
 
       // Now call contract one, passing in the addresses of contracts two and three
-      let tracer = { tracer: "callTracer" };
+      let tracer = {tracer: "callTracer"};
 
       const receipt = await ethers.provider.getTransactionReceipt(res.hash);
 
@@ -76,7 +77,7 @@ describe("Chained Contract Calls Functionality #parallel", function () {
         );
       });
 
-      let secondTracer = { tracer: "raw" };
+      let secondTracer = {tracer: "raw"};
 
       await sendJsonRpcRequest(METHOD, 1, [res.hash, secondTracer], (result, status) => {
         assert.equal(status, 200, "has status code");

--- a/tests/EvmAcceptanceTests/test/ERC20isZRC2.ts
+++ b/tests/EvmAcceptanceTests/test/ERC20isZRC2.ts
@@ -174,9 +174,9 @@ describe("ERC20 Is ZRC2", function () {
 
     const queriedLogs = await erc20_contract.queryFilter(filter);
     expect(
-        queriedLogs.every((e) => {
-          return e["data"].startsWith("0x");
-        })
+      queriedLogs.every((e) => {
+        return e["data"].startsWith("0x");
+      })
     ).to.be.equal(true);
   });
 

--- a/tests/EvmAcceptanceTests/test/Transfer.ts
+++ b/tests/EvmAcceptanceTests/test/Transfer.ts
@@ -19,7 +19,9 @@ describe("ForwardZil contract functionality #parallel", function () {
     expect(await ethers.provider.getBalance(contract.address)).to.be.eq(0);
   });
 
-  it(`Should move ${ethers.utils.formatEther(FUND)} ethers to the contract if deposit is called @block-1`, async function () {
+  it(`Should move ${ethers.utils.formatEther(
+    FUND
+  )} ethers to the contract if deposit is called @block-1`, async function () {
     await contract.deposit({value: FUND});
     expect(await ethers.provider.getBalance(contract.address)).to.be.eq(FUND);
   });

--- a/tests/EvmAcceptanceTests/test/contract-deployment/ContractDeploymentEthers.ts
+++ b/tests/EvmAcceptanceTests/test/contract-deployment/ContractDeploymentEthers.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import hre, {ethers} from "hardhat";
 import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
-import { Contract } from "ethers";
+import {Contract} from "ethers";
 
 describe("Contract Deployment using Ethers.js #parallel", function () {
   describe("Contract with zero parameter constructor", function () {

--- a/tests/EvmAcceptanceTests/test/openzeppelin/access-control/Ownable.ts
+++ b/tests/EvmAcceptanceTests/test/openzeppelin/access-control/Ownable.ts
@@ -1,6 +1,6 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers";
 import {expect} from "chai";
-import { Contract } from "ethers";
+import {Contract} from "ethers";
 import hre, {ethers} from "hardhat";
 
 describe("Openzeppelin ownable contract functionality #parallel", function () {
@@ -25,7 +25,7 @@ describe("Openzeppelin ownable contract functionality #parallel", function () {
     const notOwner = hre.allocateSigner();
 
     await expect(contract.connect(notOwner).store(123)).to.be.revertedWith("Ownable: caller is not the owner");
-  
+
     hre.releaseSigner(notOwner);
   });
 

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_getInternalOperations.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_getInternalOperations.ts
@@ -1,7 +1,7 @@
 import {assert, expect} from "chai";
 import hre, {ethers} from "hardhat";
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { Contract, Wallet } from "ethers";
+import {Contract, Wallet} from "ethers";
 
 const METHOD = "ots_getInternalOperations";
 describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
@@ -17,12 +17,9 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
       assert.equal(status, 200, "has status code");
     });
 
-
     const ACCOUNTS_COUNT = 3;
 
-    accounts = Array.from({length: ACCOUNTS_COUNT}, (v, k) =>
-      ethers.Wallet.createRandom().connect(ethers.provider)
-    );
+    accounts = Array.from({length: ACCOUNTS_COUNT}, (v, k) => ethers.Wallet.createRandom().connect(ethers.provider));
 
     addresses = accounts.map((signer) => signer.address);
 
@@ -32,7 +29,6 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
   });
 
   it("We can get the otter internal operations @block-1", async function () {
-
     // Check we can for example detect a suicide with correct value.
     // Below is taken from transfer.ts test
 
@@ -48,5 +44,4 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
       assert.equal(jsonObject[3]["type"], 1, "has correct type for self destruct");
     });
   });
-
 });

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionError.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionError.ts
@@ -1,7 +1,7 @@
 import {assert, expect} from "chai";
 import hre, {ethers} from "hardhat";
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { Contract } from "ethers";
+import {Contract} from "ethers";
 
 const METHOD = "ots_getTransactionError";
 describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
@@ -37,5 +37,4 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
       assert.equal(jsonObject, MESSAGE_ENCODED);
     });
   });
-
 });

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_searchTransactions.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_searchTransactions.ts
@@ -1,7 +1,7 @@
 import {assert, expect} from "chai";
 import hre, {ethers} from "hardhat";
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { Contract, Wallet } from "ethers";
+import {Contract, Wallet} from "ethers";
 
 const METHOD_BEFORE = "ots_searchTransactionsBefore";
 const METHOD_AFTER = "ots_searchTransactionsAfter";
@@ -20,13 +20,11 @@ describe(`Otterscan api tests: ${METHOD_AFTER} #parallel`, function () {
     await sendJsonRpcRequest(METHOD_ENABLE, 1, [true], (result, status) => {
       assert.equal(status, 200, "has status code");
     });
-  
+
     // Get the block height so we can check before/after
     height = await ethers.provider.getBlockNumber();
 
-    accounts = Array.from({length: ACCOUNTS_COUNT}, (v, k) =>
-      ethers.Wallet.createRandom().connect(ethers.provider)
-    );
+    accounts = Array.from({length: ACCOUNTS_COUNT}, (v, k) => ethers.Wallet.createRandom().connect(ethers.provider));
 
     addresses = accounts.map((signer) => signer.address);
 
@@ -36,7 +34,6 @@ describe(`Otterscan api tests: ${METHOD_AFTER} #parallel`, function () {
   });
 
   it("We can get the otter search TX before and after @block-1", async function () {
-
     // run the contract that batch sends funds to other addresses
     // then we can check that this txid comes up when asking about
     // these contract addresses.
@@ -48,7 +45,11 @@ describe(`Otterscan api tests: ${METHOD_AFTER} #parallel`, function () {
       assert.equal(status, 200, "has status code");
 
       let jsonObject = result.result;
-      assert.equal(jsonObject.txs[0].hash, contract.deployTransaction.hash, "Can find the TX which send funds to this addr");
+      assert.equal(
+        jsonObject.txs[0].hash,
+        contract.deployTransaction.hash,
+        "Can find the TX which send funds to this addr"
+      );
     });
 
     // There should be nothing before this point

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_traceTransaction.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_traceTransaction.ts
@@ -1,7 +1,7 @@
 import {assert, expect} from "chai";
 import hre, {ethers} from "hardhat";
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { Contract } from "ethers";
+import {Contract} from "ethers";
 
 const METHOD = "ots_traceTransaction";
 describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
@@ -20,7 +20,8 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
       [contractOne, contractTwo, contractThree] = await Promise.all([
         await hre.deployContract("ContractOne"),
         await hre.deployContract("ContractTwo"),
-        await hre.deployContract("ContractThree")]);
+        await hre.deployContract("ContractThree")
+      ]);
     } else {
       contractOne = await hre.deployContract("ContractOne");
       contractTwo = await hre.deployContract("ContractTwo");

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.ts
@@ -1,12 +1,12 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
-import { ethers } from "hardhat";
+import {assert} from "chai";
+import {ethers} from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 
 const METHOD = "eth_getBalance";
 
-describe(`Calling ${METHOD} #parallel`, function() {
-  it("should return the latest balance from the specified account #parallel", async function() {
+describe(`Calling ${METHOD} #parallel`, function () {
+  it("should return the latest balance from the specified account #parallel", async function () {
     const [signer] = await ethers.getSigners();
     await sendJsonRpcRequest(METHOD, 1, [signer.address, "latest"], (result, status) => {
       logDebug("Result:", result);
@@ -26,7 +26,7 @@ describe(`Calling ${METHOD} #parallel`, function() {
     });
   });
 
-  it("should return the earliest balance as specified in the ethereum protocol @block-1", async function() {
+  it("should return the earliest balance as specified in the ethereum protocol @block-1", async function () {
     const [signer] = await ethers.getSigners();
     await sendJsonRpcRequest(METHOD, 1, [signer.address, "earliest"], (result, status) => {
       logDebug("Result:", result);
@@ -46,7 +46,7 @@ describe(`Calling ${METHOD} #parallel`, function() {
     });
   });
 
-  it("should return the pending balance as specified in the ethereum protocol @block-1", async function() {
+  it("should return the pending balance as specified in the ethereum protocol @block-1", async function () {
     const [signer] = await ethers.getSigners();
     await sendJsonRpcRequest(METHOD, 1, [signer.address, "pending"], (result, status) => {
       logDebug("Result:", result);
@@ -66,7 +66,7 @@ describe(`Calling ${METHOD} #parallel`, function() {
     });
   });
 
-  it("should return an error requesting the balance due to invalid tag @block-1", async function() {
+  it("should return an error requesting the balance due to invalid tag @block-1", async function () {
     let expectedErrorMessage = "Unable To Process, invalid tag";
     let errorCode = -1;
     const [signer] = await ethers.getSigners();
@@ -84,8 +84,8 @@ describe(`Calling ${METHOD} #parallel`, function() {
     );
   });
 
-  it("should return an error requesting the balance due to insufficient parameters @block-1", async function() {
-    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+  it("should return an error requesting the balance due to insufficient parameters @block-1", async function () {
+    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised";
     let errorCode = -32602;
     const [signer] = await ethers.getSigners();
     await sendJsonRpcRequest(
@@ -102,8 +102,8 @@ describe(`Calling ${METHOD} #parallel`, function() {
     );
   });
 
-  it("should return an error requesting the balance if no parameters is specified @block-1", async function() {
-    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+  it("should return an error requesting the balance if no parameters is specified @block-1", async function () {
+    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised";
     let errorCode = -32602;
     await sendJsonRpcRequest(
       METHOD,

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBalance.ts
@@ -1,99 +1,121 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import {assert} from "chai";
-import {ethers} from "hardhat";
+import { assert } from "chai";
+import { ethers } from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
-import hre from "hardhat";
 
 const METHOD = "eth_getBalance";
 
-describe(`Calling ${METHOD} #parallel`, function () {
-  describe("When tag is 'latest'", function () {
-    it("should return the latest balance from the specified account #parallel", async function () {
-      const [signer] = await ethers.getSigners();
-      await sendJsonRpcRequest(METHOD, 1, [signer.address, "latest"], (result, status) => {
-        logDebug("Result:", result);
+describe(`Calling ${METHOD} #parallel`, function() {
+  it("should return the latest balance from the specified account #parallel", async function() {
+    const [signer] = await ethers.getSigners();
+    await sendJsonRpcRequest(METHOD, 1, [signer.address, "latest"], (result, status) => {
+      logDebug("Result:", result);
 
-        assert.equal(status, 200, "has status code");
-        assert.property(result, "result", result.error ? result.error.message : "error");
-        assert.isString(result.result, "is string");
-        assert.match(result.result, /^0x/, "should be HEX starting with 0x");
-        assert.isNumber(+result.result, "can be converted to a number");
+      assert.equal(status, 200, "has status code");
+      assert.property(result, "result", result.error ? result.error.message : "error");
+      assert.isString(result.result, "is string");
+      assert.match(result.result, /^0x/, "should be HEX starting with 0x");
+      assert.isNumber(+result.result, "can be converted to a number");
 
-        var expectedBalance = 0;
-        assert.isAbove(
-          +result.result,
-          expectedBalance,
-          "Has result:" + result + " should have balance " + expectedBalance
-        );
-      });
-    });
-  });
-
-  describe("When tag is 'earliest'", function () {
-    describe("When on Zilliqa network", function () {
-      it("should return the earliest balance as specified in the ethereum protocol @block-1", async function () {
-        const [signer] = await ethers.getSigners();
-        await sendJsonRpcRequest(METHOD, 1, [signer.address, "earliest"], (result, status) => {
-          logDebug("Result:", result);
-
-          assert.equal(status, 200, "has status code");
-          assert.property(result, "result", result.error ? result.error.message : "error");
-          assert.isString(result.result, "is string");
-          assert.match(result.result, /^0x/, "should be HEX starting with 0x");
-          assert.isNumber(+result.result, "can be converted to a number");
-
-          var expectedBalance = 0;
-          assert.isAbove(
-            +result.result,
-            expectedBalance,
-            "Has result:" + result + " should have balance " + expectedBalance
-          );
-        });
-      });
-    });
-  });
-
-  describe("When tag is 'pending'", function () {
-    describe("When on Zilliqa network", function () {
-      it("should return the pending balance as specified in the ethereum protocol @block-1", async function () {
-        const [signer] = await ethers.getSigners();
-        await sendJsonRpcRequest(METHOD, 1, [signer.address, "pending"], (result, status) => {
-          logDebug("Result:", result);
-
-          assert.equal(status, 200, "has status code");
-          assert.property(result, "result", result.error ? result.error.message : "error");
-          assert.isString(result.result, "is string");
-          assert.match(result.result, /^0x/, "should be HEX starting with 0x");
-          assert.isNumber(+result.result, "can be converted to a number");
-
-          var expectedBalance = 0;
-          assert.isAbove(
-            +result.result,
-            expectedBalance,
-            "Has result:" + result + " should have balance " + expectedBalance
-          );
-        });
-      });
-    });
-  });
-
-  describe("When tag is 'unknown tag'", function () {
-    it("should return an error requesting the balance due to invalid tag @block-1", async function () {
-      let expectedErrorMessage = "Unable To Process, invalid tag";
-      let errorCode = -1;
-      const [signer] = await ethers.getSigners();
-      await sendJsonRpcRequest(
-        METHOD,
-        1,
-        [signer.address, "unknown tag"], // not supported tag should give an error
-        (result, status) => {
-          logDebug(result);
-
-          assert.equal(status, 200, "has status code");
-          assert.equal(result.error.code, errorCode);
-          assert.equal(result.error.message, expectedErrorMessage);
-        }
+      var expectedBalance = 0;
+      assert.isAbove(
+        +result.result,
+        expectedBalance,
+        "Has result:" + result + " should have balance " + expectedBalance
       );
     });
+  });
+
+  it("should return the earliest balance as specified in the ethereum protocol @block-1", async function() {
+    const [signer] = await ethers.getSigners();
+    await sendJsonRpcRequest(METHOD, 1, [signer.address, "earliest"], (result, status) => {
+      logDebug("Result:", result);
+
+      assert.equal(status, 200, "has status code");
+      assert.property(result, "result", result.error ? result.error.message : "error");
+      assert.isString(result.result, "is string");
+      assert.match(result.result, /^0x/, "should be HEX starting with 0x");
+      assert.isNumber(+result.result, "can be converted to a number");
+
+      var expectedBalance = 0;
+      assert.isAbove(
+        +result.result,
+        expectedBalance,
+        "Has result:" + result + " should have balance " + expectedBalance
+      );
+    });
+  });
+
+  it("should return the pending balance as specified in the ethereum protocol @block-1", async function() {
+    const [signer] = await ethers.getSigners();
+    await sendJsonRpcRequest(METHOD, 1, [signer.address, "pending"], (result, status) => {
+      logDebug("Result:", result);
+
+      assert.equal(status, 200, "has status code");
+      assert.property(result, "result", result.error ? result.error.message : "error");
+      assert.isString(result.result, "is string");
+      assert.match(result.result, /^0x/, "should be HEX starting with 0x");
+      assert.isNumber(+result.result, "can be converted to a number");
+
+      var expectedBalance = 0;
+      assert.isAbove(
+        +result.result,
+        expectedBalance,
+        "Has result:" + result + " should have balance " + expectedBalance
+      );
+    });
+  });
+
+  it("should return an error requesting the balance due to invalid tag @block-1", async function() {
+    let expectedErrorMessage = "Unable To Process, invalid tag";
+    let errorCode = -1;
+    const [signer] = await ethers.getSigners();
+    await sendJsonRpcRequest(
+      METHOD,
+      1,
+      [signer.address, "unknown tag"], // not supported tag should give an error
+      (result, status) => {
+        logDebug(result);
+
+        assert.equal(status, 200, "has status code");
+        assert.equal(result.error.code, errorCode);
+        assert.equal(result.error.message, expectedErrorMessage);
+      }
+    );
+  });
+
+  it("should return an error requesting the balance due to insufficient parameters @block-1", async function() {
+    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+    let errorCode = -32602;
+    const [signer] = await ethers.getSigners();
+    await sendJsonRpcRequest(
+      METHOD,
+      1,
+      [signer.address], // insufficient parameters
+      (result, status) => {
+        logDebug(result);
+
+        assert.equal(status, 200, "has status code");
+        assert.equal(result.error.code, errorCode);
+        assert.equal(result.error.message, expectedErrorMessage);
+      }
+    );
+  });
+
+  it("should return an error requesting the balance if no parameters is specified @block-1", async function() {
+    let expectedErrorMessage = "INVALID_PARAMS: Invalid method parameters (invalid name and/or type) recognised"
+    let errorCode = -32602;
+    await sendJsonRpcRequest(
+      METHOD,
+      1,
+      [], // insufficient parameters
+      (result, status) => {
+        logDebug(result);
+
+        assert.equal(status, 200, "has status code");
+        assert.equal(result.error.code, errorCode);
+        assert.equal(result.error.message, expectedErrorMessage);
+      }
+    );
   });
 });

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.ts
@@ -1,11 +1,11 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import {assert} from "chai";
+import { assert } from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 
 const METHOD = "eth_getBlockByNumber";
 
-describe("Calling " + METHOD, function () {
+describe("Calling " + METHOD, function() {
   function TestResponse(response: any) {
     // validate all returned fields
 
@@ -69,7 +69,7 @@ describe("Calling " + METHOD, function () {
     assert.isArray(response.result.uncles, "Is not an array");
   }
 
-  it("should return an error when called with no parameters", async function () {
+  it("should return an error when called with no parameters", async function() {
     await sendJsonRpcRequest(METHOD, 1, [], (result, status) => {
       logDebug(result);
 
@@ -85,7 +85,7 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should return an error when called with only first parameter", async function () {
+  it("should return an error when called with only first parameter", async function() {
     await sendJsonRpcRequest(METHOD, 1, ["latest"], (result, status) => {
       logDebug(result);
       assert.equal(status, 200, "has status code");
@@ -100,7 +100,7 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should get full transactions objects by 'unknown tag' tag", async function () {
+  it("should get full transactions objects by 'unknown tag' tag", async function() {
     await sendJsonRpcRequest(METHOD, 2, ["unknown tag", true], (result, status) => {
       logDebug(result);
 
@@ -109,7 +109,7 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should get full transactions objects by 'latest' tag", async function () {
+  it("should get full transactions objects by 'latest' tag", async function() {
     await sendJsonRpcRequest(METHOD, 2, ["latest", true], (result, status) => {
       logDebug(result);
 
@@ -119,7 +119,7 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should get only the hashes of the transactions by 'latest' tag", async function () {
+  it("should get only the hashes of the transactions by 'latest' tag", async function() {
     await sendJsonRpcRequest(METHOD, 2, ["latest", false], (result, status) => {
       logDebug(result);
 
@@ -129,15 +129,67 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  describe("When executing 'earliest' tag", function () {
+  it("should get full transactions objects by its block number", async function() {
+    let blockNumber = 0x1;
+
+    await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
+      logDebug(result);
+
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
+    });
+  });
+
+  it("should get only the hashes of transactions objects by its block number", async function() {
+    let blockNumber = 0x1;
+
+    await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
+      logDebug(result);
+
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
+    });
+  });
+
+  it("should get full transactions objects by its block number, even if number is specified as a string", async function() {
+    let blockNumber = "0x1";
+
+    await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
+      logDebug(result);
+
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(result.result.number, blockNumber, `Block number is not ${blockNumber}`);
+    });
+  });
+
+  it("should get only the hashes of transactions objects by its block number, even if number is specified as a string", async function() {
+    let blockNumber = "0x1";
+
+    await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
+      logDebug(result);
+
+      assert.equal(status, 200, "has status code");
+      // validate all returned fields
+      TestResponse(result);
+      assert.equal(result.result.number, blockNumber, `Block number is not ${blockNumber}`);
+    });
+  });
+
+  describe("When executing 'earliest' tag", function() {
     let blockNumber = 0x0;
-    before(async function () {
+    before(async function() {
       if (hre.getNetworkName() == "isolated_server") {
         this.skip(); // FIXME: isolated server does not returns block '0' back, but a null object. see ZIL-4877
       }
     });
 
-    it("should get full transactions objects by 'earliest' tag", async function () {
+    it("should get full transactions objects by 'earliest' tag", async function() {
       await sendJsonRpcRequest(METHOD, 2, ["earliest", true], (result, status) => {
         logDebug(result);
 
@@ -148,7 +200,7 @@ describe("Calling " + METHOD, function () {
       });
     });
 
-    it("should get only the hashes of the transactions objects by 'earliest' tag", async function () {
+    it("should get only the hashes of the transactions objects by 'earliest' tag", async function() {
       await sendJsonRpcRequest(METHOD, 2, ["earliest", false], (result, status) => {
         logDebug(result);
 
@@ -160,50 +212,14 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should get full transactions objects by its block number '0'", async function () {
-    let blockNumber = 0x0;
-    before(async function () {
-      if (hre.isZilliqaNetworkSelected()) {
-        blockNumber = 0x1;
-      }
-
-      await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
-        logDebug(result);
-
-        assert.equal(status, 200, "has status code");
-        // validate all returned fields
-        TestResponse(result);
-        assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
-      });
-    });
-  });
-
-  it("should get only the hashes of transactions objects by its block number '0'", async function () {
-    let blockNumber = 0x0;
-    before(async function () {
-      if (hre.isZilliqaNetworkSelected()) {
-        blockNumber = 0x1;
-      }
-
-      await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
-        logDebug(result);
-
-        assert.equal(status, 200, "has status code");
-        // validate all returned fields
-        TestResponse(result);
-        assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
-      });
-    });
-  });
-
-  describe("When on Zilliqa network", function () {
-    before(function () {
+  describe("When on Zilliqa network", function() {
+    before(function() {
       if (!hre.isZilliqaNetworkSelected()) {
         this.skip();
       }
     });
 
-    it("should get full transactions objects by 'pending' tag", async function () {
+    it("should get full transactions objects by 'pending' tag", async function() {
       await sendJsonRpcRequest(METHOD, 2, ["pending", true], (result, status) => {
         logDebug(result);
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getBlockByNumber.ts
@@ -1,11 +1,11 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
+import {assert} from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 
 const METHOD = "eth_getBlockByNumber";
 
-describe("Calling " + METHOD, function() {
+describe("Calling " + METHOD, function () {
   function TestResponse(response: any) {
     // validate all returned fields
 
@@ -69,7 +69,7 @@ describe("Calling " + METHOD, function() {
     assert.isArray(response.result.uncles, "Is not an array");
   }
 
-  it("should return an error when called with no parameters", async function() {
+  it("should return an error when called with no parameters", async function () {
     await sendJsonRpcRequest(METHOD, 1, [], (result, status) => {
       logDebug(result);
 
@@ -85,7 +85,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should return an error when called with only first parameter", async function() {
+  it("should return an error when called with only first parameter", async function () {
     await sendJsonRpcRequest(METHOD, 1, ["latest"], (result, status) => {
       logDebug(result);
       assert.equal(status, 200, "has status code");
@@ -100,7 +100,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get full transactions objects by 'unknown tag' tag", async function() {
+  it("should get full transactions objects by 'unknown tag' tag", async function () {
     await sendJsonRpcRequest(METHOD, 2, ["unknown tag", true], (result, status) => {
       logDebug(result);
 
@@ -109,7 +109,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get full transactions objects by 'latest' tag", async function() {
+  it("should get full transactions objects by 'latest' tag", async function () {
     await sendJsonRpcRequest(METHOD, 2, ["latest", true], (result, status) => {
       logDebug(result);
 
@@ -119,7 +119,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get only the hashes of the transactions by 'latest' tag", async function() {
+  it("should get only the hashes of the transactions by 'latest' tag", async function () {
     await sendJsonRpcRequest(METHOD, 2, ["latest", false], (result, status) => {
       logDebug(result);
 
@@ -129,7 +129,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get full transactions objects by its block number", async function() {
+  it("should get full transactions objects by its block number", async function () {
     let blockNumber = 0x1;
 
     await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
@@ -142,7 +142,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get only the hashes of transactions objects by its block number", async function() {
+  it("should get only the hashes of transactions objects by its block number", async function () {
     let blockNumber = 0x1;
 
     await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
@@ -155,7 +155,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get full transactions objects by its block number, even if number is specified as a string", async function() {
+  it("should get full transactions objects by its block number, even if number is specified as a string", async function () {
     let blockNumber = "0x1";
 
     await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
@@ -168,7 +168,7 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  it("should get only the hashes of transactions objects by its block number, even if number is specified as a string", async function() {
+  it("should get only the hashes of transactions objects by its block number, even if number is specified as a string", async function () {
     let blockNumber = "0x1";
 
     await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
@@ -181,15 +181,15 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  describe("When executing 'earliest' tag", function() {
+  describe("When executing 'earliest' tag", function () {
     let blockNumber = 0x0;
-    before(async function() {
+    before(async function () {
       if (hre.getNetworkName() == "isolated_server") {
         this.skip(); // FIXME: isolated server does not returns block '0' back, but a null object. see ZIL-4877
       }
     });
 
-    it("should get full transactions objects by 'earliest' tag", async function() {
+    it("should get full transactions objects by 'earliest' tag", async function () {
       await sendJsonRpcRequest(METHOD, 2, ["earliest", true], (result, status) => {
         logDebug(result);
 
@@ -200,7 +200,7 @@ describe("Calling " + METHOD, function() {
       });
     });
 
-    it("should get only the hashes of the transactions objects by 'earliest' tag", async function() {
+    it("should get only the hashes of the transactions objects by 'earliest' tag", async function () {
       await sendJsonRpcRequest(METHOD, 2, ["earliest", false], (result, status) => {
         logDebug(result);
 
@@ -212,14 +212,14 @@ describe("Calling " + METHOD, function() {
     });
   });
 
-  describe("When on Zilliqa network", function() {
-    before(function() {
+  describe("When on Zilliqa network", function () {
+    before(function () {
       if (!hre.isZilliqaNetworkSelected()) {
         this.skip();
       }
     });
 
-    it("should get full transactions objects by 'pending' tag", async function() {
+    it("should get full transactions objects by 'pending' tag", async function () {
       await sendJsonRpcRequest(METHOD, 2, ["pending", true], (result, status) => {
         logDebug(result);
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionByHash.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getTransactionByHash.ts
@@ -1,6 +1,6 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
-import hre, { ethers } from "hardhat";
+import {assert} from "chai";
+import hre, {ethers} from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 
 const METHOD = "eth_getTransactionByHash";
@@ -9,7 +9,7 @@ describe(`Calling ${METHOD} #parallel`, function () {
   // FIXME: https://zilliqa-jira.atlassian.net/browse/EM-53
   xit("should have valid structure in response", async function () {
     const to = ethers.Wallet.createRandom();
-    const { response, signer_address } = await hre.sendTransaction({
+    const {response, signer_address} = await hre.sendTransaction({
       to: to.address,
       value: 1_000_000
     });

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockHashAndIndex.ts
@@ -1,5 +1,5 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
+import {assert} from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_getUncleByBlockNumberAndIndex.ts
@@ -1,5 +1,5 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
+import {assert} from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sendTransaction.ts
@@ -1,5 +1,5 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
+import {assert} from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 

--- a/tests/EvmAcceptanceTests/test/rpc/eth_sign.ts
+++ b/tests/EvmAcceptanceTests/test/rpc/eth_sign.ts
@@ -1,5 +1,5 @@
 import sendJsonRpcRequest from "../../helpers/JsonRpcHelper";
-import { assert } from "chai";
+import {assert} from "chai";
 import hre from "hardhat";
 import logDebug from "../../helpers/DebugHelper";
 

--- a/tests/EvmAcceptanceTests/test/subscriptions/OneIndexedParameters.ts
+++ b/tests/EvmAcceptanceTests/test/subscriptions/OneIndexedParameters.ts
@@ -51,9 +51,9 @@ describe("Subscriptions functionality", function () {
       const queriedLogs = await eventsContract.queryFilter(filter);
       expect(queriedLogs).to.have.length(2);
       expect(
-          queriedLogs.every((e) => {
-            return !e["removed"];
-          })
+        queriedLogs.every((e) => {
+          return !e["removed"];
+        })
       ).to.be.equal(true);
     });
 


### PR DESCRIPTION
## Description
Many Ethereum tools send requests to (e.g.) `eth_getBlockByNumber` as an integer, rather than a string. Other Ethereum clients support this, so we should support this. The following list is the APIs I touched on in this PR:

- eth_getBalance
- eth_getStorageAt
- eth_getTransactionCount
- eth_getBlockTransactionCountByNumber
- eth_getUncleCountByBlockNumber
- eth_getCode
- eth_getBlockByNumber
- eth_getTransactionByBlockNumberAndIndex
- eth_getUncleByBlockNumberAndIndex

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
