### PR TITLE
[master] ZIL-5376: Support type 1 and type 2 Ethereum transactions

### DIFF
--- a/src/common/BaseType.h
+++ b/src/common/BaseType.h
@@ -22,6 +22,8 @@
 #include <map>
 #include <utility>
 #include <vector>
+#include "depends/common/FixedHash.h"
+
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -37,6 +39,7 @@
 using zbytes = std::vector<uint8_t>;
 using uint128_t = boost::multiprecision::uint128_t;
 using uint256_t = boost::multiprecision::uint256_t;
+using AccessList = std::vector<std::pair<dev::h160, std::vector<dev::h256>>>;
 using GovDSShardVotesMap =
     std::map<uint32_t, std::pair<std::map<uint32_t, uint32_t>,
                                  std::map<uint32_t, uint32_t>>>;

--- a/src/common/Constants.cpp
+++ b/src/common/Constants.cpp
@@ -148,9 +148,6 @@ const bool AUTO_UPGRADE{ReadConstantString("AUTO_UPGRADE") == "true"};
 // Version constants
 const unsigned int MSG_VERSION{
     ReadConstantNumeric("MSG_VERSION", "node.version.")};
-const unsigned int TRANSACTION_VERSION{
-    ReadConstantNumeric("TRANSACTION_VERSION", "node.version.")};
-const unsigned int TRANSACTION_VERSION_ETH = 2;
 const unsigned int DSBLOCK_VERSION{
     ReadConstantNumeric("DSBLOCK_VERSION", "node.version.")};
 const unsigned int TXBLOCK_VERSION{

--- a/src/common/Constants.h
+++ b/src/common/Constants.h
@@ -148,8 +148,10 @@ extern const bool AUTO_UPGRADE;
 
 // Version constants
 extern const unsigned int MSG_VERSION;
-extern const unsigned int TRANSACTION_VERSION;
-extern const unsigned int TRANSACTION_VERSION_ETH;
+const unsigned int TRANSACTION_VERSION = 1;
+const unsigned int TRANSACTION_VERSION_ETH_LEGACY = 2;
+const unsigned int TRANSACTION_VERSION_ETH_EIP_2930 = 3;
+const unsigned int TRANSACTION_VERSION_ETH_EIP_1559 = 4;
 extern const unsigned int DSBLOCK_VERSION;
 extern const unsigned int TXBLOCK_VERSION;
 extern const unsigned int MICROBLOCK_VERSION;

--- a/src/libCps/CpsRunEvm.cpp
+++ b/src/libCps/CpsRunEvm.cpp
@@ -53,7 +53,7 @@ bool CpsRunEvm::IsResumable() const {
 CpsExecuteResult CpsRunEvm::Run(TransactionReceipt& receipt) {
   const auto fromAddress = ProtoToAddress(mProtoArgs.origin());
   const auto contractAddress =
-      mAccountStore.GetAddressForContract(fromAddress, TRANSACTION_VERSION_ETH);
+      mAccountStore.GetAddressForContract(fromAddress, TRANSACTION_VERSION_ETH_LEGACY);
 
   CREATE_SPAN(
       zil::trace::FilterClass::TXN, fromAddress.hex(), contractAddress.hex(),
@@ -495,7 +495,7 @@ CpsExecuteResult CpsRunEvm::HandleCreateTrap(const evm::EvmResult& result) {
     const evm::TrapData_Scheme_Legacy& legacy = scheme.legacy();
     fromAddress = ProtoToAddress(legacy.caller());
     contractAddress = mAccountStore.GetAddressForContract(
-        fromAddress, TRANSACTION_VERSION_ETH);
+        fromAddress, TRANSACTION_VERSION_ETH_LEGACY);
   } else if (scheme.has_create2()) {
     const evm::TrapData_Scheme_Create2& create2 = scheme.create2();
     fromAddress = ProtoToAddress(create2.caller());

--- a/src/libCrypto/CMakeLists.txt
+++ b/src/libCrypto/CMakeLists.txt
@@ -2,4 +2,4 @@ find_package(unofficial-secp256k1 CONFIG REQUIRED)
 
 add_library(EthCrypto EthCrypto.cpp)
 target_include_directories(EthCrypto PUBLIC ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(EthCrypto PRIVATE unofficial::secp256k1 unofficial::secp256k1_precomputed ${CryptoUtils_LIBRARY})
+target_link_libraries(EthCrypto PRIVATE Eth unofficial::secp256k1 unofficial::secp256k1_precomputed ${CryptoUtils_LIBRARY})

--- a/src/libCrypto/EthCrypto.h
+++ b/src/libCrypto/EthCrypto.h
@@ -60,6 +60,8 @@ zbytes StripEVM(zbytes const& in);
 // Create an ethereum style transaction hash
 zbytes CreateHash(zbytes const& rawTx);
 
+bool IsEthTransactionVersion(uint32_t version);
+
 // Create the eth-style contract address given the sender address and nonce
 zbytes CreateContractAddr(zbytes const& senderAddr, int nonce);
 

--- a/src/libData/AccountData/Account.cpp
+++ b/src/libData/AccountData/Account.cpp
@@ -474,7 +474,7 @@ Address Account::GetAddressForContract(const Address& sender,
     }
 
     copy(output.end() - ACC_ADDR_SIZE, output.end(), address.asArray().begin());
-  } else if (version == TRANSACTION_VERSION_ETH) {
+  } else if (IsEthTransactionVersion(version)) {
     // Note the nonce accounting for Zil TXs is always 1 ahead so we decrement
     // here
     auto output = CreateContractAddr(sender.asBytes(), nonce);

--- a/src/libData/AccountData/Transaction.h
+++ b/src/libData/AccountData/Transaction.h
@@ -32,7 +32,8 @@ struct TransactionCoreInfo {
                       const uint128_t& amountInput,
                       const uint128_t& gasPriceInput,
                       const uint64_t& gasLimitInput, const zbytes& codeInput,
-                      const zbytes& dataInput)
+                      const zbytes& dataInput, const AccessList& accessListInput,
+                      const uint128_t& maxPriorityFeePerGasInput, const uint128_t& maxFeePerGasInput)
       : version(versionInput),
         nonce(nonceInput),
         toAddr(toAddrInput),
@@ -41,7 +42,10 @@ struct TransactionCoreInfo {
         gasPrice(gasPriceInput),
         gasLimit(gasLimitInput),
         code(codeInput),
-        data(dataInput) {}
+        data(dataInput),
+        accessList(accessListInput),
+        maxPriorityFeePerGas(maxPriorityFeePerGasInput),
+        maxFeePerGas(maxFeePerGasInput) {}
 
   uint32_t version{};
   uint64_t nonce{};  // counter: the number of tx from m_fromAddr
@@ -52,6 +56,9 @@ struct TransactionCoreInfo {
   uint64_t gasLimit{};
   zbytes code;
   zbytes data;
+  AccessList accessList;
+  uint128_t maxPriorityFeePerGas;
+  uint128_t maxFeePerGas;
 };
 
 /// Stores information on a single transaction.
@@ -88,6 +95,20 @@ class Transaction : public SerializableDataBlock {
               const uint128_t& amount, const uint128_t& gasPrice,
               const uint64_t& gasLimit, const zbytes& code, const zbytes& data,
               const Signature& signature);
+
+  /// Constructor with specified transaction fields.
+  Transaction(const uint32_t& version, const uint64_t& nonce,
+              const Address& toAddr, const PubKey& senderPubKey,
+              const uint128_t& amount, const uint128_t& gasPrice,
+              const uint64_t& gasLimit, const zbytes& code, const zbytes& data,
+              const Signature& signature, const AccessList &accessList);
+
+  /// Constructor with specified transaction fields.
+  Transaction(const uint32_t& version, const uint64_t& nonce,
+              const Address& toAddr, const PubKey& senderPubKey,
+              const uint128_t& amount, const uint128_t& gasPrice,
+              const uint64_t& gasLimit, const zbytes& code, const zbytes& data,
+              const Signature& signature, const AccessList &accessList, const uint128_t& maxPriorityFeePerGas, const uint128_t& maxFeePerGas);
 
   /// Constructor with core information.
   Transaction(const TxnHash& tranID, const TransactionCoreInfo& coreInfo,

--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -73,28 +73,42 @@ Json::Value populateReceiptHelper(
   ret["r"] = GetR(sig);
   ret["s"] = GetS(sig);
 
+  switch (tx.GetVersionIdentifier()) {
+    case TRANSACTION_VERSION:
+      ret["type"] = "0x0"; // FIXME?
+      break;
+    case TRANSACTION_VERSION_ETH_LEGACY:
+      ret["type"] = "0x0";
+      break;
+    case TRANSACTION_VERSION_ETH_EIP_2930:
+      ret["type"] = "0x1";
+      break;
+    case TRANSACTION_VERSION_ETH_EIP_1559:
+      ret["type"] = "0x2";
+      break;
+    default:
+      LOG_GENERAL(WARNING, "Invalid transaction type");
+      break;
+  }
+
   return ret;
 }
 
-// Given a RLP message, parse out the fields and return a EthFields object
-EthFields parseRawTxFields(std::string const &message) {
+EthFields parseLegacyTransaction(zbytes asBytes) {
   EthFields ret;
-
-  zbytes asBytes;
-  DataConversion::HexStrToUint8Vec(message, asBytes);
 
   dev::RLP rlpStream1(asBytes,
                       dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
 
   if (rlpStream1.isNull()) {
-    LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX! " << message);
+    LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX!");
     return {};
   }
 
   int i = 0;
   // todo: checks on size of rlp stream etc.
 
-  ret.version = DataConversion::Pack(CHAIN_ID, 2);
+  ret.version = DataConversion::Pack(CHAIN_ID, TRANSACTION_VERSION_ETH_LEGACY);
 
   // RLP TX contains: nonce, gasPrice, gasLimit, to, value, data, v,r,s
   for (auto it = rlpStream1.begin(); it != rlpStream1.end();) {
@@ -143,6 +157,178 @@ EthFields parseRawTxFields(std::string const &message) {
   ret.nonce++;
 
   return ret;
+}
+
+EthFields parseEip2930Transaction(zbytes asBytes) {
+  EthFields ret;
+
+  dev::RLP rlpStream1(asBytes,
+                      dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
+
+  if (rlpStream1.isNull()) {
+    LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX!");
+    return {};
+  }
+
+  int i = 0;
+
+  ret.version = DataConversion::Pack(CHAIN_ID, TRANSACTION_VERSION_ETH_EIP_2930);
+
+  // RLP TX contains: chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, signatureYParity, signatureR, signatureS
+  for (auto it = rlpStream1.begin(); it != rlpStream1.end();) {
+    auto byteIt = (*it).operator zbytes();
+
+    switch (i) {
+      case 0: // Chain ID - validated earlier
+        break;
+      case 1:
+        ret.nonce = uint32_t(*it);
+        break;
+      case 2:
+        ret.gasPrice = uint128_t{*it};
+        break;
+      case 3:
+        ret.gasLimit = uint64_t{*it};
+        break;
+      case 4:
+        ret.toAddr = byteIt;
+        break;
+      case 5:
+        ret.amount = uint128_t(*it);
+        break;
+      case 6:
+        ret.code = byteIt;
+        break;
+      case 7:
+        ret.accessList = AccessList(*it);
+        break;
+      case 8:  // signatureYParity - only needed for pub sig recovery
+        break;
+      case 9:  // signatureR
+      {
+        zbytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
+      case 10:  // signatureS
+      {
+        zbytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
+      default:
+        LOG_GENERAL(WARNING, "too many fields received in rlp!");
+    }
+
+    i++;
+    it++;
+  }
+
+  // Because of the way Zil handles nonces, we increment the nonce here
+  ret.nonce++;
+
+  return ret;
+}
+
+EthFields parseEip1559Transaction(zbytes asBytes) {
+  EthFields ret;
+
+  dev::RLP rlpStream1(asBytes,
+                      dev::RLP::FailIfTooBig | dev::RLP::FailIfTooSmall);
+
+  if (rlpStream1.isNull()) {
+    LOG_GENERAL(WARNING, "Failed to parse RLP stream in raw TX!");
+    return {};
+  }
+
+  int i = 0;
+
+  ret.version = DataConversion::Pack(CHAIN_ID, TRANSACTION_VERSION_ETH_EIP_1559);
+
+  // RLP TX contains: chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s
+  for (auto it = rlpStream1.begin(); it != rlpStream1.end();) {
+    auto byteIt = (*it).operator zbytes();
+
+    switch (i) {
+      case 0: // Chain ID - validated earlier
+        break;
+      case 1:
+        ret.nonce = uint32_t(*it);
+        break;
+      case 2:
+        ret.maxPriorityFeePerGas = uint128_t{*it};
+        break;
+      case 3:
+        ret.maxFeePerGas = uint128_t{*it};
+        break;
+      case 4:
+        ret.gasLimit = uint64_t{*it};
+        break;
+      case 5:
+        ret.toAddr = byteIt;
+        break;
+      case 6:
+        ret.amount = uint128_t(*it);
+        break;
+      case 7:
+        ret.code = byteIt;
+        break;
+      case 8:
+        ret.accessList = AccessList(*it);
+        break;
+      case 9:  // signatureYParity - only needed for pub sig recovery
+        break;
+      case 10:  // signatureR
+      {
+        zbytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
+      case 11:  // signatureS
+      {
+        zbytes b = dev::toBigEndian(dev::u256(*it));
+        ret.signature.insert(ret.signature.end(), b.begin(), b.end());
+      } break;
+      default:
+        LOG_GENERAL(WARNING, "too many fields received in rlp!");
+    }
+
+    i++;
+    it++;
+  }
+
+  // Set gas price now, based on `maxPriorityFeePerGas` and `maxFeePerGas`. This gas price is what will actually be
+  // used for all downstream transaction processing. We only need to keep around the two values from the request so
+  // that we can reconstruct it later.
+  ret.gasPrice = ret.maxFeePerGas;
+
+  // Because of the way Zil handles nonces, we increment the nonce here
+  ret.nonce++;
+
+  return ret;
+}
+
+// Given a RLP message, parse out the fields and return a EthFields object
+EthFields parseRawTxFields(std::string const &message) {
+  if (message.size() < 2) {
+    LOG_GENERAL(WARNING, "Invalid transaction: " << message);
+    return {};
+  }
+
+  zbytes asBytes;
+  DataConversion::HexStrToUint8Vec(message, asBytes);
+  auto const firstByte = asBytes[0];
+  if (firstByte == 0x01) {
+    zbytes transaction(asBytes.begin() + 1, asBytes.end());
+    return parseEip2930Transaction(transaction);
+  } else if (firstByte == 0x02) {
+    zbytes transaction(asBytes.begin() + 1, asBytes.end());
+    return parseEip1559Transaction(transaction);
+  } else if ((firstByte >= 0xc0) && (firstByte <= 0xfe)) {
+    // See https://eips.ethereum.org/EIPS/eip-2718 section "Backwards Compatibility"
+    return parseLegacyTransaction(asBytes);
+  } else {
+    LOG_GENERAL(WARNING, "invalid transaction. Tx: " << message << " First byte: " << firstByte);
+    return {};
+  }
+
 }
 
 bool ValidateEthTxn(const Transaction &tx, const Address &fromAddr,
@@ -420,6 +606,7 @@ uint32_t GetBaseLogIndexForReceiptInBlock(const TxnHash &txnHash,
 // parse the fields into a TX and get its hash
 Transaction GetTxFromFields(Eth::EthFields const &fields, zbytes const &pubKey,
                             std::string &hash) {
+  LOG_MARKER();
   hash = ZEROES_HASH;
 
   Address toAddr{fields.toAddr};
@@ -439,7 +626,10 @@ Transaction GetTxFromFields(Eth::EthFields const &fields, zbytes const &pubKey,
                  fields.gasLimit,
                  code,  // either empty or stripped EVM-less code
                  data,  // either empty or un-hexed byte-stream
-                 Signature(fields.signature, 0)};
+                 Signature(fields.signature, 0),
+                 fields.accessList,
+                 fields.maxPriorityFeePerGas,
+                 fields.maxFeePerGas};
 
   hash = DataConversion::AddOXPrefix(tx.GetTranID().hex());
 

--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -177,8 +177,6 @@ EthFields parseEip2930Transaction(zbytes const& asBytes) {
 
   // RLP TX contains: chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, signatureYParity, signatureR, signatureS
   for (const auto& it : rlpStream1) {
-    auto byteIt = it.operator zbytes();
-
     switch (i) {
       case 0: // Chain ID - validated earlier
         break;
@@ -192,13 +190,13 @@ EthFields parseEip2930Transaction(zbytes const& asBytes) {
         ret.gasLimit = uint64_t{it};
         break;
       case 4:
-        ret.toAddr = byteIt;
+        ret.toAddr = zbytes(it);
         break;
       case 5:
         ret.amount = uint128_t(it);
         break;
       case 6:
-        ret.code = byteIt;
+        ret.code = zbytes(it);
         break;
       case 7:
         ret.accessList = AccessList(it);
@@ -245,8 +243,6 @@ EthFields parseEip1559Transaction(zbytes const& asBytes) {
 
   // RLP TX contains: chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s
   for (const auto& it : rlpStream1) {
-    auto byteIt = it.operator zbytes();
-
     switch (i) {
       case 0: // Chain ID - validated earlier
         break;
@@ -263,13 +259,13 @@ EthFields parseEip1559Transaction(zbytes const& asBytes) {
         ret.gasLimit = uint64_t{it};
         break;
       case 5:
-        ret.toAddr = byteIt;
+        ret.toAddr = zbytes(it);;
         break;
       case 6:
         ret.amount = uint128_t(it);
         break;
       case 7:
-        ret.code = byteIt;
+        ret.code = zbytes(it);
         break;
       case 8:
         ret.accessList = AccessList(it);

--- a/src/libEth/Eth.cpp
+++ b/src/libEth/Eth.cpp
@@ -259,7 +259,7 @@ EthFields parseEip1559Transaction(zbytes const& asBytes) {
         ret.gasLimit = uint64_t{it};
         break;
       case 5:
-        ret.toAddr = zbytes(it);;
+        ret.toAddr = zbytes(it);
         break;
       case 6:
         ret.amount = uint128_t(it);

--- a/src/libEth/Eth.h
+++ b/src/libEth/Eth.h
@@ -60,8 +60,8 @@ Json::Value populateReceiptHelper(
     const Json::Value &logs, const Json::Value &logsBloom,
     const Json::Value &transactionIndex, const Transaction &txn);
 
-EthFields parseEip2930Transaction(zbytes asBytes);
-EthFields parseEip1559Transaction(zbytes asBytes);
+EthFields parseEip2930Transaction(zbytes const& asBytes);
+EthFields parseEip1559Transaction(zbytes const& asBytes);
 EthFields parseRawTxFields(std::string const &message);
 
 bool ValidateEthTxn(const Transaction &tx, const Address &fromAddr,

--- a/src/libEth/Eth.h
+++ b/src/libEth/Eth.h
@@ -47,6 +47,9 @@ struct EthFields {
   zbytes code;
   zbytes data;
   zbytes signature;
+  AccessList accessList;
+  uint128_t maxPriorityFeePerGas;
+  uint128_t maxFeePerGas;
 };
 
 Json::Value populateReceiptHelper(
@@ -57,6 +60,8 @@ Json::Value populateReceiptHelper(
     const Json::Value &logs, const Json::Value &logsBloom,
     const Json::Value &transactionIndex, const Transaction &txn);
 
+EthFields parseEip2930Transaction(zbytes asBytes);
+EthFields parseEip1559Transaction(zbytes asBytes);
 EthFields parseRawTxFields(std::string const &message);
 
 bool ValidateEthTxn(const Transaction &tx, const Address &fromAddr,

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -829,7 +829,7 @@ bool ProtobufToTransactionCoreInfo(
       storageKeys.push_back(storageKey);
     }
     auto accessListItem = std::make_pair(address, storageKeys);
-    txnCoreInfo.accessList.push_back(accessListItem);
+    txnCoreInfo.accessList.push_back(std::move(accessListItem));
   }
   ProtobufByteArrayToNumber<uint128_t, UINT128_SIZE>(protoTxnCoreInfo.maxpriorityfeepergas(),
                                                      txnCoreInfo.maxPriorityFeePerGas);

--- a/src/libMessage/Messenger.cpp
+++ b/src/libMessage/Messenger.cpp
@@ -821,11 +821,11 @@ bool ProtobufToTransactionCoreInfo(
   }
   txnCoreInfo.accessList.reserve(protoTxnCoreInfo.accesslist_size());
   for (const auto& item : protoTxnCoreInfo.accesslist()) {
-    dev::h160 address = dev::h160(item.address(), dev::h160::ConstructFromStringType::FromBinary);
+    dev::h160 address(item.address(), dev::h160::ConstructFromStringType::FromBinary);
     std::vector<dev::h256> storageKeys;
     storageKeys.reserve(item.storagekeys_size());
     for (const auto& key : item.storagekeys()) {
-      dev::h256 storageKey = dev::h256(key, dev::h256::ConstructFromStringType::FromBinary);
+      dev::h256 storageKey(key, dev::h256::ConstructFromStringType::FromBinary);
       storageKeys.push_back(storageKey);
     }
     auto accessListItem = std::make_pair(address, storageKeys);

--- a/src/libMessage/ZilliqaMessage.proto
+++ b/src/libMessage/ZilliqaMessage.proto
@@ -396,6 +396,15 @@ message ProtoTransactionCoreInfo
     uint64 gaslimit        = 7;
     oneof oneof8 { bytes code = 8; }
     oneof oneof9 { bytes data = 9; }
+    repeated AccessListItem accessList = 10;
+    ByteArray maxpriorityfeepergas = 11;
+    ByteArray maxfeepergas = 12;
+}
+
+message AccessListItem
+{
+    bytes address = 1;
+    repeated bytes storagekeys = 2;
 }
 
 message ProtoTransaction

--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -806,7 +806,7 @@ std::string EthRpcMethods::GetEthEstimateGas(const Json::Value &json,
     } else if (toAccount == nullptr) {
       if (!ENABLE_CPS) {
         toAddr = Account::GetAddressForContract(fromAddr, sender->GetNonce(),
-                                                TRANSACTION_VERSION_ETH);
+                                                TRANSACTION_VERSION_ETH_LEGACY);
       }
       contractCreation = true;
     }

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -729,7 +729,8 @@ const Json::Value JSONConversion::convertTxtoEthJson(
  }
  switch (tx.GetVersionIdentifier()) {
   case TRANSACTION_VERSION:
-    retJson["type"] = "0x0"; // FIXME?
+    // Return a type of 0 for native Zilliqa transactions too.
+    retJson["type"] = "0x0";
     break;
   case TRANSACTION_VERSION_ETH_LEGACY:
     retJson["type"] = "0x0";

--- a/src/libServer/JSONConversion.cpp
+++ b/src/libServer/JSONConversion.cpp
@@ -727,7 +727,27 @@ const Json::Value JSONConversion::convertTxtoEthJson(
                   txn.GetTransaction().GetNonce() - 1, txn.GetTransaction().GetVersionIdentifier())
                   .hex();
  }
- retJson["type"] = "0x0";
+ switch (tx.GetVersionIdentifier()) {
+  case TRANSACTION_VERSION:
+    retJson["type"] = "0x0"; // FIXME?
+    break;
+  case TRANSACTION_VERSION_ETH_LEGACY:
+    retJson["type"] = "0x0";
+    break;
+  case TRANSACTION_VERSION_ETH_EIP_2930:
+    retJson["type"] = "0x1";
+    retJson["accessList"] = convertAccessList(tx.GetCoreInfo().accessList);
+    break;
+  case TRANSACTION_VERSION_ETH_EIP_1559:
+    retJson["type"] = "0x2";
+    retJson["accessList"] = convertAccessList(tx.GetCoreInfo().accessList);
+    retJson["maxPriorityFeePerGas"] = (boost::format("0x%x") % tx.GetCoreInfo().maxPriorityFeePerGas).str();
+    retJson["maxFeePerGas"] = (boost::format("0x%x") % tx.GetCoreInfo().maxFeePerGas).str();
+    break;
+  default:
+    LOG_GENERAL(WARNING, "Invalid transaction type");
+    break;
+ }
 
  std::string sig{tx.GetSignature()};
  retJson["v"] = GetV(tx.GetCoreInfo(), ETH_CHAINID, sig);
@@ -736,6 +756,26 @@ const Json::Value JSONConversion::convertTxtoEthJson(
 
  retJson["transactionIndex"] = (boost::format("0x%x") % txindex).str();
  return retJson;
+}
+
+const Json::Value JSONConversion::convertAccessList(const AccessList& accessList) {
+  Json::Value result = Json::arrayValue;
+
+  for (const auto& item : accessList) {
+    Json::Value resultItem = Json::objectValue;
+
+    resultItem["address"] = "0x" + item.first.hex();
+
+    Json::Value resultItemKeys = Json::arrayValue;
+    for (const auto& key : item.second) {
+      resultItemKeys.append("0x" + key.hex());
+    }
+    resultItem["storageKeys"] = resultItemKeys;
+    
+    result.append(resultItem);
+  }
+
+  return result;
 }
 
 const Json::Value JSONConversion::convertNode(const PairOfNode& node) {

--- a/src/libServer/JSONConversion.h
+++ b/src/libServer/JSONConversion.h
@@ -72,6 +72,7 @@ class JSONConversion {
   static const Json::Value convertTxtoEthJson(uint64_t txindex,
                                               const TransactionWithReceipt& txn,
                                               const TxBlock& txblock);
+  static const Json::Value convertAccessList(const AccessList& accessList);
   // Convert a node to json
   static const Json::Value convertNode(const PairOfNode& node);
   // conver a node with reputation to json

--- a/tests/EvmAcceptanceTests/test/Transfer.ts
+++ b/tests/EvmAcceptanceTests/test/Transfer.ts
@@ -51,6 +51,64 @@ describe("ForwardZil contract functionality #parallel", function () {
   });
 });
 
+describe("Transaction types", function () {
+  it("should be possible to send a legacy ethereum transaction", async function () {
+    const payee = ethers.Wallet.createRandom();
+
+    const {response} = await hre.sendEthTransaction({
+      to: payee.address,
+      value: FUND,
+      type: 0,
+    });
+
+    const receipt = await response.wait();
+    expect(receipt.type).to.be.eq(0);
+
+    expect(response.type).to.be.eq(0);
+  });
+
+  it("should be possible to send a EIP-2930 ethereum transaction", async function () {
+    const payee = ethers.Wallet.createRandom();
+
+    const accessList = [{ address: ethers.Wallet.createRandom().address, storageKeys: ["0x0bcad17ecf260d6506c6b97768bdc2acfb6694445d27ffd3f9c1cfbee4a9bd6d"] }];
+
+    const {response} = await hre.sendEthTransaction({
+      to: payee.address,
+      value: FUND,
+      type: 1,
+      accessList: accessList,
+    });
+
+    const receipt = await response.wait();
+    expect(receipt.type).to.be.eq(1);
+
+    expect(response.type).to.be.eq(1);
+    expect(response.accessList).to.have.lengthOf(1);
+  });
+
+  it("should be possible to send a EIP-1557 ethereum transaction", async function () {
+    const payee = ethers.Wallet.createRandom();
+
+    const accessList = [{ address: ethers.Wallet.createRandom().address, storageKeys: ["0x0bcad17ecf260d6506c6b97768bdc2acfb6694445d27ffd3f9c1cfbee4a9bd6d"] }];
+
+    const {response} = await hre.sendEthTransaction({
+      to: payee.address,
+      value: FUND,
+      type: 2,
+      accessList: accessList,
+      maxFeePerGas: 100,
+    });
+
+    const receipt = await response.wait();
+    expect(receipt.type).to.be.eq(2);
+
+    expect(response.type).to.be.eq(2);
+    expect(response.accessList).to.have.lengthOf(1);
+    expect(response.maxPriorityFeePerGas).to.be.not.null;
+    expect(response.maxFeePerGas).to.be.not.null;
+  });
+});
+
 describe("Transfer ethers #parallel", function () {
   it("should be possible to transfer ethers to a user account @block-1", async function () {
     const payee = ethers.Wallet.createRandom();


### PR DESCRIPTION
A brief description of how these transaction types differ and the potentially controversial choices I made while supporting them...

Type 1 transactions are defined in EIP-2930 and allow access lists to be provided with transactions. In Zilliqa, access lists are completely ignored and do not have any affect on gas accounting, but we do keep track of them so the transaction can be reconstructed later.

Type 2 transactions are defined in EIP-1559 and accept access lists, plus they allow for a different model for gas accounting. Instead of setting a single `gasPrice` for a transaction, you set a 'priority fee' which is paid in addition to the block's base fee. A maximum fee is also sent in transactions which limits the total fee the user is willing to pay (base fee + priority fee). In Zilliqa, we ignore the priority fee and just use the maximum fee as the entire fee for the transaction.

Its also worth noting that I removed the ability to configurability of transaction versions and just hardcoded the values that we use everywhere. We were already hardcoding these in many places in the source code, so there was only one set of configured values which would actually result in a working network anyway.