### PR TITLE
[release/v9.3] Check null condition before accessing dsblock consensus object

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -782,6 +782,12 @@ bool DirectoryService::ProcessDSBlockConsensus(
   zbytes unused_reserialized_message;
   PubKey senderPubKey;
 
+  if (m_consensusObject == nullptr) {
+    LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
+                "m_consensusObject is not created.");
+    return false;
+  }
+
   if (!m_consensusObject->PreProcessMessage(message, offset,
                                             unused_consensus_id, senderPubKey,
                                             unused_reserialized_message)) {

--- a/src/libNode/DSBlockProcessing.cpp
+++ b/src/libNode/DSBlockProcessing.cpp
@@ -346,7 +346,7 @@ bool Node::ProcessVCDSBlocksMessage(
   LOG_MARKER();
 
   const bool leader = m_mediator.m_ds->GetConsensusMyID() ==
-                      m_mediator.m_ds->GetConsensusMyID();
+                      m_mediator.m_ds->GetConsensusLeaderID();
   LOG_GENERAL(WARNING, "I am " << (leader ? "" : "not") << " the leader");
   lock_guard<mutex> g(m_mutexDSBlock);
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->
A newly joined node receives an invalid gossip message for `DS_FINALBLOCKCONSENSUS`. As the newly joined node wasn't part of the ds block consensus, it has no consensus object created. But because of timing issues, it receives late gossip messages for DS block consensus which we should ignore as the consensus object is not initialized.
If the consensus object is created by other message, the state check would automatically handle the message or reject it.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [ ] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [x] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
