### PR TITLE
[master] US-322: ots_hasCode() should take an integer as its second argument.

### DIFF
--- a/src/libServer/EthRpcMethods.cpp
+++ b/src/libServer/EthRpcMethods.cpp
@@ -442,7 +442,7 @@ void EthRpcMethods::Init(LookupServer *lookupServer) {
   m_lookupServer->bindAndAddExternalMethod(
       jsonrpc::Procedure("ots_hasCode", jsonrpc::PARAMS_BY_POSITION,
                          jsonrpc::JSON_BOOLEAN, "param01", jsonrpc::JSON_STRING,
-                         "param02", jsonrpc::JSON_STRING, NULL),
+                         "param02", jsonrpc::JSON_INTEGER, NULL),
       &EthRpcMethods::HasCodeI);
 
   m_lookupServer->bindAndAddExternalMethod(
@@ -2144,7 +2144,7 @@ Json::Value EthRpcMethods::GetHeaderByNumber(const uint64_t blockNumber) {
 }
 
 bool EthRpcMethods::HasCode(const std::string &address,
-                            const std::string & /*block*/) {
+                            const uint64_t /* blockNumber */) {
   // TODO: Respect block parameter - We can probably do this by finding the
   // contract creation transaction and comparing the block numbers.
   Address addr{address, Address::FromHex};

--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -729,7 +729,7 @@ class EthRpcMethods {
   inline virtual void HasCodeI(const Json::Value& request,
                                Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
-    response = this->HasCode(request[0u].asString(), request[1u].asString());
+    response = this->HasCode(request[0u].asString(), request[1u].asUInt64());
   }
 
   inline virtual void GetBlockDetailsI(const Json::Value& request,
@@ -843,7 +843,7 @@ class EthRpcMethods {
                                       const Json::Value& json);
 
   Json::Value GetHeaderByNumber(const uint64_t blockNumber);
-  bool HasCode(const std::string& address, const std::string& block);
+  bool HasCode(const std::string& address, const uint64_t block);
   Json::Value GetBlockDetails(const uint64_t blockNumber);
   Json::Value GetBlockTransactions(const uint64_t blockNumber,
                                    const uint32_t pageNumber,


### PR DESCRIPTION
## Description

Fix ots_hasCode so that otterscan doesn't choke when calling it.


## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [] This is not a breaking change
- [X] This is a breaking change

## Review Suggestion
Check that otterscan now works with ZQ1 (in particular, txn details and logs)

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
