### PR TITLE
[master] (fix) ZIL-5492: Disable ots_enable

### DIFF
--- a/src/libServer/EthRpcMethods.h
+++ b/src/libServer/EthRpcMethods.h
@@ -625,7 +625,11 @@ class EthRpcMethods {
   inline virtual void OtterscanEnableI(const Json::Value& request,
                                        Json::Value& response) {
     LOG_MARKER_CONTITIONAL(LOG_SC);
-    ARCHIVAL_LOOKUP_WITH_TX_TRACES = request[0u].asBool();
+    // This is fatal to ordinary seedpubs - partly because they never receive some txns,
+    // partly because it takes a long time to generate the traces once they have;
+    // disabled.
+    // - rrw 2023-11-24
+    // ARCHIVAL_LOOKUP_WITH_TX_TRACES = request[0u].asBool();
   }
 
   /**

--- a/tests/EvmAcceptanceTests/test/ChainedCalls.ts
+++ b/tests/EvmAcceptanceTests/test/ChainedCalls.ts
@@ -29,8 +29,8 @@ describe("Chained Contract Calls Functionality #parallel", function () {
     });
   });
 
-  describe("Install and call chained contracts @block-1", function () {
-    it("Should create a transaction trace after child creation", async function () {
+  describe("Install and call chained contracts @block-1 [disabled because traces are disabled]", function () {
+    xit("Should create a transaction trace after child creation", async function () {
       const METHOD = "debug_traceTransaction";
       const METHOD_BLOCK = "debug_traceBlockByNumber";
 

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_getInternalOperations.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_getInternalOperations.ts
@@ -28,7 +28,9 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
     });
   });
 
-  it("We can get the otter internal operations @block-1", async function () {
+  // Disabled because it requires TX_TRACES on and this can't be on by default
+  // ZIL-5489 - rrw 2023-11-29
+  xit("We can get the otter internal operations @block-1", async function () {
     // Check we can for example detect a suicide with correct value.
     // Below is taken from transfer.ts test
 

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionBySenderAndNonce.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionBySenderAndNonce.ts
@@ -13,7 +13,8 @@ describe(`Otterscan api tests: ${METHOD}`, function () {
     });
   });
 
-  it("We can get the otter search for sender by nonce", async function () {
+  // Temporarily disabled - requires an archival lookup with traces.
+  xit("We can get the otter search for sender by nonce", async function () {
     // To test this, send money to an account then have it send it back.
     // The nonces should be able to lookup via 0, 1, 2
     // re-use the batch transfer code for this

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionError.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_getTransactionError.ts
@@ -17,7 +17,7 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
     revertContract = await hre.deployContract("Revert");
   });
 
-  it("When we revert the TX, we can get the tx error @block-1", async function () {
+  xit("When we revert the TX, we can get the tx error @block-1", async function () {
     const REVERT_MESSAGE = "Transaction too old";
 
     const abi = ethers.utils.defaultAbiCoder;

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_searchTransactions.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_searchTransactions.ts
@@ -33,7 +33,7 @@ describe(`Otterscan api tests: ${METHOD_AFTER} #parallel`, function () {
     });
   });
 
-  it("We can get the otter search TX before and after @block-1", async function () {
+  xit("We can get the otter search TX before and after @block-1", async function () {
     // run the contract that batch sends funds to other addresses
     // then we can check that this txid comes up when asking about
     // these contract addresses.

--- a/tests/EvmAcceptanceTests/test/otterscan/ots_traceTransaction.ts
+++ b/tests/EvmAcceptanceTests/test/otterscan/ots_traceTransaction.ts
@@ -29,7 +29,7 @@ describe(`Otterscan api tests: ${METHOD} #parallel`, function () {
     }
   });
 
-  it("We can get the otter trace transaction @block-1", async function () {
+  xit("We can get the otter trace transaction @block-1", async function () {
     let addrOne = contractOne.address.toLowerCase();
     let addrTwo = contractTwo.address.toLowerCase();
     let addrThree = contractThree.address.toLowerCase();


### PR DESCRIPTION
## Description

Disable ots_enable; ots_enable allows you to enable tracing on seedpubs, which would be dangerous even if seedpub tracing did work. It doesn't (for various reasons), and the time taken to fail tends to break the seedpub. 

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [X] This is a breaking change

## Review Suggestion

Build and test.

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [X] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
