### PR TITLE
[master] ZIL-5496: Don't validate work header if extra data was submitted

### DIFF
--- a/src/libServer/GetWorkServer.cpp
+++ b/src/libServer/GetWorkServer.cpp
@@ -202,7 +202,7 @@ ethash_mining_result_t GetWorkServer::VerifySubmit(const string& nonce,
   }
 
   // check the header and boundary is same with current work
-  if (header != m_curWork.header) {
+  if (extraData.size() == 0 && header != m_curWork.header) {
     LOG_GENERAL(WARNING, "Submit header diff with current work");
     LOG_GENERAL(WARNING, "Current header: " << m_curWork.header);
     LOG_GENERAL(WARNING, "Submit header: " << header);


### PR DESCRIPTION
There are two code paths into `VerifySubmit`. One comes from the `eth_submitWork` API and does not pass any `extraData`. In this case we retain the old behaviour and still validate the submitted header is the same as the header we expect for this bit of work. The other case comes from the `zil_submitWorkWithExtraData` API. This takes `extraData` instead of a `header` and computes a new header based on the data. In this case, we skip the check which validates the calculated header is the same as the original work header, because it will always fail.