### PR TITLE
[master] Allow syncing of ds nodes if they kicked out of ds comm instead of rejoin from scrach

### DIFF
--- a/src/libDirectoryService/DSBlockPostProcessing.cpp
+++ b/src/libDirectoryService/DSBlockPostProcessing.cpp
@@ -573,8 +573,9 @@ void DirectoryService::StartFirstTxEpoch() {
     if (!found) {
       LOG_EPOCH(WARNING, m_mediator.m_currentEpochNum,
                 "My DS node signed insufficient blocks. Kicked out and "
-                "invoking RejoinAsNormal now.");
-      m_mediator.m_node->RejoinAsNormal();
+                "start syncing.Better luck next time !!!");
+      m_mediator.m_lookup->SetSyncType(SyncType::NORMAL_SYNC);
+      m_mediator.m_node->StartSynchronization();
       return;
     }
 


### PR DESCRIPTION
## Description
<!-- What is the overall goal of your pull request? -->
<!-- What is the context of your pull request? -->
<!-- What are the related issues and pull requests? -->

A DS node is removed from the consensus because of not signing enough blocks or competition performs rejoins. This means it downloads complete persistence and syncs again which is a very time-consuming process. The fix is to allow the node to start syncing to join in the next epoch.

## Backward Compatibility
<!-- For breaking changes, code must be protected by UPGRADE_TARGET -->
- [x] This is not a breaking change
- [ ] This is a breaking change

## Review Suggestion
<!-- How should the reviewers get started on reviewing your pull request-->
<!-- How can the reviewers verify the pull request is working as expected -->

## Status

### Implementation
<!-- Add more TODOs before "ready for review", if any  -->
- [x] **ready for review**

### Integration Test (Core Team)
<!-- This is for core team only, ignore this if you are a community contributor -->

<!-- append the commit digest to inform the others of the versions you have tested -->
- [ ] local machine test
<!-- - [ ] local machine test (commit: bbbbbbbb) -->
<!-- - [ ] local machine test (commit: cccccccc) -->
<!-- - [ ] local machine test (commit: dddddddd) -->
- [ ] small-scale cloud test
<!-- - [ ] small-scale cloud test (commit: bbbbbbbb) -->
<!-- - [ ] small-scale cloud test (commit: cccccccc) -->
<!-- - [ ] small-scale cloud test (commit: dddddddd) -->
