### PR TITLE
[master] fix(ZIL-5493): add CDN bypass header MANIFEST, CURRENT, LOG and lock files

### DIFF
--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -31,6 +31,7 @@ import hashlib
 from distutils.dir_util import copy_tree
 from pprint import pformat
 import download_static_DB
+from urllib.parse import urlparse
 
 PERSISTENCE_SNAPSHOT_NAME='incremental'
 STATEDELTA_DIFF_NAME='statedelta'
@@ -57,6 +58,9 @@ mutex = Lock()
 DOWNLOADED_LIST = []
 DOWNLOAD_STARTED_LIST = []
 
+EXCLUDE_CDN_CACHE_HEADER = { "X-z-cdn-bypass": "true", }
+EXCLUDE_CDN_CACHE_KEYS = [ 'CURRENT', '.lock', '.currentTxBlk', 'LOG', 'LOG.old', 'LOCK' ]
+
 def isGCP():
 	return AWS_ENDPOINT_URL and '.googleapis.com' in AWS_ENDPOINT_URL
 
@@ -71,14 +75,14 @@ def getURL():
 		return "http://"+BUCKET_NAME+".s3.amazonaws.com"
 
 def UploadLock():
-	response = requests.get(getURL()+"/"+PERSISTENCE_SNAPSHOT_NAME+"/"+TESTNET_NAME+"/.lock")
+	response = requests.get(getURL()+"/"+PERSISTENCE_SNAPSHOT_NAME+"/"+TESTNET_NAME+"/.lock", headers=EXCLUDE_CDN_CACHE_HEADER)
 	if response.status_code == 200:
 		return True
 	return False
 
 def GetCurrentTxBlkNum():
 	url = getURL()+"/"+PERSISTENCE_SNAPSHOT_NAME+"/"+TESTNET_NAME+"/.currentTxBlk"
-	response = requests.get(url, stream=True)
+	response = requests.get(url, stream=True, headers=EXCLUDE_CDN_CACHE_HEADER)
 	if response.status_code == 200:
 		return int(response.text.strip())
 	else:
@@ -215,7 +219,13 @@ def GetPersistenceKey(key_url):
 	mutex.release()
 	while True:
 		try:
-			response = requests.get(key_url, stream=True)
+			parsed_url = urlparse(key_url)
+			fname = parsed_url.path.split('/')[-1]
+			if fname in EXCLUDE_CDN_CACHE_KEYS:
+				req_header = EXCLUDE_CDN_CACHE_HEADER
+			else:
+				req_header = None
+			response = requests.get(key_url, stream=True, headers=req_header)
 		except Exception as e:
 			print("Exception occurred while downloading " + key_url + ": " + str(e))
 			retry_counter+=1

--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -59,7 +59,7 @@ DOWNLOADED_LIST = []
 DOWNLOAD_STARTED_LIST = []
 
 EXCLUDE_CDN_CACHE_HEADER = { "X-z-cdn-bypass": "true", }
-EXCLUDE_CDN_CACHE_KEYS = [ 'CURRENT', '.lock', '.currentTxBlk', 'LOG', 'LOG.old', 'LOCK' ]
+EXCLUDE_CDN_CACHE_KEYS = [ 'CURRENT', '.lock', '.currentTxBlk', 'LOG', 'LOG.old', 'LOCK', 'state_purge' ]
 
 def isGCP():
 	return AWS_ENDPOINT_URL and '.googleapis.com' in AWS_ENDPOINT_URL
@@ -221,7 +221,8 @@ def GetPersistenceKey(key_url):
 		try:
 			parsed_url = urlparse(key_url)
 			fname = parsed_url.path.split('/')[-1]
-			if fname in EXCLUDE_CDN_CACHE_KEYS:
+			dname = parsed_url.path.split('/')[-2]
+			if fname in EXCLUDE_CDN_CACHE_KEYS or dname in EXCLUDE_CDN_CACHE_KEYS:
 				req_header = EXCLUDE_CDN_CACHE_HEADER
 			else:
 				req_header = None

--- a/scripts/download_incr_DB.py
+++ b/scripts/download_incr_DB.py
@@ -59,7 +59,7 @@ DOWNLOADED_LIST = []
 DOWNLOAD_STARTED_LIST = []
 
 EXCLUDE_CDN_CACHE_HEADER = { "X-z-cdn-bypass": "true", }
-EXCLUDE_CDN_CACHE_KEYS = [ 'CURRENT', '.lock', '.currentTxBlk', 'LOG', 'LOG.old', 'LOCK', 'state_purge' ]
+EXCLUDE_CDN_CACHE_KEYS = [ 'CURRENT', '.lock', '.currentTxBlk', 'LOG', 'LOG.old', 'LOCK', 'state_purge', 'contractTrie_purge' ]
 
 def isGCP():
 	return AWS_ENDPOINT_URL and '.googleapis.com' in AWS_ENDPOINT_URL
@@ -222,10 +222,7 @@ def GetPersistenceKey(key_url):
 			parsed_url = urlparse(key_url)
 			fname = parsed_url.path.split('/')[-1]
 			dname = parsed_url.path.split('/')[-2]
-			if fname in EXCLUDE_CDN_CACHE_KEYS or dname in EXCLUDE_CDN_CACHE_KEYS:
-				req_header = EXCLUDE_CDN_CACHE_HEADER
-			else:
-				req_header = None
+			req_header = EXCLUDE_CDN_CACHE_HEADER if fname in EXCLUDE_CDN_CACHE_KEYS or dname in EXCLUDE_CDN_CACHE_KEYS else None
 			response = requests.get(key_url, stream=True, headers=req_header)
 		except Exception as e:
 			print("Exception occurred while downloading " + key_url + ": " + str(e))

--- a/scripts/upload_incr_DB.py
+++ b/scripts/upload_incr_DB.py
@@ -130,7 +130,7 @@ def SetCurrentTxBlkNum(txBlkNum):
 	Path(".currentTxBlk").touch()
 	with open(".currentTxBlk",encoding='utf-8', mode='w') as file:
 		file.write(txBlkNum)
-	bashCommand = awsCli() + " s3 cp .currentTxBlk "+getBucketString(PERSISTENCE_SNAPSHOT_NAME)+"/.currentTxBlk"
+	bashCommand = awsCli() + " s3 cp .currentTxBlk "+getBucketString(PERSISTENCE_SNAPSHOT_NAME)+"/.currentTxBlk"+' --metadata "cache-control=no-store"'
 	process = subprocess.Popen(bashCommand, universal_newlines=True, shell=True,stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 	output, error = process.communicate()
 	logging.info("[" + str(datetime.datetime.now()) + "] SetCurrentTxBlkNum:" + txBlkNum + " for uploading process")	


### PR DESCRIPTION
This PR add the capability to bypass the CDN while downloading the levelDB files which contains the updated structure of the persistence content. As the default configuration for the CDN cache is 1d, while downloading files such us CURRENT which keeps the id of the current leveldb MANIFEST, the id was pointing to the old instead of the current manifest file leaving the downloaded persistence inconsistent/corrupted. 

## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [ ] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
