### PR TITLE
[master] ZIL-5354 sendTransaction doesn't work - response handled differently in ethers 6, looking for 0x0 in data not empty string.

### DIFF
--- a/scripts/license_checker.sh
+++ b/scripts/license_checker.sh
@@ -60,6 +60,8 @@ scope=$(find . -type f \( \
             ! -path "./.local/*" \
             ! -path "./.husky/*" \
             ! -path "./_localdev/*" \
+            ! -path "./native/*" \
+            ! -path "./venv/*" \
 	          ! -path "./vcpkg/*" \
             ! -path "./scripts/depends/*")
 

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -698,7 +698,13 @@ const Json::Value JSONConversion::convertTxtoEthJson(
    } else {
      inputField += callData;
    }
+ } else {
+   // Append extra '0x' prefix iff GetCode() gave empty string
+   if (inputField.empty()) {
+     inputField += "0x";
+   }
  }
+
  retJson["input"] = inputField;
  // ethers also expects 'data' field
  retJson["data"] = inputField;

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -683,30 +683,17 @@ const Json::Value JSONConversion::convertTxtoEthJson(
  retJson["hash"] = "0x" + tx.GetTranID().hex();
 
  // Concatenated Code and CallData form input entry in response json
- std::string inputField;
+ std::string inputField = "0x0";
 
  if (!tx.GetCode().empty()) {
-   inputField =
-       "0x" + DataConversion::Uint8VecToHexStrRet(StripEVM(tx.GetCode()));
+   inputField = DataConversion::Uint8VecToHexStrRet(StripEVM(tx.GetCode()));
  }
 
  if (!tx.GetData().empty()) {
-   const auto callData = DataConversion::Uint8VecToHexStrRet(tx.GetData());
-   // Append extra '0x' prefix iff GetCode() gave empty string
-   if (inputField.empty()) {
-     inputField += "0x" + callData;
-   } else {
-     inputField += callData;
-   }
- } else {
-   // Append extra '0x' prefix iff GetCode() gave empty string
-   if (inputField.empty()) {
-     inputField += "0x";
-   }
+   inputField += DataConversion::Uint8VecToHexStrRet(tx.GetData());
  }
 
  retJson["input"] = inputField;
- // ethers also expects 'data' field
  retJson["data"] = inputField;
 
  // NOTE: Nonce is decremented since the internal representation is +1 due to

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -683,17 +683,30 @@ const Json::Value JSONConversion::convertTxtoEthJson(
  retJson["hash"] = "0x" + tx.GetTranID().hex();
 
  // Concatenated Code and CallData form input entry in response json
- std::string inputField = "0x0";
+ std::string inputField;
 
  if (!tx.GetCode().empty()) {
-   inputField = DataConversion::Uint8VecToHexStrRet(StripEVM(tx.GetCode()));
+   inputField =
+       "0x" + DataConversion::Uint8VecToHexStrRet(StripEVM(tx.GetCode()));
  }
 
  if (!tx.GetData().empty()) {
-   inputField += DataConversion::Uint8VecToHexStrRet(tx.GetData());
+   const auto callData = DataConversion::Uint8VecToHexStrRet(tx.GetData());
+   // Append extra '0x' prefix iff GetCode() gave empty string
+   if (inputField.empty()) {
+     inputField += "0x" + callData;
+   } else {
+     inputField += callData;
+   }
+ } else {
+   // Append extra '0x' prefix if GetCode() gave empty string
+   if (inputField.empty()) {
+     inputField = "0x";
+   }
  }
 
  retJson["input"] = inputField;
+ // ethers also expects 'data' field
  retJson["data"] = inputField;
 
  // NOTE: Nonce is decremented since the internal representation is +1 due to


### PR DESCRIPTION
ZIL-5354 blank response in data not handled by ethers 6, switched to 0x0

## Description
<!-- What is the overall goal of your pull request? -->
Fix bug outlined in ZIL-5354 
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

In testing, tests passed locally

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
