### PR TITLE
Remove malloc trim call that reclaims STL memory back to OS

### DIFF
--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -401,8 +401,6 @@ bool Account::FetchStateJson(Json::Value& root, const string& vname,
     if (ENABLE_MEMORY_STATS) {
       startMem = DisplayPhysicalMemoryStats("After FetchStateJson", startMem);
     }
-    // Clear STL memory cache
-    DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
   }
 
   if ((vname.empty() && indices.empty()) || vname == "_balance") {

--- a/src/libDirectoryService/FinalBlockPostProcessing.cpp
+++ b/src/libDirectoryService/FinalBlockPostProcessing.cpp
@@ -276,9 +276,6 @@ void DirectoryService::ProcessFinalBlockConsensusWhenDone() {
     }
   }
 
-  // Clear STL memory cache
-  DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
-
   m_mediator.UpdateDSBlockRand();
   m_mediator.UpdateTxBlockRand();
 

--- a/src/libLookup/Lookup.cpp
+++ b/src/libLookup/Lookup.cpp
@@ -3620,9 +3620,6 @@ bool Lookup::ProcessSetStateDeltasFromSeed(
                     "AccountStore::GetInstance().DeserializeDelta failed");
         return false;
       }
-      if (txBlkNum % RELEASE_CACHE_INTERVAL == 0) {
-        DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
-      }
       if (!BlockStorage::GetBlockStorage().PutStateDelta(txBlkNum, delta)) {
         LOG_GENERAL(WARNING, "BlockStorage::PutStateDelta failed");
         return false;

--- a/src/libNode/FinalBlockProcessing.cpp
+++ b/src/libNode/FinalBlockProcessing.cpp
@@ -1244,9 +1244,6 @@ bool Node::ProcessFinalBlockCore(uint64_t& dsBlockNumber,
                          << "][" << txBlock.GetHeader().GetBlockNum()
                          << "] LAST");
   }
-  // Clear STL memory cache
-  DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
-
   // Assumption: New PoW done after every block committed
   // If I am not a DS committee member (and since I got this FinalBlock message,
   // then I know I'm not), I can start doing PoW again

--- a/src/libPersistence/Retriever.cpp
+++ b/src/libPersistence/Retriever.cpp
@@ -168,10 +168,6 @@ bool Retriever::ConstructFromStateDeltas(const uint64_t& lastBlockNum,
                 return false;
               }
 
-              if (j % RELEASE_CACHE_INTERVAL == 0 || j == i) {
-                DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
-              }
-
               TxBlockSharedPtr txBlockPerDelta;
               if (!BlockStorage::GetBlockStorage().GetTxBlock(
                       j, txBlockPerDelta)) {
@@ -237,9 +233,6 @@ bool Retriever::ConstructFromStateDeltas(const uint64_t& lastBlockNum,
         LOG_GENERAL(WARNING,
                     "AccountStore::GetInstance().DeserializeDelta failed");
         return false;
-      }
-      if (extra_delta_index % RELEASE_CACHE_INTERVAL == 0) {
-        DetachedFunction(1, CommonUtils::ReleaseSTLMemoryCache);
       }
       BlockStorage::GetBlockStorage().PutStateDelta(extra_delta_index++,
                                                     stateDelta);

--- a/src/libUtils/CommonUtils.cpp
+++ b/src/libUtils/CommonUtils.cpp
@@ -27,20 +27,6 @@
 
 using namespace std;
 
-void CommonUtils::ReleaseSTLMemoryCache() {
-#ifdef __linux__
-  LOG_MARKER();
-
-  static mutex relMemoryCacheMutex;
-  if (relMemoryCacheMutex.try_lock()) {
-    malloc_trim(0);
-    relMemoryCacheMutex.unlock();
-  } else {
-    LOG_GENERAL(WARNING, "MemoryCache cleanup already in progress!");
-  }
-#endif
-}
-
 bool CommonUtils::IsVacuousEpoch(const uint64_t& epochNum) {
   return ((epochNum + NUM_VACUOUS_EPOCHS) % NUM_FINAL_BLOCK_PER_POW) == 0;
 }


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

This PR reverts the PR https://github.com/Zilliqa/Zilliqa/pull/2516. For Large object occupied memory in container is not released back to OS that caused memory to build up and ultimately the process goes OOM. This was the reason we decided to use `malloc_trim` to reclaim memory.

**NOTE: This is a experimental branch and should not go to master until it is proved that the commit [](https://github.com/Zilliqa/Zilliqa/pull/2516 is not required anymore.**


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
