### PR TITLE
(feat) DEVOPS-1093: Expose the fireblocks entry point in /etc/hosts i…

### DIFF
--- a/scripts/localdev.py
+++ b/scripts/localdev.py
@@ -196,6 +196,8 @@ def print_config_advice(config):
                         "localdev-l2api",
                         "localdev-newapi",
                         "localdev-origin",
+                        "localdev-api-fireblocks",
+                        "localdev-evm-filter"
                         "localdev-origin-internal" ]
     hosts = "\n".join([ f"{ip} {host}.localdomain" for host in host_names ])
     print(f"Minikube is at {ip}")
@@ -826,7 +828,9 @@ def get_mitm_instances(testnet_name):
              "l2api" : { "host" : f"{testnet_name}-l2api.localdomain", "port" : 5302 },
              "newapi" : { "host" : f"{testnet_name}-newapi.localdomain", "port" : 5303 },
              "origin" : { "host" : f"{testnet_name}-origin.localdomain", "port" : 5304 },
-             "grafana" : { "host" : f"{testnet_name}-grafana.localdomain", "port" : 5305 } }
+             "grafana" : { "host" : f"{testnet_name}-grafana.localdomain", "port" : 5305 },
+             "fireblocks" : { "host" : f"{testnet_name}-api-fireblocks.localdomain", "port" : 5306 },
+            }
 
 def stop_proxy(config, testnet_name):
     mitm_instances = get_mitm_instances(testnet_name)


### PR DESCRIPTION
…n localdev.

## Description

Expose fireblocks entry point in localdev.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [X] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion

Check if the fireblocks entry point shows up in your /etc/hosts - there is a corresponding PR to testnet which does the other half of this.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
